### PR TITLE
DataCite does not support SSLv3 any more

### DIFF
--- a/plugins/importexport/datacite/DataciteExportPlugin.inc.php
+++ b/plugins/importexport/datacite/DataciteExportPlugin.inc.php
@@ -140,7 +140,6 @@ class DataciteExportPlugin extends DOIExportPlugin {
 		curl_setopt($curlCh, CURLOPT_USERPWD, "$username:$password");
 
 		// Set up SSL.
-		curl_setopt($curlCh, CURLOPT_SSLVERSION, 3);
 		curl_setopt($curlCh, CURLOPT_SSL_VERIFYPEER, false);
 
 		// Transmit meta-data.


### PR DESCRIPTION
Due to the POODLE vulnerability DataCite now only support TLS 1, 1.1 and 1.2.

A client reported `No response from server` error when registering DOIs via OJS. He verified that removing he `CURLOPT_SSLVERSION` line resolves the problem.
