### PR TITLE
Check that the zip extension is installed in PHP.

### DIFF
--- a/plugins/generic/pln/classes/tasks/Depositor.inc.php
+++ b/plugins/generic/pln/classes/tasks/Depositor.inc.php
@@ -73,7 +73,7 @@ class Depositor extends ScheduledTask {
 			}
 			
 			// check to make sure zip is installed
-			if (!$this->_plugin->curlInstalled()) {
+			if (!$this->_plugin->zipInstalled()) {
 				$this->addExecutionLogEntry(__('plugins.generic.pln.notifications.zip_missing'), SCHEDULED_TASK_MESSAGE_TYPE_WARNING);
 				$this->_plugin->createJournalManagerNotification($journal->getId(),PLN_PLUGIN_NOTIFICATION_TYPE_ZIP_MISSING);
 				continue;


### PR DESCRIPTION
Make PLN plugin checks for the curl and zip extensions, rather than checking for the curl extension twice.

Fixes pkp/pkp-lib#266
