### PR TITLE
*7984* Show archived items on author home pages

### DIFF
--- a/classes/submission/author/AuthorSubmissionDAO.inc.php
+++ b/classes/submission/author/AuthorSubmissionDAO.inc.php
@@ -260,11 +260,11 @@ class AuthorSubmissionDAO extends DAO {
 		$sql = 'SELECT count(*), status FROM articles a LEFT JOIN sections s ON (s.section_id = a.section_id) WHERE a.journal_id = ? AND a.user_id = ? GROUP BY a.status';
 
 		$result =& $this->retrieve($sql, array($journalId, $authorId));
-
+        //07092012 LS adding in logic to get archived/rejected items
 		while (!$result->EOF) {
 			if ($result->fields['status'] != 1) {
 				$submissionsCount[1] += $result->fields[0];
-			} else {
+			}else {
 				$submissionsCount[0] += $result->fields[0];
 			}
 			$result->moveNext();
@@ -274,7 +274,7 @@ class AuthorSubmissionDAO extends DAO {
 		unset($result);
 
 		return $submissionsCount;
-	}
+	}	
 	
 	/**
 	 * Map a column heading value to a database value for sorting

--- a/templates/user/index.tpl
+++ b/templates/user/index.tpl
@@ -123,6 +123,7 @@
 		{if $isValid.Author.$journalId || $isValid.Reviewer.$journalId}
 			<tr><td class="separator" width="100%" colspan="5">&nbsp;</td></tr>
 		{/if}
+		{*  07092012 LS adding logic to provide access to archived items if they exist*}
 		{if $isValid.Author.$journalId}
 			{assign var="authorSubmissionsCount" value=$submissionsCount.Author.$journalId}
 			<tr>


### PR DESCRIPTION
Currently in OJS, if a submission is rejected by the journal editor, that submission is moved to the Archive. From an author's perspective (when they're viewing their home screen) the submission has simply disappeared, as there is no clear path to the Archived items on the home pages.

I suggest placing a "# Archived" link next to the "# Active" link that appears on the author's home pages.

http://pkp.sfu.ca/support/forum/viewtopic.php?f=9&t=8692
