### PR TITLE
*5941* Limit opening of reading tools to double ckicks within the galley

### DIFF
--- a/templates/article/footer.tpl
+++ b/templates/article/footer.tpl
@@ -75,7 +75,19 @@
 	if(document.captureEvents) {
 		document.captureEvents(Event.DBLCLICK);
 	}
-	document.ondblclick = new Function("openSearchTermWindow('{/literal}{url page="rt" op="context" path=$articleId|to_array:$galleyId:$defineTermsContextId escape=false}{literal}')");
+
+	// Make sure to only open the reading tools when double clicking within the galley	
+	if (document.getElementById('inlinePdfResizer')) {
+		context = document.getElementById('inlinePdfResizer');	
+	}
+	else if (document.getElementById('content')) {
+		context = document.getElementById('content');	
+	}
+	else {
+		context = document;
+	}
+
+	context.ondblclick = new Function("openSearchTermWindow('{/literal}{url page="rt" op="context" path=$articleId|to_array:$galleyId:$defineTermsContextId escape=false}{literal}')");
 // -->
 {/literal}
 </script>


### PR DESCRIPTION
Fix for http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=5941. Please see details in ticket comment.
