### PR TITLE
*6365* add Universal Analytics to Google Analytics plugin

### DIFF
--- a/plugins/generic/googleAnalytics/GoogleAnalyticsPlugin.inc.php
+++ b/plugins/generic/googleAnalytics/GoogleAnalyticsPlugin.inc.php
@@ -193,8 +193,10 @@ class GoogleAnalyticsPlugin extends GenericPlugin {
 				$trackingCode = $this->getSetting($journalId, 'trackingCode');
 				if ($trackingCode == "ga") {
 					$output .= $templateMgr->fetch($this->getTemplatePath() . 'pageTagGa.tpl');
-				} else {
+				} elseif ($trackingCode == "urchin") {
 					$output .= $templateMgr->fetch($this->getTemplatePath() . 'pageTagUrchin.tpl');
+				} elseif ($trackingCode == "analytics") {
+					$output .= $templateMgr->fetch($this->getTemplatePath() . 'pageTagAnalytics.tpl');
 				}
 			}
 		}

--- a/plugins/generic/googleAnalytics/GoogleAnalyticsSettingsForm.inc.php
+++ b/plugins/generic/googleAnalytics/GoogleAnalyticsSettingsForm.inc.php
@@ -70,7 +70,7 @@ class GoogleAnalyticsSettingsForm extends Form {
 		$plugin->updateSetting($journalId, 'googleAnalyticsSiteId', trim($this->getData('googleAnalyticsSiteId'), "\"\';"), 'string');
 
 		$trackingCode = $this->getData('trackingCode');
-		if (($trackingCode != "urchin") && ($trackingCode != "ga")) {
+		if (($trackingCode != "urchin") && ($trackingCode != "ga") && ($trackingCode != "analytics")) {
 			$trackingCode = "urchin";
 		}
 		$plugin->updateSetting($journalId, 'trackingCode', $trackingCode, 'string');

--- a/plugins/generic/googleAnalytics/locale/en_US/locale.xml
+++ b/plugins/generic/googleAnalytics/locale/en_US/locale.xml
@@ -27,7 +27,8 @@
 	<message key="plugins.generic.googleAnalytics.manager.settings.trackingCode">Tracking code</message>
 	<message key="plugins.generic.googleAnalytics.manager.settings.trackingCodeRequired">Please select a tracking code to use.</message>
 	<message key="plugins.generic.googleAnalytics.manager.settings.urchin">Legacy tracking code (urchin.js)</message>
-	<message key="plugins.generic.googleAnalytics.manager.settings.ga">New tracking code (ga.js)</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.ga">Legacy tracking code (ga.js)</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.analytics">New tracking code for Universal Analytics (analytics.js)</message>
 	<message key="plugins.generic.googleAnalytics.authorAccount">Google Analytics account number</message>
 	<message key="plugins.generic.googleAnalytics.authorAccount.description">To track published article readership using Google Analytics, enter an account number here (e.g. UA-xxxxxx-x).</message>
 	<message key="plugins.generic.googleAnalytics.authorAccountInvalid">One or more Google Analytics account numbers entered for submission authors are not valid.</message>

--- a/plugins/generic/googleAnalytics/pageTagAnalytics.tpl
+++ b/plugins/generic/googleAnalytics/pageTagAnalytics.tpl
@@ -1,0 +1,24 @@
+{**
+ * plugins/generic/googleAnalytics/pageTagAnalytics.tpl
+ *
+ * Copyright (c) 2013-2014 Simon Fraser University Library
+ * Copyright (c) 2003-2014 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Google Analytics analytics.js page tag.
+ *
+ *}
+<!-- Google Analytics -->
+{literal}
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', '{$googleAnalyticsSiteId|escape}', 'auto');
+ga('send', 'pageview');
+
+</script>
+{/literal}
+<!-- End Google Analytics -->

--- a/plugins/generic/googleAnalytics/settingsForm.tpl
+++ b/plugins/generic/googleAnalytics/settingsForm.tpl
@@ -38,6 +38,10 @@
 		<td width="20%" class="label">&nbsp;</td>
 		<td width="80%" class="value"><input type="radio" name="trackingCode" id="trackingCode-ga" value="ga" {if $trackingCode eq "ga"}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.ga"}</td>
 	</tr>
+	<tr valign="top">
+		<td width="20%" class="label">&nbsp;</td>
+		<td width="80%" class="value"><input type="radio" name="trackingCode" id="trackingCode-analytics" value="analytics" {if $trackingCode eq "analytics"}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.analytics"}</td>
+	</tr>
 </table>
 
 <br/>


### PR DESCRIPTION
This new request is identical to the previous (https://github.com/pkp/ojs/pull/201) except that I've added a full path to the template file as per Jason's request, and have added {literal} tags around the javascript snippet so that it displays correctly. 
