### PR TITLE
pkp/pkp-lib#282 Dataverse plugin: remove markup from dataset metadata

### DIFF
--- a/plugins/generic/dataverse/DataversePlugin.inc.php
+++ b/plugins/generic/dataverse/DataversePlugin.inc.php
@@ -1225,13 +1225,17 @@ class DataversePlugin extends GenericPlugin {
 			if(!array_key_exists('holdingsURI', $pubIdAttributes)) {
 				$pubIdAttributes['holdingsURI'] = Request::url($journal->getPath(), 'article', 'view', array($article->getId()));
 			}
+			// Add copyright notice. 
+			if ($article->getCopyrightYear() && $article->getCopyrightHolder($article->getLocale())) {
+				AppLocale::requireComponents(LOCALE_COMPONENT_APPLICATION_COMMON);
+				$package->addMetadata('rights',	__('submission.copyrightStatement', array('copyrightYear' => $article->getCopyrightYear(), 'copyrightHolder' => $article->getCopyrightHolder($article->getLocale()))));
+			}
 		}
 
 		// Journal metadata
 		$package->addMetadata('publisher', $journal->getSetting('publisherInstitution'));
-		$package->addMetadata('rights', String::html2text($journal->getLocalizedSetting('copyrightNotice', $journal->getPrimaryLocale())));
 		$package->addMetadata('isReferencedBy', String::html2text($this->getCitation($article)), $pubIdAttributes);
-		
+
 		// Suppfile metadata
 		$suppFileDao =& DAORegistry::getDAO('SuppFileDAO');				
 		$dvFileDao =& DAORegistry::getDAO('DataverseFileDAO');

--- a/plugins/generic/dataverse/DataversePlugin.inc.php
+++ b/plugins/generic/dataverse/DataversePlugin.inc.php
@@ -1171,7 +1171,7 @@ class DataversePlugin extends GenericPlugin {
 		$package->addMetadata('description', 
 						$article->getLocalizedData('studyDescription') ? 
 						$article->getLocalizedData('studyDescription') :
-						$article->getLocalizedAbstract()
+						String::html2text($article->getLocalizedAbstract())
 		);
 		foreach ($article->getAuthors() as $author) {
 			$package->addMetadata('creator', $author->getFullName(true), array('affiliation' => $this->_formatAffiliation($author)));
@@ -1228,8 +1228,8 @@ class DataversePlugin extends GenericPlugin {
 
 		// Journal metadata
 		$package->addMetadata('publisher', $journal->getSetting('publisherInstitution'));
-		$package->addMetadata('rights', $journal->getLocalizedSetting('copyrightNotice'));
-		$package->addMetadata('isReferencedBy', $this->getCitation($article), $pubIdAttributes);
+		$package->addMetadata('rights', String::html2text($journal->getLocalizedSetting('copyrightNotice')));
+		$package->addMetadata('isReferencedBy', String::html2text($this->getCitation($article)), $pubIdAttributes);
 		
 		// Suppfile metadata
 		$suppFileDao =& DAORegistry::getDAO('SuppFileDAO');				


### PR DESCRIPTION
Some markup accepted in dataset metadata in Dataverse 3, but not in 4. 