### PR TITLE
Report upload sizes in 1000 byte units

### DIFF
--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -110,7 +110,7 @@ class DepositPackage {
 		
 		$url = $journal->getUrl() . '/' . PLN_PLUGIN_ARCHIVE_FOLDER . '/deposits/' . $this->_deposit->getUUID();
 		$pkpDetails = $atom->createElementNS('http://pkp.sfu.ca/SWORD', 'pkp:content', $url);
-		$pkpDetails->setAttribute('size', ceil(filesize($packageFile)/1024));
+		$pkpDetails->setAttribute('size', ceil(filesize($packageFile)/1000));
 		
 		$objectVolume = "";
 		$objectIssue = "";


### PR DESCRIPTION
Report upload file sizes in 1000 byte units (kB) instead of 1024 byte units (KB), as that's what SWORD expects.

Fixes pkp/pkp-lib#268