### PR TITLE
Password Reset Encryption: use config, not hardcoded MD5

### DIFF
--- a/classes/security/Validation.inc.php
+++ b/classes/security/Validation.inc.php
@@ -256,7 +256,8 @@ class Validation {
 			// No such user
 			return false;
 		}
-		return substr(md5($user->getId() . $user->getUsername() . $user->getPassword()), 0, 6);
+		$hash = Validation::encryptCredentials($user->getUsername(), $user->getPassword());
+		return substr($hash, 0, 6);
 	}
 
 	/**


### PR DESCRIPTION
Configuration has encryption options of: md5, sha1, default is md5.
If you use sha1, users can create accounts (using sha1), but if they
reset password OJS would default to resetting using md5 hash, and user will
get an email with invalid reset token. This fix uses the existing
hash encryption technique.

To test this: alter config.inc.php

``` php
; The encryption (hashing) algorithm to use for encrypting user passwords
; Valid values are: md5, sha1
; Note that sha1 requires PHP >= 4.3.0
encryption = sha1
```

Then try to do password reset: /login/lostPassword

Unmodified OJS will send you an invalid reset token. 

This patch will use your configured encryption technique, so password resets will work, and users are less flustered when they reset their password 15 times, and it never works.
