### PR TITLE
An implementation of rolling table of contents

### DIFF
--- a/classes/article/ArticleCommentDAO.inc.php
+++ b/classes/article/ArticleCommentDAO.inc.php
@@ -256,6 +256,17 @@ class ArticleCommentDAO extends DAO {
 			)
 		);
 	}
+
+	 * Check how many comments each article has.
+	 * @param $articleId int The ID of the article to check
+	 * @return boolean
+	 */
+	function attributedCommentsExistForArticle($articleId) {
+		$result =& $this->retrieve('SELECT count(*) FROM comments WHERE article_id = ?', (int) $articleId);
+		$returner = $result->fields[0];
+		$result->Close();
+		return $returner;
+	}
 }
 
 ?>

--- a/pages/index/IndexHandler.inc.php
+++ b/pages/index/IndexHandler.inc.php
@@ -73,6 +73,8 @@ class IndexHandler extends Handler {
 					$templateMgr->assign('enableAnnouncementsHomepage', $enableAnnouncementsHomepage);
 				}
 			}
+			$CommentDAO =& DAORegistry::getDAO('ArticleCommentDAO');
+			$templateMgr->assign('ArticleCommentDAO', $ArticleCommentDAO);
 			$templateMgr->display('index/journal.tpl');
 		} else {
 			$site =& Request::getSite();

--- a/pages/issue/IssueHandler.inc.php
+++ b/pages/issue/IssueHandler.inc.php
@@ -90,6 +90,9 @@ class IssueHandler extends Handler {
 		$this->_setupIssueTemplate($request, $issue, ($showToc == 'showToc') ? true : false);
 		$templateMgr->assign('issueId', $issue->getBestIssueId());
 
+		$ArticleCommentDAO =& DAORegistry::getDAO('ArticleCommentDAO');
+		$templateMgr->assign('ArticleCommentDAO', $ArticleCommentDAO);
+		
 		// Display creative commons logo/licence if enabled
 		$templateMgr->assign('displayCreativeCommons', $journal->getSetting('includeCreativeCommons'));
 		$templateMgr->assign('pageHierarchy', array(array($request->url(null, 'issue', 'archive'), 'archive.archives')));
@@ -127,6 +130,30 @@ class IssueHandler extends Handler {
 		$templateMgr->assign_by_ref('issues', $publishedIssuesIterator);
 		$templateMgr->assign('helpTopicId', 'user.currentAndArchives');
 		$templateMgr->display('issue/archive.tpl');
+	}
+
+	function section($args) {
+		parent::validate(true);
+		$sectionId = isset($args[0]) ? $args[0] : 0;
+
+		$journal = &Request::getJournal();
+		$publishedArticleDao = &DAORegistry::getDAO('PublishedArticleDAO');
+		$publishedArticles = &$publishedArticleDao->getallPublishedArticlesBySectionId($sectionId, false);
+		$SectionDao = &DAORegistry::getDAO('SectionDAO');
+		$Section = &$SectionDao->getSection($sectionId);
+		$SectionTitle = $Section->getTitle(Locale::getLocale());
+		$CommentDAO =& DAORegistry::getDAO('CommentDAO');
+ 		$templateMgr = &TemplateManager::getManager();
+
+			$issueDao = &DAORegistry::getDAO('IssueDAO');
+			$templateMgr->assign('issueDao', $issueDao);
+
+		$templateMgr->assign('CommentDAO', $CommentDAO);
+		$templateMgr->assign('locale', Locale::getLocale());
+		$templateMgr->assign_by_ref('issues', $publishedIssuesIterator);
+		$templateMgr->assign('SectionTitle', $SectionTitle);
+		$templateMgr->assign('publishedArticles', $publishedArticles);
+		$templateMgr->display('issue/section.tpl');
 	}
 
 	/**
@@ -443,13 +470,19 @@ class IssueHandler extends Handler {
 				// Published articles
 				$publishedArticleDao =& DAORegistry::getDAO('PublishedArticleDAO');
 				$publishedArticles =& $publishedArticleDao->getPublishedArticlesInSections($issue->getId(), true);
+				$allpublishedArticles = &$publishedArticleDao->getallPublishedArticlesInSections($issue->getIssueId(), true);
 
 				$publicFileManager = new PublicFileManager();
 				$templateMgr->assign_by_ref('publishedArticles', $publishedArticles);
+				$templateMgr->assign_by_ref('allpublishedArticles', $allpublishedArticles);
+				$templateMgr->assign_by_ref('recentpublishedArticles', $recentpublishedArticles);
 				$showToc = true;
 			}
 			$templateMgr->assign('showToc', $showToc);
 			$templateMgr->assign_by_ref('issue', $issue);
+
+			$issueDao = &DAORegistry::getDAO('IssueDAO');
+			$templateMgr->assign('issueDao', $issueDao);
 
 			// Subscription Access
 			import('classes.issue.IssueAction');

--- a/templates/index/journal.tpl
+++ b/templates/index/journal.tpl
@@ -45,8 +45,7 @@
 {if $issue && $currentJournal->getSetting('publishingMode') != $smarty.const.PUBLISHING_MODE_NONE}
 	{* Display the table of contents or cover page of the current issue. *}
 	<br />
-	<h3>{$issue->getIssueIdentification()|strip_unsafe_html|nl2br}</h3>
-	{include file="issue/view.tpl"}
+	{include file="issue/customissue.tpl"}
 {/if}
 
 {include file="common/footer.tpl"}

--- a/templates/issue/customissue.tpl
+++ b/templates/issue/customissue.tpl
@@ -1,0 +1,183 @@
+<div class="recentlyPublished">
+	<div id="whatsnew">
+
+{assign var=displayedNewArticles value=0}
+{foreach from=$recentpublishedArticles item=article}
+	{assign var=displayedNewArticles value=$displayedNewArticles+1}
+	{assign var=issue2 value=$issueDao->getIssueById($article->getIssueId())}
+	{assign var=articleId value=$article->getArticleId()}
+	{assign var=fpage value=$article->getPages()|escape|explode:"-"}
+	{assign var=articleId value=$article->getArticleId()}
+	{assign var=articlePath value=$article->getBestArticleId($currentJournal)}
+
+	{if $displayedNewArticles == 1}
+		<div id="whatsnew-1">
+			<div id="whatsnew-1-thumb">
+				<img src="{$coverPagePath|escape}{$article->getFileName($locale)}" alt="Cover image" />
+				<br />
+				{$article->getCoverPageAltText($locale)}
+			</div><!--whatsnew-1-thumb-->
+			<div class="toc-title">{$article->getArticleTitle()|strip_unsafe_html}</div>
+			<div class="toc-date">{$article->getDatePublished()|date_format:"%B %e, %Y"}. Vol. {$issue2->getVolume()}({$issue2->getNumber()}){if $article->getPages()|escape}, pp.{$article->getPages()|escape}{/if}</div>
+
+			<div class="toc-byline">
+				{if (!$section.hideAuthor && $article->getHideAuthor() == 0) || $article->getHideAuthor() == 2}
+					{foreach from=$article->getAuthors() item=author name=authorList}
+						{$author->getFullName()|escape}{if !$smarty.foreach.authorList.last},{/if}
+					{/foreach}
+				{else}
+					&nbsp;
+				{/if}
+			</div><!--toc-byline-->
+
+			<div class="toc-links">
+				{foreach from=$article->getLocalizedGalleys() item=galley name=galleyList}
+					<a href="{url page="article" op="view" path=$articlePath|to_array:$galley->getBestGalleyId($currentJournal)}" class="file">{$galley->getGalleyLabel()|escape}</a> |
+					{/foreach}
+
+				{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId())}
+					{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId()) == 1}
+						<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comment ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+					{else}
+						<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comments ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+					{/if}
+				{else}
+					<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Add a comment</a>
+				{/if}
+			</div><!--toc-links-->
+
+			<div style="clear: both;"></div>
+		</div><!--whatsnew-1-->
+		<div class="whatsnew-2-meta">
+	{else}
+		<div class="whatsnew-2">
+			<div class="whatsnew-2-thumb">
+				<img src="{$baseurl}/images/{$issue2->getVolume()}/e{$fpage[0]}/{$article->getArticleId()}-thumb.png" alt="Cover image" />
+				<br />
+				{$article->getCoverPageAltText($locale)}
+			</div>
+			<div class="toc-thumb-title">{$article->getArticleTitle()|strip_unsafe_html}</div>
+			<div class="toc-thumb-date">{$article->getDatePublished()|date_format:"%B %e, %Y"}. Vol. {$issue2->getVolume()}({$issue2->getNumber()}){if $article->getPages()|escape}, pp.{$article->getPages()|escape}{/if}</div>
+
+			<div class="toc-thumb-byline">
+				{if (!$section.hideAuthor && $article->getHideAuthor() == 0) || $article->getHideAuthor() == 2}
+					{foreach from=$article->getAuthors() item=author name=authorList}
+						{$author->getFullName()|escape}{if !$smarty.foreach.authorList.last},{/if}
+					{/foreach}
+				{else}
+					&nbsp;
+				{/if}
+			</div>
+
+			<div class="toc-links">
+				{foreach from=$article->getLocalizedGalleys() item=galley name=galleyList}
+					<a href="{url page="article" op="view" path=$articlePath|to_array:$galley->getBestGalleyId($currentJournal)}" class="file">{$galley->getGalleyLabel()|escape}</a> |
+					{/foreach}
+
+				{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId())}
+					{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId()) == 1}
+						<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comment ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+					{else}
+						<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comments ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+					{/if}
+				{else}
+					<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Add a comment</a>
+				{/if}
+			</div>
+		</div>
+
+	{/if}
+	{if !$smarty.foreach.sections.last}
+	{/if}
+{/foreach}
+
+	<div style="clear: both;"></div>
+	</div> <!--Close meta-->
+	</div> <!-- Close Whatsnew -->
+</div><!--Close recentlyPublished-->
+
+
+{foreach name=sections from=$allpublishedArticles item=section key=sectionId}
+{assign var=moregiven value=0}
+{assign var=displayedarticles value=0}
+	{if $section.title}<div class="toc-Title2">{$section.title|escape}</div>{/if}
+
+	{foreach from=$section.articles item=article}
+		{assign var=issue2 value=$issueDao->getIssueById($article->getIssueId())}
+		{if $displayedarticles >= 3}
+			{if $moregiven == 0}
+				<div><a href="{url page="issue" op="section" path=$sectionId}">&raquo;See more articles in the <em>{$section.title|escape}</em> section</a></div>
+				{assign var=moregiven value=1}
+			{/if}
+		{else}
+			{assign var=displayedarticles value=$displayedarticles+1}
+			{assign var=articlePath value=$article->getBestArticleId($currentJournal)}
+
+
+			{if $article->getArticleAbstract() == ""}
+				{assign var=hasAbstract value=0}
+			{else}
+				{assign var=hasAbstract value=1}
+			{/if}
+
+			{assign var=articleId value=$article->getArticleId()}
+			{if (!$subscriptionRequired || $article->getAccessStatus() || $subscribedUser || $subscribedDomain || ($subscriptionExpiryPartial && $articleExpiryPartial.$articleId))}
+				{assign var=hasAccess value=1}
+			{else}
+				{assign var=hasAccess value=0}
+			{/if}
+
+			 <div class="toc-title">{$article->getArticleTitle()|strip_unsafe_html}</div>
+
+			<div class="toc-date">{$article->getDatePublished()|date_format:"%B %e, %Y"}. Vol. {$issue2->getVolume()}({$issue2->getNumber()}){if $article->getPages()|escape}, pp.{$article->getPages()|escape}{/if}</div>
+
+			<div class="toc-byline">
+				{if (!$section.hideAuthor && $article->getHideAuthor() == 0) || $article->getHideAuthor() == 2}
+					{foreach from=$article->getAuthors() item=author name=authorList}
+						{$author->getFullName()|escape}{if !$smarty.foreach.authorList.last},{/if}
+					{/foreach}
+				{else}
+					&nbsp;
+				{/if}
+			</div>
+			<div class="toc-links">
+				{if $hasAccess || ($subscriptionRequired && $showGalleyLinks)}
+					{foreach from=$article->getLocalizedGalleys() item=galley name=galleyList}
+						<a href="{url page="article" op="view" path=$articlePath|to_array:$galley->getBestGalleyId($currentJournal)}" class="file">{$galley->getGalleyLabel()|escape}</a> |
+						{if $subscriptionRequired && $showGalleyLinks && $restrictOnlyPdf}
+							{if $article->getAccessStatus() || !$galley->isPdfGalley()}	
+								<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_open_medium.gif" alt="{translate key="article.accessLogoOpen.altText"}" />
+							{else}
+								<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_restricted_medium.gif" alt="{translate key="article.accessLogoRestricted.altText"}" />
+							{/if}
+						{/if}
+					{/foreach}
+				{/if}
+				{if $subscriptionRequired && $showGalleyLinks && !$restrictOnlyPdf}
+					{if $article->getAccessStatus()}
+						<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_open_medium.gif" alt="{translate key="article.accessLogoOpen.altText"}" />
+					{else}
+						<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_restricted_medium.gif" alt="{translate key="article.accessLogoRestricted.altText"}" />
+					{/if}
+				{/if}
+				{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId())}
+					{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId()) == 1}
+						<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comment ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+					{else}
+						<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comments ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+					{/if}
+				{else}
+					<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Add a comment</a>
+				{/if}
+			</div>
+			{/if}
+	{/foreach}
+
+	{if !$smarty.foreach.sections.last}
+	{/if}
+{/foreach}
+
+<!--<div class="block" id="sidebarExternalFeed">
+{$tadditionalHomeContent-off}
+</div>
+-->

--- a/templates/issue/section.tpl
+++ b/templates/issue/section.tpl
@@ -1,0 +1,87 @@
+{**
+ * section.tpl
+ *
+ * Copyright (c) 2003-2009 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Issue Archive.
+ *
+ * $Id: archive.tpl,v 1.24.2.1 2009/04/08 19:43:32 asmecher Exp $
+ *}
+{assign var="pageTitle" value="$SectionTitle"}
+{include file="common/header.tpl"}
+
+{foreach name=articles from=$publishedArticles item=article}
+	{assign var=articlePath value=$article->getBestArticleId($currentJournal)}
+	{assign var=issue2 value=$issueDao->getIssueById($article->getIssueId())}
+	{assign var=articleId value=$article->getArticleId()}
+
+
+	{if $article->getFileName($locale) && $article->getShowCoverPage($locale) && !$article->getHideCoverPageToc($locale)}
+		<a href="{url page="article" op="view" path=$articlePath}" class="file">
+		<img src="{$coverPagePath|escape}{$article->getFileName($locale)|escape}"{if $article->getCoverPageAltText($locale) != ''} alt="{$article->getCoverPageAltText($locale)|escape}"{else} alt="{translate key="article.coverPage.altText"}"{/if}/></a></div>
+	{/if}
+
+	{if $article->getArticleAbstract() == ""}
+		{assign var=hasAbstract value=0}
+	{else}
+		{assign var=hasAbstract value=1}
+	{/if}
+
+	{if (!$subscriptionRequired || $article->getAccessStatus() || $subscribedUser || $subscribedDomain || ($subscriptionExpiryPartial && $articleExpiryPartial.$articleId))}
+		{assign var=hasAccess value=1}
+	{else}
+		{assign var=hasAccess value=0}
+	{/if}
+
+	 <div class="toc-title">{if !$hasAccess || $hasAbstract}<a href="{url page="article" op="view" path=$articlePath}">{$article->getArticleTitle()|strip_unsafe_html}</a>{else}{$article->getArticleTitle()|strip_unsafe_html}{/if}</div>
+
+	<div class="toc-date">{$article->getDatePublished()|date_format:"%B %e, %Y"}. Vol. {$issue2->getVolume()}({$issue2->getNumber()}){if $article->getPages()|escape}, pp.{$article->getPages()|escape}{/if}
+
+</div>
+
+	<div class="toc-byline">
+		{if (!$section.hideAuthor && $article->getHideAuthor() == 0) || $article->getHideAuthor() == 2}
+			{foreach from=$article->getAuthors() item=author name=authorList}
+				{$author->getFullName()|escape}{if !$smarty.foreach.authorList.last},{/if}
+			{/foreach}
+		{else}
+			&nbsp;
+		{/if}
+	</div>
+	<div class="toc-links">
+		{if $hasAccess || ($subscriptionRequired && $showGalleyLinks)}
+			{foreach from=$article->getLocalizedGalleys() item=galley name=galleyList}
+				<a href="{url page="article" op="view" path=$articlePath|to_array:$galley->getBestGalleyId($currentJournal)}" class="file">{$galley->getGalleyLabel()|escape}</a>
+				{if $subscriptionRequired && $showGalleyLinks && $restrictOnlyPdf}
+					{if $article->getAccessStatus() || !$galley->isPdfGalley()}	
+						<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_open_medium.gif" alt="{translate key="article.accessLogoOpen.altText"}" />
+					{else}
+						<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_restricted_medium.gif" alt="{translate key="article.accessLogoRestricted.altText"}" />
+					{/if}
+				{/if}
+			{/foreach}
+		{/if}
+		{if $subscriptionRequired && $showGalleyLinks && !$restrictOnlyPdf}
+			{if $article->getAccessStatus()}
+				<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_open_medium.gif" alt="{translate key="article.accessLogoOpen.altText"}" />
+			{else}
+				<img class="accessLogo" src="{$baseUrl}/templates/images/icons/fulltext_restricted_medium.gif" alt="{translate key="article.accessLogoRestricted.altText"}" />
+			{/if}
+		{/if}
+		{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId())}
+			{if $CommentDAO->attributedCommentsExistForArticle($article->getArticleId()) == 1}
+				<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comment ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+			{else}
+				<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Comments ({$CommentDAO->attributedCommentsExistForArticle($article->getArticleId())})</a>
+			{/if}
+		{else}
+		<a href="{$baseUrl}/comment/view/{$article->getArticleId()}/0" class="file">Add a comment</a>
+		{/if}
+	</div>
+
+	{if !$smarty.foreach.sections.last}
+	{/if}
+{/foreach}
+
+{include file="common/footer.tpl"}


### PR DESCRIPTION
This pull implements a rolling table of contents, in which the three most recent articles are featured prominently, and all other articles are divided into their sections and displayed there.

This code was originally written in OJS 2.2.3, and has not been heavily tested in OJS 2.3.4, though this work is currently ongoing.

For a live example, see http://openmedicine.ca

tarek : )
