### PR TITLE
Added a few fields on user XML's sample

### DIFF
--- a/plugins/importexport/users/sample.xml
+++ b/plugins/importexport/users/sample.xml
@@ -35,9 +35,9 @@
 		<first_name>TestUser2FirstName</first_name>
 		<midle_name>TestUser2MidletName</midle_name>
 		<last_name>TestUser2LastName</last_name>
+		<gender>M</gender>
 		<initials>TES</initials>
         	<url>http://www.testuser2.com</url>
-		<gender>M</gender>
 		<affiliation>TestUser2Affiliation</affiliation>
 		<phone>4242424242</phone>
         	<mailing_address>42 St.</mailing_address>


### PR DESCRIPTION
When I had to make a importation of users I didn't found a few fields in the sample provided by OJS, thus having to manually create one user with all fields and exporting it to see how the xml was formed.
