### PR TITLE
Check that the PHP zip extension is installed.

### DIFF
--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -110,7 +110,7 @@ class DepositPackage {
 		
 		$url = $journal->getUrl() . '/' . PLN_PLUGIN_ARCHIVE_FOLDER . '/deposits/' . $this->_deposit->getUUID();
 		$pkpDetails = $atom->createElementNS('http://pkp.sfu.ca/SWORD', 'pkp:content', $url);
-		$pkpDetails->setAttribute('size', ceil(filesize($packageFile)/1024));
+		$pkpDetails->setAttribute('size', ceil(filesize($packageFile)/1000));
 		
 		$objectVolume = "";
 		$objectIssue = "";

--- a/plugins/generic/pln/classes/tasks/Depositor.inc.php
+++ b/plugins/generic/pln/classes/tasks/Depositor.inc.php
@@ -73,7 +73,7 @@ class Depositor extends ScheduledTask {
 			}
 			
 			// check to make sure zip is installed
-			if (!$this->_plugin->curlInstalled()) {
+			if (!$this->_plugin->zipInstalled()) {
 				$this->addExecutionLogEntry(__('plugins.generic.pln.notifications.zip_missing'), SCHEDULED_TASK_MESSAGE_TYPE_WARNING);
 				$this->_plugin->createJournalManagerNotification($journal->getId(),PLN_PLUGIN_NOTIFICATION_TYPE_ZIP_MISSING);
 				continue;


### PR DESCRIPTION
Call the zipInstalled() method when checking if the zip extension is installed.

Fixes #266.