### PR TITLE
*7232* point URL given in copyedit author request email to editing page

### DIFF
--- a/classes/submission/sectionEditor/SectionEditorAction.inc.php
+++ b/classes/submission/sectionEditor/SectionEditorAction.inc.php
@@ -1084,8 +1084,7 @@ class SectionEditorAction extends Action {
 					'authorUsername' => $author->getUsername(),
 					'authorPassword' => $author->getPassword(),
 					'editorialContactSignature' => $user->getContactSignature(),
-					'submissionCopyeditingUrl' => $request->url(null, 'author', 'submission', $sectionEditorSubmission->getId())
-
+					'submissionCopyeditingUrl' => $request->url(null, 'author', 'submissionEditing', $sectionEditorSubmission->getId())
 				);
 				$email->assignParams($paramArray);
 			}


### PR DESCRIPTION
Fulfils this bug http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=7232

But I wonder if the (previously same) URLs given with similar emails should also be changed?

(Am I doing this right? Should I post anything in the bugzilla?)
