### PR TITLE
pkp/pkp-lib#280 When deleting a CustomBlock the entries still remain in ...

### DIFF
--- a/plugins/generic/customBlockManager/SettingsForm.inc.php
+++ b/plugins/generic/customBlockManager/SettingsForm.inc.php
@@ -79,10 +79,10 @@ class SettingsForm extends Form {
 
 		$deletedBlocks = explode(':',$this->getData('deletedBlocks'));
 		foreach ($deletedBlocks as $deletedBlock) {
-			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock.'CustomBlockPlugin', 'enabled');
-			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock.'CustomBlockPlugin', 'seq');
-			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock.'CustomBlockPlugin', 'context');
-			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock.'CustomBlockPlugin', 'blockContent');
+			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock, 'enabled');
+			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock, 'seq');
+			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock, 'context');
+			$pluginSettingsDao->deleteSetting($journalId, $deletedBlock, 'blockContent');
 		}
 
 		//sort the blocks in alphabetical order


### PR DESCRIPTION
...the database. This has been fixed.