### PR TITLE
Delete on Editor Decision Email doesn't work

### DIFF
--- a/templates/submission/comment/editorDecisionEmail.tpl
+++ b/templates/submission/comment/editorDecisionEmail.tpl
@@ -25,7 +25,7 @@ function deleteAttachment(fileId) {
 {/literal}
 </script>
 <div id="editorDecisionEmail">
-<form method="post" name="emailForm" action="{$formActionUrl}"{if $attachmentsEnabled} enctype="multipart/form-data"{/if}>
+<form method="post" id="emailForm" name="emailForm" action="{$formActionUrl}"{if $attachmentsEnabled} enctype="multipart/form-data"{/if}>
 <input type="hidden" name="continued" value="1"/>
 {if $hiddenFormParams}
 	{foreach from=$hiddenFormParams item=hiddenFormParam key=key}


### PR DESCRIPTION
Page JS expects form element to have ID attribute set to "emailForm" in order for attachment deletion to work.
