### PR TITLE
*6582* Override getCurrentVersion() on Custom Block Plugin

### DIFF
--- a/plugins/generic/customBlockManager/CustomBlockPlugin.inc.php
+++ b/plugins/generic/customBlockManager/CustomBlockPlugin.inc.php
@@ -41,6 +41,14 @@ class CustomBlockPlugin extends BlockPlugin {
 	}
 
 	/**
+	 * Override currentVersion to prevent upgrade and delete management.
+	 * @return boolean
+	 */
+	function getCurrentVersion() {
+		return false;
+	}
+
+	/**
 	 * Get the symbolic name of the plugin.
 	 * @return string
 	 */


### PR DESCRIPTION
 to prevent the upgrade and delete management verbs for a subsidiary plugin.  C.f. http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=6582
