### PR TITLE
Check for Archive_Tar

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -55,6 +55,7 @@ define('PLN_PLUGIN_NOTIFICATION_TYPE_ISSN_MISSING',		PLN_PLUGIN_NOTIFICATION_TYP
 define('PLN_PLUGIN_NOTIFICATION_TYPE_HTTP_ERROR',		PLN_PLUGIN_NOTIFICATION_TYPE_PLUGIN_BASE + 0x0000003);
 define('PLN_PLUGIN_NOTIFICATION_TYPE_CURL_MISSING',		PLN_PLUGIN_NOTIFICATION_TYPE_PLUGIN_BASE + 0x0000004);
 define('PLN_PLUGIN_NOTIFICATION_TYPE_ZIP_MISSING',		PLN_PLUGIN_NOTIFICATION_TYPE_PLUGIN_BASE + 0x0000005);
+define('PLN_PLUGIN_NOTIFICATION_TYPE_TAR_MISSING',		PLN_PLUGIN_NOTIFICATION_TYPE_PLUGIN_BASE + 0x0000006);
 
 class PLNPlugin extends GenericPlugin {
 
@@ -528,6 +529,14 @@ class PLNPlugin extends GenericPlugin {
 	function zipInstalled() {
 		return class_exists('ZipArchive');
 	}
+        
+        /**
+         * Check if the Archive_Tar extension is installed and available. BagIt
+         * requires it, and will not function without it.
+         */
+        function tarInstalled() {
+                return class_exists('Archive_Tar');
+        }
 	
 	/**
 	 * Get resource using CURL

--- a/plugins/generic/pln/classes/tasks/Depositor.inc.php
+++ b/plugins/generic/pln/classes/tasks/Depositor.inc.php
@@ -79,6 +79,12 @@ class Depositor extends ScheduledTask {
 				continue;
 			}
 			
+                        if(!$this->_plugin->tarInstalled()) {
+				$this->addExecutionLogEntry(__('plugins.generic.pln.notifications.tar_missing'), SCHEDULED_TASK_MESSAGE_TYPE_WARNING);
+				$this->_plugin->createJournalManagerNotification($journal->getId(),PLN_PLUGIN_NOTIFICATION_TYPE_TAR_MISSING);
+				continue;
+                        }
+                        
 			// get the sword service document
 			$sdResult = $this->_plugin->getServiceDocument($journal->getId());
 			


### PR DESCRIPTION
Check for the presence of the Archive_Tar extension, included with PECL.... the BagIt library requires it, but does not check for its presence.

Fixes bugzilla 8976.