### PR TITLE
Typo on oocss stylesheet import

### DIFF
--- a/styles/ojs.css
+++ b/styles/ojs.css
@@ -15,7 +15,7 @@
 /* Includes CSS files necessary for OJS to use new interface components such as Grids */
 
 /* OOCSS - http://github.com/stubbornella/oocss */
-@import url("../lib/pkp/styles/oocss/grids.css");
+@import url("../lib/pkp/styles/lib/oocss/grids.css");
 
 /* Theme */
 @import url("../lib/pkp/styles/themes/default/theme.css");


### PR DESCRIPTION
I'm not sure if this @import is actually wanted in 2.4 (isn't Grids 3.0 specific?), but it's generating an error with the bad URL.
