### PR TITLE
*9037* Show titles in TOC as configured in manager/languages

### DIFF
--- a/classes/article/ArticleGalley.inc.php
+++ b/classes/article/ArticleGalley.inc.php
@@ -92,37 +92,37 @@ class ArticleGalley extends ArticleFile {
 	 * Get the localized value of the galley label.
 	 * @return $string
 	 */
-  function getGalleyLabel() {
-    $label = $this->getLabel();
-    $localeDisplayFile = AppLocale::getLocaleDisplayFile();
+	function getGalleyLabel() {
+		$label = $this->getLabel();
+		$localeDisplayFile = AppLocale::getLocaleDisplayFile();
 
-    switch ($localeDisplayFile) {
-      case "show":
-          // Show lang label appened to the galley tag.
-          if ($this->getLocale() != AppLocale::getLocale()) {
-            $locales = AppLocale::getAllLocales();
-            $label .= ' (' . $locales[$this->getLocale()] . ')';
-          }
-          else {
-            $locales = AppLocale::getAllLocales();
-            $label .= ' (' . $locales[$this->getLocale()] . ')'; 
-          }
-        break;
+		switch ($localeDisplayFile) {
+			case "show":
+				// Show lang label appened to the galley tag.
+				if ($this->getLocale() != AppLocale::getLocale()) {
+					$locales = AppLocale::getAllLocales();
+					$label .= ' (' . $locales[$this->getLocale()] . ')';
+				}
+				else {
+					$locales = AppLocale::getAllLocales();
+					$label .= ' (' . $locales[$this->getLocale()] . ')'; 
+				}
+			break;
 
-      case "hide":
-          // Do nothing.
-        break;
+			case "hide":
+				// Do nothing.
+			break;
 
-      case "legacy":
-      default:
-          // Show lang label, except for user's current language.
-          if ($this->getLocale() != AppLocale::getLocale()) {
-            $locales = AppLocale::getAllLocales();
-            $label .= ' (' . $locales[$this->getLocale()] . ')';
-          }
-        break;
-    }
-		return $label;
+			case "legacy":
+			default:
+				// Show lang label, except for user's current language.
+				if ($this->getLocale() != AppLocale::getLocale()) {
+					$locales = AppLocale::getAllLocales();
+					$label .= ' (' . $locales[$this->getLocale()] . ')';
+				}
+			break;
+		}
+	return $label;
 	}
 
 	/**

--- a/classes/article/ArticleGalley.inc.php
+++ b/classes/article/ArticleGalley.inc.php
@@ -92,12 +92,36 @@ class ArticleGalley extends ArticleFile {
 	 * Get the localized value of the galley label.
 	 * @return $string
 	 */
-	function getGalleyLabel() {
-		$label = $this->getLabel();
-		if ($this->getLocale() != AppLocale::getLocale()) {
-			$locales = AppLocale::getAllLocales();
-			$label .= ' (' . $locales[$this->getLocale()] . ')';
-		}
+  function getGalleyLabel() {
+    $label = $this->getLabel();
+    $localeDisplayFile = AppLocale::getLocaleDisplayFile();
+
+    switch ($localeDisplayFile) {
+      case "show":
+          // Show lang label appened to the galley tag.
+          if ($this->getLocale() != AppLocale::getLocale()) {
+            $locales = AppLocale::getAllLocales();
+            $label .= ' (' . $locales[$this->getLocale()] . ')';
+          }
+          else {
+            $locales = AppLocale::getAllLocales();
+            $label .= ' (' . $locales[$this->getLocale()] . ')'; 
+          }
+        break;
+
+      case "hide":
+          // Do nothing.
+        break;
+
+      case "legacy":
+      default:
+          // Show lang label, except for user's current language.
+          if ($this->getLocale() != AppLocale::getLocale()) {
+            $locales = AppLocale::getAllLocales();
+            $label .= ' (' . $locales[$this->getLocale()] . ')';
+          }
+        break;
+    }
 		return $label;
 	}
 

--- a/classes/i18n/AppLocale.inc.php
+++ b/classes/i18n/AppLocale.inc.php
@@ -24,6 +24,8 @@ define('LOCALE_COMPONENT_OJS_MANAGER',		0x00000104);
 define('LOCALE_COMPONENT_OJS_ADMIN',		0x00000105);
 define('LOCALE_COMPONENT_OJS_DEFAULT',		0x00000106);
 
+define('DEFAULT_LOCALE_DISPLAY', 'legacy');
+
 class AppLocale extends PKPLocale {
 	/**
 	 * Get all supported UI locales for the current context.
@@ -172,6 +174,40 @@ class AppLocale extends PKPLocale {
 
 		return $locale;
 	}
+
+  /**
+   * Retrieve the localization display mode of the titles.
+   * @return string
+   */
+  function getLocaleDisplayTitle() {
+    $journal =& Request::getJournal();
+
+    if (isset($journal)) {
+      $locale = $journal->getLocaleDisplayTitle();
+    }
+    else {
+      $locale = DEFAULT_LOCALE_DISPLAY;
+    }
+
+    return $locale;
+  }
+
+  /**
+   * Retrieve the localization display mode of the titles.
+   * @return string
+   */
+  function getLocaleDisplayFile() {
+    $journal =& Request::getJournal();
+
+    if (isset($journal)) {
+      $locale = $journal->getLocaleDisplayFile();
+    }
+    else {
+      $locale = DEFAULT_LOCALE_DISPLAY;                                                                                                                      
+    }
+
+    return $locale;
+  }
 
 	/**
 	 * Make a map of components to their respective files.

--- a/classes/i18n/AppLocale.inc.php
+++ b/classes/i18n/AppLocale.inc.php
@@ -175,39 +175,39 @@ class AppLocale extends PKPLocale {
 		return $locale;
 	}
 
-  /**
-   * Retrieve the localization display mode of the titles.
-   * @return string
-   */
-  function getLocaleDisplayTitle() {
-    $journal =& Request::getJournal();
+	/**
+	 * Retrieve the localization display mode of the titles.
+	 * @return string
+	 */
+	function getLocaleDisplayTitle() {
+		$journal =& Request::getJournal();
 
-    if (isset($journal)) {
-      $locale = $journal->getLocaleDisplayTitle();
-    }
-    else {
-      $locale = DEFAULT_LOCALE_DISPLAY;
-    }
+		if (isset($journal)) {
+			$locale = $journal->getLocaleDisplayTitle();
+		}
+		else {
+			$locale = DEFAULT_LOCALE_DISPLAY;
+		}
 
-    return $locale;
-  }
+		return $locale;
+	}
 
-  /**
-   * Retrieve the localization display mode of the titles.
-   * @return string
-   */
-  function getLocaleDisplayFile() {
-    $journal =& Request::getJournal();
+	/**
+	 * Retrieve the localization display mode of the titles.
+	 * @return string
+	 */
+	function getLocaleDisplayFile() {
+		$journal =& Request::getJournal();
 
-    if (isset($journal)) {
-      $locale = $journal->getLocaleDisplayFile();
-    }
-    else {
-      $locale = DEFAULT_LOCALE_DISPLAY;                                                                                                                      
-    }
+		if (isset($journal)) {
+			$locale = $journal->getLocaleDisplayFile();
+		}
+		else {
+			$locale = DEFAULT_LOCALE_DISPLAY;
+		}
 
-    return $locale;
-  }
+		return $locale;
+	}
 
 	/**
 	 * Make a map of components to their respective files.

--- a/classes/journal/Journal.inc.php
+++ b/classes/journal/Journal.inc.php
@@ -55,47 +55,47 @@ class Journal extends DataObject {
 		return $this->setData('primaryLocale', $primaryLocale);
 	}
 
-  /**
-   * Return the locale display of the titles of this journal.
-   * @return string
-   */
-  function getLocaleDisplayTitle() {
-    $localeDisplayTitle = $this->getSetting('localeDisplayTitle');
+	/**
+	 * Return the locale display of the titles of this journal.
+	 * @return string
+	 */
+	function getLocaleDisplayTitle() {
+		$localeDisplayTitle = $this->getSetting('localeDisplayTitle');
 
-    if (!isset($localeDisplayTitle)) {
-      $localeDisplayTitle = DEFAULT_LOCALE_DISPLAY;
-    }
-    return $localeDisplayTitle;
-  }
+		if (!isset($localeDisplayTitle)) {
+			$localeDisplayTitle = DEFAULT_LOCALE_DISPLAY;
+		}
+		return $localeDisplayTitle;
+	}
 
-  /**
-   * Set the locale display of the titles of this journal.
-   * @param $localeDisplayTitle string
-   */
-  function setLocaleDisplayTitle($localeDisplayTitle) {
-    return $this->setData('localeDisplayTitle', $localeDisplayTitle);
-  }
+	/**
+	 * Set the locale display of the titles of this journal.
+	 * @param $localeDisplayTitle string
+	 */
+	function setLocaleDisplayTitle($localeDisplayTitle) {
+		return $this->setData('localeDisplayTitle', $localeDisplayTitle);
+	}
 
-  /**
-   * Return the locale display of the galleys of this journal.
-   * @return string
-   */
-  function getLocaleDisplayFile() {
-    $localeDisplayFile = $this->getSetting('localeDisplayFile');
+	/**
+	 * Return the locale display of the galleys of this journal.
+	 * @return string
+	 */
+	function getLocaleDisplayFile() {
+		$localeDisplayFile = $this->getSetting('localeDisplayFile');
 
-    if (!isset($localeDisplayFile)) {
-      $localeDisplayFile = DEFAULT_LOCALE_DISPLAY;
-    }
-    return $localeDisplayFile;
-  }
+		if (!isset($localeDisplayFile)) {
+			$localeDisplayFile = DEFAULT_LOCALE_DISPLAY;
+		}
+		return $localeDisplayFile;
+	}
 
-  /**
-   * Set the locale display of the galleys of this journal.
-   * @param $localeDisplayFile string
-   */
-  function setLocaleDisplayFile($localeDisplayFile) {
-    return $this->setData('localeDisplayFile', $localeDisplayFile);
-  }
+	/**
+	 * Set the locale display of the galleys of this journal.
+	 * @param $localeDisplayFile string
+	 */
+	function setLocaleDisplayFile($localeDisplayFile) {
+		return $this->setData('localeDisplayFile', $localeDisplayFile);
+	}
 
 	/**
 	 * Return associative array of all locales supported by the journal.

--- a/classes/journal/Journal.inc.php
+++ b/classes/journal/Journal.inc.php
@@ -55,6 +55,48 @@ class Journal extends DataObject {
 		return $this->setData('primaryLocale', $primaryLocale);
 	}
 
+  /**
+   * Return the locale display of the titles of this journal.
+   * @return string
+   */
+  function getLocaleDisplayTitle() {
+    $localeDisplayTitle = $this->getSetting('localeDisplayTitle');
+
+    if (!isset($localeDisplayTitle)) {
+      $localeDisplayTitle = DEFAULT_LOCALE_DISPLAY;
+    }
+    return $localeDisplayTitle;
+  }
+
+  /**
+   * Set the locale display of the titles of this journal.
+   * @param $localeDisplayTitle string
+   */
+  function setLocaleDisplayTitle($localeDisplayTitle) {
+    return $this->setData('localeDisplayTitle', $localeDisplayTitle);
+  }
+
+  /**
+   * Return the locale display of the galleys of this journal.
+   * @return string
+   */
+  function getLocaleDisplayFile() {
+    $localeDisplayFile = $this->getSetting('localeDisplayFile');
+
+    if (!isset($localeDisplayFile)) {
+      $localeDisplayFile = DEFAULT_LOCALE_DISPLAY;
+    }
+    return $localeDisplayFile;
+  }
+
+  /**
+   * Set the locale display of the galleys of this journal.
+   * @param $localeDisplayFile string
+   */
+  function setLocaleDisplayFile($localeDisplayFile) {
+    return $this->setData('localeDisplayFile', $localeDisplayFile);
+  }
+
 	/**
 	 * Return associative array of all locales supported by the journal.
 	 * These locales are used to provide a language toggle on the journal-specific pages.

--- a/classes/manager/form/LanguageSettingsForm.inc.php
+++ b/classes/manager/form/LanguageSettingsForm.inc.php
@@ -32,9 +32,9 @@ class LanguageSettingsForm extends Form {
 		$this->settings = array(
 			'supportedLocales' => 'object',
 			'supportedSubmissionLocales' => 'object',
-      'supportedFormLocales' => 'object',
-      'localeDisplayTitle' => 'object',
-      'localeDisplayFile' => 'object'
+			'supportedFormLocales' => 'object',
+			'localeDisplayTitle' => 'object',
+			'localeDisplayFile' => 'object'
 		);
 
 		$site =& Request::getSite();
@@ -74,16 +74,16 @@ class LanguageSettingsForm extends Form {
 			if ($this->getData($name) == null || !is_array($this->getData($name))) {
 				$this->setData($name, array());
 			}
-    }
+		}
 
-    // Assign DEFAULT lang display modes:
-    if ($this->getData('localeDisplayTitle') == null) {
-      $this->setData('localeDisplayTitle', 'legacy');
-    }
+		// Assign DEFAULT lang display modes:
+		if ($this->getData('localeDisplayTitle') == null) {
+			$this->setData('localeDisplayTitle', 'legacy');
+		}
 
-    if ($this->getData('localeDisplayFile') == null) {
-      $this->setData('localeDisplayFile', 'legacy');
-    }
+		if ($this->getData('localeDisplayFile') == null) {
+			$this->setData('localeDisplayFile', 'legacy');
+		}
 
 	}
 
@@ -92,24 +92,24 @@ class LanguageSettingsForm extends Form {
 	 */
 	function readInputData() {
 		$vars = array_keys($this->settings);
-    $vars[] = 'primaryLocale';
-    $vars[] = 'localeDisplayTitle';
-    $vars[] = 'localeDisplayFile';
+		$vars[] = 'primaryLocale';
+		$vars[] = 'localeDisplayTitle';
+		$vars[] = 'localeDisplayFile';
 		$this->readUserVars($vars);
 
 		foreach (array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales') as $name) {
 			if ($this->getData($name) == null || !is_array($this->getData($name))) {
 				$this->setData($name, array());
 			}
-    }
+		}
 
-    // Assign DEFAULT lang display mode: (Why are we doing this twice? just in case initData fails?)
-    if ($this->getData('localeDisplayTitle') == null) {
-       $this->setData('localeDisplayTitle', 'legacy');
-    }
-    if ($this->getData('localeDisplayFile') == null) {
-       $this->setData('localeDisplayFile', 'legacy');
-    }
+		// Assign DEFAULT lang display mode: (Why are we doing this twice? just in case initData fails?)
+		if ($this->getData('localeDisplayTitle') == null) {
+			$this->setData('localeDisplayTitle', 'legacy');
+		}
+		if ($this->getData('localeDisplayFile') == null) {
+			$this->setData('localeDisplayFile', 'legacy');
+		}
 
 	}
 
@@ -144,10 +144,10 @@ class LanguageSettingsForm extends Form {
 		$this->setData('supportedSubmissionLocales', $supportedSubmissionLocales);
 		$this->setData('supportedFormLocales', $supportedFormLocales);
 
-    $localeDisplayTitle = $this->getData('localeDisplayTitle');
+		$localeDisplayTitle = $this->getData('localeDisplayTitle');
 		$this->setData('localeDisplayTitle', $localeDisplayTitle);
 
-    $localeDisplayFile = $this->getData('localeDisplayFile');
+		$localeDisplayFile = $this->getData('localeDisplayFile');
 		$this->setData('localeDisplayFile', $localeDisplayFile);
 
 		foreach ($this->_data as $name => $value) {

--- a/classes/manager/form/LanguageSettingsForm.inc.php
+++ b/classes/manager/form/LanguageSettingsForm.inc.php
@@ -32,7 +32,9 @@ class LanguageSettingsForm extends Form {
 		$this->settings = array(
 			'supportedLocales' => 'object',
 			'supportedSubmissionLocales' => 'object',
-			'supportedFormLocales' => 'object'
+      'supportedFormLocales' => 'object',
+      'localeDisplayTitle' => 'object',
+      'localeDisplayFile' => 'object'
 		);
 
 		$site =& Request::getSite();
@@ -72,7 +74,17 @@ class LanguageSettingsForm extends Form {
 			if ($this->getData($name) == null || !is_array($this->getData($name))) {
 				$this->setData($name, array());
 			}
-		}
+    }
+
+    // Assign DEFAULT lang display modes:
+    if ($this->getData('localeDisplayTitle') == null) {
+      $this->setData('localeDisplayTitle', 'legacy');
+    }
+
+    if ($this->getData('localeDisplayFile') == null) {
+      $this->setData('localeDisplayFile', 'legacy');
+    }
+
 	}
 
 	/**
@@ -80,14 +92,25 @@ class LanguageSettingsForm extends Form {
 	 */
 	function readInputData() {
 		$vars = array_keys($this->settings);
-		$vars[] = 'primaryLocale';
+    $vars[] = 'primaryLocale';
+    $vars[] = 'localeDisplayTitle';
+    $vars[] = 'localeDisplayFile';
 		$this->readUserVars($vars);
 
 		foreach (array('supportedFormLocales', 'supportedSubmissionLocales', 'supportedLocales') as $name) {
 			if ($this->getData($name) == null || !is_array($this->getData($name))) {
 				$this->setData($name, array());
 			}
-		}
+    }
+
+    // Assign DEFAULT lang display mode: (Why are we doing this twice? just in case initData fails?)
+    if ($this->getData('localeDisplayTitle') == null) {
+       $this->setData('localeDisplayTitle', 'legacy');
+    }
+    if ($this->getData('localeDisplayFile') == null) {
+       $this->setData('localeDisplayFile', 'legacy');
+    }
+
 	}
 
 	/**
@@ -120,6 +143,12 @@ class LanguageSettingsForm extends Form {
 		$this->setData('supportedLocales', $supportedLocales);
 		$this->setData('supportedSubmissionLocales', $supportedSubmissionLocales);
 		$this->setData('supportedFormLocales', $supportedFormLocales);
+
+    $localeDisplayTitle = $this->getData('localeDisplayTitle');
+		$this->setData('localeDisplayTitle', $localeDisplayTitle);
+
+    $localeDisplayFile = $this->getData('localeDisplayFile');
+		$this->setData('localeDisplayFile', $localeDisplayFile);
 
 		foreach ($this->_data as $name => $value) {
 			if (!in_array($name, array_keys($this->settings))) continue;

--- a/classes/submission/form/MetadataForm.inc.php
+++ b/classes/submission/form/MetadataForm.inc.php
@@ -337,7 +337,7 @@ class MetadataForm extends Form {
 		$section =& $sectionDao->getSection($article->getSectionId());
 		$article->setAbstract($this->getData('abstract'), null); // Localized
 
-    $article->setLocale($this->getData('submissionLocale'), null);
+		$article->setLocale($this->getData('submissionLocale'), null);
 
 		import('classes.file.PublicFileManager');
 		$publicFileManager = new PublicFileManager();

--- a/classes/submission/form/MetadataForm.inc.php
+++ b/classes/submission/form/MetadataForm.inc.php
@@ -124,6 +124,7 @@ class MetadataForm extends Form {
 				'authors' => array(),
 				'title' => $article->getTitle(null), // Localized
 				'abstract' => $article->getAbstract(null), // Localized
+				'submissionLocale' => $article->getLocale(null),
 				'coverPageAltText' => $article->getCoverPageAltText(null), // Localized
 				'showCoverPage' => $article->getShowCoverPage(null), // Localized
 				'hideCoverPageToc' => $article->getHideCoverPageToc(null), // Localized
@@ -249,6 +250,7 @@ class MetadataForm extends Form {
 				'primaryContact',
 				'title',
 				'abstract',
+				'submissionLocale',
 				'coverPageAltText',
 				'showCoverPage',
 				'hideCoverPageToc',
@@ -334,6 +336,8 @@ class MetadataForm extends Form {
 
 		$section =& $sectionDao->getSection($article->getSectionId());
 		$article->setAbstract($this->getData('abstract'), null); // Localized
+
+    $article->setLocale($this->getData('submissionLocale'), null);
 
 		import('classes.file.PublicFileManager');
 		$publicFileManager = new PublicFileManager();

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -33,6 +33,15 @@
 	<message key="manager.languages.languageInstructions"><![CDATA[OJS can be made available to users in any of several supported languages. As well, OJS can operate as a multilingual system, providing users with an ability to toggle between languages on each page, and allowing certain data to be entered in several additional languages.<br /><br/>If a language supported by OJS is not listed below, ask your site administrator to install the language from the site administration interface. For instructions on adding support for new languages, please consult the OJS documentation.]]></message>
 	<message key="manager.languages.noneAvailable">Sorry, no additional languages are available. Contact your site administrator if you wish to use additional languages with this journal.</message>
 	<message key="manager.languages.primaryLocaleInstructions">This will be the default language for the journal site.</message>
+  <message key="manager.languages.locale.display.intro">In this section you can modify how OJS will display the titles and galleys in TOC when they are availiable in multiple languages. If you have doubts or your journal is publishing in a single language, probably "legacy" option is the good one for you.</message>
+  <message key="manager.languages.locale.display.title">Display of titles:</message>
+  <message key="manager.languages.locale.display.title.original">Original: Show the title in the original language.</message>
+  <message key="manager.languages.locale.display.title.both">Both: Show the title in the user's current language (if availiable) AND also in the original language.</message>
+  <message key="manager.languages.locale.display.title.legacy">Legacy: Show the title in the user's current language (if avaliable) OR the original language. This option is enabled by default.</message>
+  <message key="manager.languages.locale.display.file">Display of galleys:</message>
+  <message key="manager.languages.locale.display.file.show">Show language: Links to files will include the language's tag (e.g. "PDF (English), HTML (Klingon)").</message>
+  <message key="manager.languages.locale.display.file.hide">Hide language: Links to files won't include the language's tag (e.g. "PDF, HTML").</message>
+  <message key="manager.languages.locale.display.file.legacy">Legacy: Links to files will include the language's tag except if it's the current user's language. (e.j: "PDF, HTML (Klingon)"). This option is enabled by default.</message>
 	<message key="manager.managementPages">Management Pages</message>
 	<message key="manager.payment.action">Action</message>
 	<message key="manager.payment.addPayment">Add Payment</message>

--- a/templates/issue/issue.tpl
+++ b/templates/issue/issue.tpl
@@ -50,9 +50,9 @@
 	<td class="tocArticleTitleAuthors{if $showCoverPage} showCoverImage{/if}">
 		<div class="tocTitle">
 			{if !$hasAccess || $hasAbstract}
-				<a href="{url page="article" op="view" path=$articlePath}">{$article->getLocalizedTitle()|strip_unsafe_html}</a>
+				<a href="{url page="article" op="view" path=$articlePath}">{$article->getLocalizedTitle($currentLocale)|strip_unsafe_html}</a>
 			{else}
-				{$article->getLocalizedTitle()|strip_unsafe_html}
+				{$article->getLocalizedTitle($currentLocale)|strip_unsafe_html}
 			{/if}
 		</div>
 		<div class="tocAuthors">

--- a/templates/manager/languageSettings.tpl
+++ b/templates/manager/languageSettings.tpl
@@ -60,6 +60,30 @@
 </tr>
 </table>
 
+<br />
+<br />
+<table id="languageDisplay" class="data" width="100%">
+<tr valign="top">
+  <td colspan="2" class="value"><span class="instruct">{translate key="manager.languages.locale.display.intro"}</span></td>
+</tr>
+<tr valign="top">
+  <td width="20%" class="label">{fieldLabel name="localeDisplayTitle" required="true" key="manager.languages.locale.display.title"}</td>
+  <td width="80%" class="value">
+      <input type="radio" name="localeDisplayTitle" value="original"{if ($localeDisplayTitle == 'original')} checked="checked"{/if}/>{translate key="manager.languages.locale.display.title.original"}<br />
+      <input type="radio" name="localeDisplayTitle" value="both"{if ($localeDisplayTitle == 'both')} checked="checked"{/if}/>{translate key="manager.languages.locale.display.title.both"}<br />
+      <input type="radio" name="localeDisplayTitle" value="legacy"{if ($localeDisplayTitle == 'legacy')} checked="checked"{/if}/>{translate key="manager.languages.locale.display.title.legacy"}<br />
+  </td>
+</tr>
+<tr valign="top">
+  <td width="20%" class="label">{fieldLabel name="localeDisplayFile" required="true" key="manager.languages.locale.display.file"}</td>
+  <td width="80%" class="value">
+      <input type="radio" name="localeDisplayFile" value="show"{if ($localeDisplayFile == 'show')} checked="checked"{/if}/>{translate key="manager.languages.locale.display.file.show"}<br />
+      <input type="radio" name="localeDisplayFile" value="hide"{if ($localeDisplayFile == 'hide')} checked="checked"{/if}/>{translate key="manager.languages.locale.display.file.hide"}<br />
+      <input type="radio" name="localeDisplayFile" value="legacy"{if ($localeDisplayFile == 'legacy')} checked="checked"{/if}/>{translate key="manager.languages.locale.display.file.legacy"}<br />
+  </td>
+</tr>
+</table>
+
 <p><input type="submit" value="{translate key="common.save"}" class="button defaultButton" /> <input type="button" value="{translate key="common.cancel"}" class="button" onclick="document.location.href='{url page="manager"}'" /></p>
 
 <p><span class="formRequired">{translate key="common.requiredField"}</span></p>

--- a/templates/submission/metadata/metadataEdit.tpl
+++ b/templates/submission/metadata/metadataEdit.tpl
@@ -229,6 +229,14 @@ function moveAuthor(dir, authorIndex) {
 		<td class="label">{if $section->getAbstractsNotRequired()==0}{fieldLabel name="abstract" required="true" key="article.abstract"}{else}{fieldLabel name="abstract" key="article.abstract"}{/if}</td>
 		<td class="value"><textarea name="abstract[{$formLocale|escape}]" id="abstract" rows="15" cols="60" class="textArea">{$abstract[$formLocale]|escape}</textarea></td>
 	</tr>
+  <tr>
+    <td width="20%" class="label">{fieldLabel name="submissionLocale" required="true" key="author.submit.submissionLocale"}</td>
+    <td width="80%" class="value">
+    <select name="submissionLocale" id="submissionLocale" size="1" class="selectMenu">
+        {html_options options=$formLocales selected=$submissionLocale}
+    </select>
+    </td>
+  </tr>
 </table>
 </div>
 
@@ -488,4 +496,3 @@ function moveAuthor(dir, authorIndex) {
 </form>
 
 {include file="common/footer.tpl"}
-


### PR DESCRIPTION
A very few modifications in core to get more control about how language is shown in TOC in multilang journals.
The aim of the modifications was commented here:
http://pkp.sfu.ca/support/forum/viewtopic.php?f=9&t=13021&p=49967
The new feature also requires modifications submitted to "lib-pkp" submodule.

A deep review of the code (and specially of the literals in locale/en_US/manager.xml) is encouraged.
