### PR TITLE
*8742* Check article object before calling

### DIFF
--- a/plugins/importexport/datacite/classes/DataciteExportDom.inc.php
+++ b/plugins/importexport/datacite/classes/DataciteExportDom.inc.php
@@ -167,7 +167,7 @@ class DataciteExportDom extends DOIExportDom {
 		if (!empty($articleFile)) XMLCustomWriter::appendChild($rootElement, $this->_formatsElement($articleFile));
 
 		// Rights
-		$rightsURL = $article->getLicenseURL();
+		$rightsURL = $article?$article->getLicenseURL():$journal->getSetting('licenseURL');
 		$rightsListElement =& XMLCustomWriter::createElement($this->getDoc(), 'rightsList');
 		$rightsElement = $this->createElementWithText('rights', strip_tags(Application::getCCLicenseBadge($rightsURL)), array('rightsURI' => $rightsURL));
 		XMLCustomWriter::appendChild($rightsListElement, $rightsElement);


### PR DESCRIPTION
Check the existence of the article object before fetching its rights, falling back on the journal if needed.
