### PR TITLE
*8958* Cleanup unset/unused variables in usageStats plugin settings form

### DIFF
--- a/plugins/generic/usageStats/UsageStatsSettingsForm.inc.php
+++ b/plugins/generic/usageStats/UsageStatsSettingsForm.inc.php
@@ -39,21 +39,20 @@ class UsageStatsSettingsForm extends Form {
 
 		$this->setData('createLogFiles', $plugin->getSetting(CONTEXT_SITE, 'createLogFiles'));
 		$this->setData('accessLogFileParseRegex', $plugin->getSetting(0, 'accessLogFileParseRegex'));
-		$this->setData('minTimeBetweenRequests', $plugin->getSetting(0, 'minTimeBetweenRequests'));
 	}
 
 	/**
 	 * Assign form data to user-submitted data.
 	 */
 	function readInputData() {
-		$this->readUserVars(array('createLogFiles','accessLogFileParseRegex', 'minTimeBetweenRequests'));
+		$this->readUserVars(array('createLogFiles','accessLogFileParseRegex'));
 	}
 
 	/**
 	 * @see Form::fetch()
 	 */
 	function display() {
-		$templateMgr =& TemplateManager::getManager($request);
+		$templateMgr =& TemplateManager::getManager();
 		$templateMgr->assign('pluginName', $this->plugin->getName());
 		parent::display();
 	}
@@ -66,7 +65,6 @@ class UsageStatsSettingsForm extends Form {
 
 		$plugin->updateSetting(0, 'createLogFiles', $this->getData('createLogFiles'));
 		$plugin->updateSetting(0, 'accessLogFileParseRegex', $this->getData('accessLogFileParseRegex'));
-		$plugin->updateSetting(0, 'minTimeBetweenRequests', (int)$this->getData('minTimeBetweenRequests'));
 	}
 
 }


### PR DESCRIPTION
http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=8958

c.f. https://github.com/pkp/ojs/commit/1029a94639cfea21b312b7636509b77f97081212
