### PR TITLE
Bug 8251 fix

### DIFF
--- a/templates/article/footer.tpl
+++ b/templates/article/footer.tpl
@@ -61,8 +61,10 @@
 			var range = document.selection.createRange();
 			term = range.text;
 		}
-		if (url.indexOf('?') > -1) openRTWindowWithToolbar(url + '&defineTerm=' + term);
-		else openRTWindowWithToolbar(url + '?defineTerm=' + term);
+		if (term != ""){
+			if (url.indexOf('?') > -1) openRTWindowWithToolbar(url + '&defineTerm=' + term);
+			else openRTWindowWithToolbar(url + '?defineTerm=' + term);
+		}
 	}
 
 	if(document.captureEvents) {


### PR DESCRIPTION
double-click a blank part of the article page still opening the term search window, with no keyword to search.
I fix this adding an "if" in the javascript that not open the search window when there are no text selected
