### PR TITLE
*8931* Ensure journals are listed on site home for unassociated users

### DIFF
--- a/pages/user/UserHandler.inc.php
+++ b/pages/user/UserHandler.inc.php
@@ -75,6 +75,9 @@ class UserHandler extends Handler {
 			$templateMgr->assign_by_ref('userJournals', $userJournals);
 			$templateMgr->assign('showAllJournals', 1);
 
+			$allJournals =& $journalDao->getJournals();
+			$templateMgr->assign_by_ref('allJournals', $allJournals->toArray());
+
 		} else { // Currently within a journal's context.
 			$journalId = $journal->getId();
 


### PR DESCRIPTION
For users not associated with any journals, this ensures the listing of all journals is populated.  Previously, it was missing because this variable wasn't present in the template manager.
