### PR TITLE
Move UUID generation function from PLN plugin to PKP Library (String).  ##ulsdevteam/add-uuid-string-creation##

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -658,16 +658,7 @@ class PLNPlugin extends GenericPlugin {
 	 * @return string
 	 */
 	function newUUID() {
-		
-		mt_srand((double)microtime()*10000);
-		$charid = strtoupper(md5(uniqid(rand(), true)));
-		$hyphen = '-';
-		$uuid = substr($charid, 0, 8).$hyphen
-				.substr($charid, 8, 4).$hyphen
-				.substr($charid,12, 4).$hyphen
-				.substr($charid,16, 4).$hyphen
-				.substr($charid,20,12);
-		return $uuid;
+		return String::generateUUID();
 	}
 	
 


### PR DESCRIPTION
Let's make this function available more broadly.  Also fix the UUID v4 generation to appropriately set the reserved bits (http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29).