### PR TITLE
*9016* PLN plugin now checks for null settings and applies defaults.

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -19,7 +19,7 @@ import('classes.issue.Issue');
 
 define('PLN_PLUGIN_NAME','plnplugin');
 
-define('PLN_PLUGIN_NETWORK', 'pkp-pln.lib.sfu.ca');
+define('PLN_PLUGIN_NETWORK', 'http://pkp-pln.lib.sfu.ca');
 
 define('PLN_PLUGIN_HTTP_STATUS_OK', 200);
 define('PLN_PLUGIN_HTTP_STATUS_CREATED', 201);
@@ -169,11 +169,10 @@ class PLNPlugin extends GenericPlugin {
 	
 	/**
 	 * @see PKPPlugin::getSetting()
-	 * @param $journalId string
+	 * @param $journalId int
 	 * @param $settingName string
 	 */
 	function getSetting($journalId,$settingName) {
-                        
 		// if there isn't a journal_uuid, make one
 		if ($settingName == 'journal_uuid') {
 			$uuid = parent::getSetting($journalId, $settingName);

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -177,7 +177,7 @@ class PLNPlugin extends GenericPlugin {
 		// if there isn't a journal_uuid, make one
 		if ($settingName == 'journal_uuid') {
 			$uuid = parent::getSetting($journalId, $settingName);
-			if ($uuid) return $uuid;
+			if (!is_null($uuid) && $uuid != '') return $uuid;
 			$this->updateSetting($journalId, $settingName, $this->newUUID());
 		}
 		

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -433,7 +433,7 @@ class PLNPlugin extends GenericPlugin {
 		
 		// retrieve the service document
 		$result = $this->_curlGet(
-			'http://' . PLN_PLUGIN_NETWORK . PLN_PLUGIN_SD_IRI,
+			PLN_PLUGIN_NETWORK . PLN_PLUGIN_SD_IRI,
 			array(
 				'On-Behalf-Of: '.$this->getSetting($journalId, 'journal_uuid'),
 				'Journal-URL: '.$journal->getUrl()

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -19,9 +19,7 @@ import('classes.issue.Issue');
 
 define('PLN_PLUGIN_NAME','plnplugin');
 
-define('PLN_PLUGIN_NETWORKS', serialize(array(
-	'PKP' => 'pkp-pln.lib.sfu.ca'
-)));
+define('PLN_PLUGIN_NETWORK', 'pkp-pln.lib.sfu.ca');
 
 define('PLN_PLUGIN_HTTP_STATUS_OK', 200);
 define('PLN_PLUGIN_HTTP_STATUS_CREATED', 201);
@@ -448,13 +446,12 @@ class PLNPlugin extends GenericPlugin {
 	 */
 	function getServiceDocument($journalId) {
 			
-		$plnNetworks = unserialize(PLN_PLUGIN_NETWORKS);
 		$journalDao =& DAORegistry::getDAO('JournalDAO');
 		$journal =& $journalDao->getById($journalId);
 		
 		// retrieve the service document
 		$result = $this->_curlGet(
-			'http://' . $plnNetworks[$this->getSetting($journalId, 'pln_network')] . PLN_PLUGIN_SD_IRI,
+			'http://' . PLN_PLUGIN_NETWORK . PLN_PLUGIN_SD_IRI,
 			array(
 				'On-Behalf-Of: '.$this->getSetting($journalId, 'journal_uuid'),
 				'Journal-URL: '.$journal->getUrl()

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -173,29 +173,12 @@ class PLNPlugin extends GenericPlugin {
 	 * @param $settingName string
 	 */
 	function getSetting($journalId,$settingName) {
-                $settingValue = parent::getSetting($journalId, $settingName);
-		if ($settingValue != null) return $settingValue;
                         
-		// if a setting returns null, populate it with a default
-		switch ($settingName) {
-			case 'journal_uuid':
-				$this->updateSetting($journalId, $settingName, $this->newUUID(), 'string');
-				break;
-			case 'checksum_type':
-				$this->updateSetting($journalId, $settingName, 'SHA-1', 'string');
-				break;
-			case 'object_type':
-				$this->updateSetting($journalId, $settingName, 'Issue', 'string');
-				break;
-			case 'object_threshold':
-				$this->updateSetting($journalId, $settingName, 20, 'int');
-				break;
-			case 'pln_network':
-				$this->updateSetting($journalId, $settingName, 'PKP', 'string');
-				break;
-			case 'pln_accepting':
-				$this->updateSetting($journalId, $settingName, false, 'bool');
-				break;
+		// if there isn't a journal_uuid, make one
+		if ($settingName == 'journal_uuid') {
+			$uuid = parent::getSetting($journalId, $settingName);
+			if ($uuid) return $uuid;
+			$this->updateSetting($journalId, $settingName, $this->newUUID());
 		}
 		
 		return parent::getSetting($journalId,$settingName);

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -175,12 +175,29 @@ class PLNPlugin extends GenericPlugin {
 	 * @param $settingName string
 	 */
 	function getSetting($journalId,$settingName) {
-
-		// if there isn't a journal_uuid, make one
-		if ($settingName == 'journal_uuid') {
-			$uuid = parent::getSetting($journalId, $settingName);
-			if ($uuid) return $uuid;
-			$this->updateSetting($journalId, $settingName, $this->newUUID());
+                $settingValue = parent::getSetting($journalId, $settingName);
+		if ($settingValue != null) return $settingValue;
+                        
+		// if a setting returns null, populate it with a default
+		switch ($settingName) {
+			case 'journal_uuid':
+				$this->updateSetting($journalId, $settingName, $this->newUUID(), 'string');
+				break;
+			case 'checksum_type':
+				$this->updateSetting($journalId, $settingName, 'SHA-1', 'string');
+				break;
+			case 'object_type':
+				$this->updateSetting($journalId, $settingName, 'Issue', 'string');
+				break;
+			case 'object_threshold':
+				$this->updateSetting($journalId, $settingName, 20, 'int');
+				break;
+			case 'pln_network':
+				$this->updateSetting($journalId, $settingName, 'PKP', 'string');
+				break;
+			case 'pln_accepting':
+				$this->updateSetting($journalId, $settingName, false, 'bool');
+				break;
 		}
 		
 		return parent::getSetting($journalId,$settingName);

--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -272,7 +272,7 @@ class DepositPackage {
 		$plnDir = $fileManager->filesDir . PLN_PLUGIN_ARCHIVE_FOLDER;
 		
 		// post the atom document
-		$url = 'http://' . PLN_PLUGIN_NETWORK;
+		$url = PLN_PLUGIN_NETWORK;
 		if ($this->_deposit->getUpdateStatus()) {
 			$url .= PLN_PLUGIN_CONT_IRI . '/' . $plnPlugin->getSetting($this->_deposit->getJournalID(), 'journal_uuid');
 			$url .= '/' . $this->_deposit->getUUID() . '/edit';
@@ -350,7 +350,7 @@ class DepositPackage {
 		$depositDao =& DAORegistry::getDAO('DepositDAO');
 		$plnPlugin =& PluginRegistry::getPlugin('generic','plnplugin');
 		
-		$url = 'http://' . PLN_PLUGIN_NETWORK . PLN_PLUGIN_CONT_IRI;
+		$url = PLN_PLUGIN_NETWORK . PLN_PLUGIN_CONT_IRI;
 		$url .= '/' . $plnPlugin->getSetting($this->_deposit->getJournalID(), 'journal_uuid');
 		$url .= '/' . $this->_deposit->getUUID() . '/state';
 		

--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -268,12 +268,11 @@ class DepositPackage {
 		$depositDao =& DAORegistry::getDAO('DepositDAO');
 		$journalDao =& DAORegistry::getDAO('JournalDAO');
 		$plnPlugin =& PluginRegistry::getPlugin('generic',PLN_PLUGIN_NAME);
-		$plnNetworks = unserialize(PLN_PLUGIN_NETWORKS);
 		$fileManager = new JournalFileManager($journalDao->getById($this->_deposit->getJournalId()));
 		$plnDir = $fileManager->filesDir . PLN_PLUGIN_ARCHIVE_FOLDER;
 		
 		// post the atom document
-		$url = 'http://' . $plnNetworks[$plnPlugin->getSetting($this->_deposit->getJournalID(), 'pln_network')];
+		$url = 'http://' . PLN_PLUGIN_NETWORK;
 		if ($this->_deposit->getUpdateStatus()) {
 			$url .= PLN_PLUGIN_CONT_IRI . '/' . $plnPlugin->getSetting($this->_deposit->getJournalID(), 'journal_uuid');
 			$url .= '/' . $this->_deposit->getUUID() . '/edit';
@@ -350,9 +349,8 @@ class DepositPackage {
 			
 		$depositDao =& DAORegistry::getDAO('DepositDAO');
 		$plnPlugin =& PluginRegistry::getPlugin('generic','plnplugin');
-		$plnNetworks = unserialize(PLN_PLUGIN_NETWORKS);
 		
-		$url = 'http://' . $plnNetworks[$plnPlugin->getSetting($this->_deposit->getJournalID(), 'pln_network')] . PLN_PLUGIN_CONT_IRI;
+		$url = 'http://' . PLN_PLUGIN_NETWORK . PLN_PLUGIN_CONT_IRI;
 		$url .= '/' . $plnPlugin->getSetting($this->_deposit->getJournalID(), 'journal_uuid');
 		$url .= '/' . $this->_deposit->getUUID() . '/state';
 		

--- a/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
@@ -84,6 +84,9 @@ class PLNSettingsForm extends Form {
 	 */
 	function execute() { 
 		$this->_plugin->updateSetting($this->_journalId, 'terms_of_use_agreement', serialize($this->getData('terms_of_use_agreement')), 'object');
+                $journalDao =& DAORegistry::getDAO('JournalDAO');
+                $journal = $journalDao->getById($this->_journalId);
+                $this->_plugin->installContextSpecificSettings(null, array(null, $journal));
 	}
 	
 }

--- a/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
@@ -84,9 +84,8 @@ class PLNSettingsForm extends Form {
 	 */
 	function execute() { 
 		$this->_plugin->updateSetting($this->_journalId, 'terms_of_use_agreement', serialize($this->getData('terms_of_use_agreement')), 'object');
-                $journalDao =& DAORegistry::getDAO('JournalDAO');
-                $journal = $journalDao->getById($this->_journalId);
-                $this->_plugin->installContextSpecificSettings(null, array(null, $journal));
+		$pluginSettingsDao =& DAORegistry::getDAO('PluginSettingsDAO');
+		$pluginSettingsDao->installSettings($this->_journalId, $this->_plugin->getName(), $this->_plugin->getContextSpecificPluginSettingsFile());
 	}
 	
 }

--- a/plugins/generic/pln/classes/form/PLNStatusForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNStatusForm.inc.php
@@ -50,9 +50,9 @@ class PLNStatusForm extends Form {
 		
 		if (!$networkStatusMessage) {
 			if ($networkStatus === true) {
-				$networkStatusMessage = __("plugins.generic.pln.notifications.pln_accepting");
+				$networkStatusMessage = __('plugins.generic.pln.notifications.pln_accepting');
 			} else {
-				$networkStatusMessage = __("plugins.generic.pln.notifications.pln_not_accepting");
+				$networkStatusMessage = __('plugins.generic.pln.notifications.pln_not_accepting');
 			}
 		}
 		$templateMgr =& TemplateManager::getManager();

--- a/plugins/generic/pln/classes/form/PLNStatusForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNStatusForm.inc.php
@@ -50,9 +50,9 @@ class PLNStatusForm extends Form {
 		
 		if (!$networkStatusMessage) {
 			if ($networkStatus === true) {
-				$networkStatusMessage = __(PLN_PLUGIN_NOTIFICATION_PLN_ACCEPTING);
+				$networkStatusMessage = __("plugins.generic.pln.notifications.pln_accepting");
 			} else {
-				$networkStatusMessage = __(PLN_PLUGIN_NOTIFICATION_PLN_NOT_ACCEPTING);
+				$networkStatusMessage = __("plugins.generic.pln.notifications.pln_not_accepting");
 			}
 		}
 		$templateMgr =& TemplateManager::getManager();

--- a/plugins/generic/pln/locale/de_DE/locale.xml
+++ b/plugins/generic/pln/locale/de_DE/locale.xml
@@ -27,7 +27,6 @@
 	<message key="plugins.generic.pln.settings.refresh">Aktualisieren</message>
 	<message key="plugins.generic.pln.settings.refresh_help">Wenn aus irgendeinem Grund keine Einträge oben gelistet sind oder wenn Sie wissen, dass die Einträge aktualisiert worden sind, klicken Sie Aktualisieren um die Liste zu erneuern.</message>
 	
-	<message key="plugins.generic.pln.required.pln_network">Bitte wählen Sie ein PLN-Netzwerk.</message>
 	<message key="plugins.generic.pln.required.object_type">Bitte wählen Sie einen Typ für die Objektablieferung.</message>
 	<message key="plugins.generic.pln.required.object_threshold">Bitte wählen Sie eine Schwelle für die Objektablieferung.</message>
 	<message key="plugins.generic.pln.required.terms_of_use_agreement">Die Zustimmung zu den Nutzungsbedingungen des Netzwerks ist erforderlich, um bei dem PLN abzuliefern.</message>

--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -27,7 +27,6 @@
 	<message key="plugins.generic.pln.settings.refresh">Refresh</message>
 	<message key="plugins.generic.pln.settings.refresh_help">If for some reason there are no terms listed above or you know these terms have been updated, click Refresh to update the terms listed above.</message>
 	
-	<message key="plugins.generic.pln.required.pln_network">Please choose a PLN network.</message>
 	<message key="plugins.generic.pln.required.object_type">Please choose an deposit object type.</message>
 	<message key="plugins.generic.pln.required.object_threshold">Please choose a deposit object threshold.</message>
 	<message key="plugins.generic.pln.required.terms_of_use_agreement">Agreement to the network's terms of use is required in order to deposit to the PLN.</message>

--- a/plugins/generic/pln/locale/ru_RU/locale.xml
+++ b/plugins/generic/pln/locale/ru_RU/locale.xml
@@ -28,7 +28,6 @@
 	<message key="plugins.generic.pln.settings.refresh">Обновить</message>
 	<message key="plugins.generic.pln.settings.refresh_help">Если по какой-либо причине выше не показаны условия использования или вы знаете, что эти условия были изменены, щелкните на кнопке «Обновить» для обновления списка условий выше.</message>
 	
-	<message key="plugins.generic.pln.required.pln_network">Пожалуйста, выберите сеть PLN.</message>
 	<message key="plugins.generic.pln.required.object_type">Пожалуйста, выберите тип депонируемого объекта.</message>
 	<message key="plugins.generic.pln.required.object_threshold">Пожалуйста, выберите порог депонируемых объектов.</message>
 	<message key="plugins.generic.pln.required.terms_of_use_agreement">Принятие условий использования сети является обязательным для депонирования в PLN.</message>

--- a/plugins/generic/pln/xml/settings.xml
+++ b/plugins/generic/pln/xml/settings.xml
@@ -38,11 +38,6 @@
 		<name>object_threshold</name>
 		<value>20</value>
 	</setting>
-	<!-- chosen staging server -->
-	<setting type="string">
-		<name>pln_network</name>
-		<value>PKP</value>
-	</setting>
 	<!-- is the PLN accepting deposits -->
 	<setting type="bool">
 		<name>pln_accepting</name>


### PR DESCRIPTION
*9016* PLN plugin fix update - Settings are not created for plugins during an upgrade installation. This work around supplies defaults for any setting that isn't found. 

(cherry picked from commit 5700ede93bf52baa79d554c14b2db966e7fad865)
(cherry picked from commit 9c59d866df64be8041e9b473f9cba73bb5b2a088)

Fixes bugzilla 9016.