### PR TITLE
Update block.tpl

### DIFF
--- a/plugins/blocks/keywordCloud/block.tpl
+++ b/plugins/blocks/keywordCloud/block.tpl
@@ -11,6 +11,6 @@
 <div class="block" id="sidebarKeywordCloud">
 	<span class="blockTitle">{translate key="plugins.block.keywordCloud.title"}</span>
 	{foreach name=cloud from=$cloudKeywords key=keyword item=count}
-		<a href="{url page="search" subject=$keyword}"><span style="font-size: {math equation="((x-1) / y * 100)+75" x=$count y=$maxOccurs}%;">{$keyword}</span></a>
+		<a href="{url page="search" subject=$keyword}"><span style="font-size: {math equation="round(((x-1) / y * 100)+75)" x=$count y=$maxOccurs}%;">{$keyword}</span></a>
 	{/foreach}
 </div>


### PR DESCRIPTION
If you have OJS in spanish and english (for example), this is that happens at render the keyword cloud:

If i switch English i see ok the keyword cloud, because the component writes:
.....         font-size: 183.88888888889%;           ............

In Spanish the result is not css compatible, because the number in font-size has a comma:
.........      font-size: 183,88888888889%;       ...........

So i have rounded the real number to integer to have no comma nor point problem:
font-size: 183%;

Now you can see the keyword cloud without problem in english, spanish and other languages.
