### PR TITLE
Prepare COUNTER plugin for SUSHI-Lite

### DIFF
--- a/plugins/reports/counter/CounterReportPlugin.inc.php
+++ b/plugins/reports/counter/CounterReportPlugin.inc.php
@@ -53,6 +53,13 @@ class CounterReportPlugin extends ReportPlugin {
 	}
 
 	/**
+	 * @see PKPPlugin::getTemplatePath()
+	 */
+	function getTemplatePath() {
+		return parent::getTemplatePath() . 'templates/';
+	}	 
+
+	/**
 	 * @see PKPPlugin::isSitePlugin()
 	 */
 	function isSitePlugin() {
@@ -353,7 +360,13 @@ class CounterReportPlugin extends ReportPlugin {
 		$base_url =& Config::getVar('general','base_url');
 
 		$reqUser =& Request::getUser();
-		$templateManager->assign_by_ref('reqUser', $reqUser);
+		if ($reqUser) {
+			$templateManager->assign('reqUserName', $reqUser->getUsername());
+			$templateManager->assign('reqUserId', $reqUser->getUserId());
+		} else {
+			$templateManager->assign('reqUserName', __('plugins.reports.counter.1a.anonymous'));
+			$templateManager->assign('reqUserId', '');
+		}
 
 		$templateManager->assign_by_ref('journalsArray', $journalsArray);
 

--- a/plugins/reports/counter/counter_monthly_log_1_1.xml
+++ b/plugins/reports/counter/counter_monthly_log_1_1.xml
@@ -9,6 +9,7 @@
 * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
 *
 * second version of the counter_monthly_log with one row per month per journal
+* DEPRECATED upgrade function for 2.3.x
 -->
 
 <data>

--- a/plugins/reports/counter/locale/ca_ES/locale.xml
+++ b/plugins/reports/counter/locale/ca_ES/locale.xml
@@ -15,8 +15,8 @@
 <locale name="ca_ES" full_name="Català">
 	<message key="plugins.reports.counter.description"><![CDATA[El mòdul COUNTER (comptador) permet enregistrar i crear informes de l'activitat del lloc web, d'acord amb la iniciativa <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>.]]></message>
 	<message key="plugins.reports.counter">Estadístiques de COUNTER</message>
-	<message key="plugins.reports.counter.1a.title">Informe de la revista 1 (R2): Sol·licituds d'articles de text complet per mes i revista</message>
-	<message key="plugins.reports.counter.1a.title1">Informe de la revista 1 (R2):</message>
+	<message key="plugins.reports.counter.1a.title">Informe de la revista 1 (R3): Sol·licituds d'articles de text complet per mes i revista</message>
+	<message key="plugins.reports.counter.1a.title1">Informe de la revista 1 (R3):</message>
 	<message key="plugins.reports.counter.1a.title2">Nombre de sol·licituds amb èxit d'articles de text complet per mes i revista (any {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Data d'execució:</message>
 	<message key="plugins.reports.counter.1a.publisher">Institució publicadora</message>

--- a/plugins/reports/counter/locale/cs_CZ/locale.xml
+++ b/plugins/reports/counter/locale/cs_CZ/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description">COUNTER plugin umožňuje zaznamenávání a vytváření zpráv o aktivitě na stránkách.</message>
 	<message key="plugins.reports.counter">COUNTER statistiky</message>
 
-	<message key="plugins.reports.counter.1a.title">Zpráva časopisu 1 (R2): Požadavek na Full-Text článku po měsících a časopisech</message>
-	<message key="plugins.reports.counter.1a.title1">Zpráva časopisu 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Zpráva časopisu 1 (R3): Požadavek na Full-Text článku po měsících a časopisech</message>
+	<message key="plugins.reports.counter.1a.title1">Zpráva časopisu 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Počet úspěšných požadavků na Full-Text článků po měsících a časopisech (Rok {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Datum spuštění:</message>
 	<message key="plugins.reports.counter.1a.publisher">Vydavatel</message>

--- a/plugins/reports/counter/locale/da_DK/locale.xml
+++ b/plugins/reports/counter/locale/da_DK/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[TÆLLER plugin'et tillader registrering og <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>-forenelig registrering af site aktivitet.]]></message>
 	<message key="plugins.reports.counter">TÆLLER statistik</message>
 
-	<message key="plugins.reports.counter.1a.title">Tidsskrift rapport  1 (R2): Fuldtekst artikel-anmodninger efter måned og tidsskrift.</message>
-	<message key="plugins.reports.counter.1a.title1">Tidsskrift rapport  1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Tidsskrift rapport  1 (R3): Fuldtekst artikel-anmodninger efter måned og tidsskrift.</message>
+	<message key="plugins.reports.counter.1a.title1">Tidsskrift rapport  1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Antal succesfulde fuldtekst-anmodninger efter måned og tidsskrift (Year {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Dato for kørsel:</message>
 	<message key="plugins.reports.counter.1a.publisher">Udgiver</message>

--- a/plugins/reports/counter/locale/de_DE/locale.xml
+++ b/plugins/reports/counter/locale/de_DE/locale.xml
@@ -14,8 +14,8 @@
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.reports.counter.description"><![CDATA[Das Counter-Plug-In ermöglicht die Aufzeichnung und <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>-entsprechende Wiedergabe der Webseitenaktivität.]]></message>
 	<message key="plugins.reports.counter">COUNTER-Bericht</message>
-	<message key="plugins.reports.counter.1a.title">Zeitschriften-Report 1 (R2): Volltext-Seitenaufrufe pro Monat und Zeitschrift</message>
-	<message key="plugins.reports.counter.1a.title1">Zeitschriften-Report 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Zeitschriften-Report 1 (R3): Volltext-Seitenaufrufe pro Monat und Zeitschrift</message>
+	<message key="plugins.reports.counter.1a.title1">Zeitschriften-Report 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Zahl erfolgreicher Volltext-Seitenaufrufe pro Monat und Zeitschrift (Jahr {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Datum:</message>
 	<message key="plugins.reports.counter.1a.publisher">Verlag</message>

--- a/plugins/reports/counter/locale/el_GR/locale.xml
+++ b/plugins/reports/counter/locale/el_GR/locale.xml
@@ -23,8 +23,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[Το COUNTER plugin επιτρέπει την καταγραφή και την σύνταξη αναφορών συμβατών με το <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> για τα στατιστικά του ιστοτόπου.]]></message>
 	<message key="plugins.reports.counter">Στατιστικά COUNTER</message>
 
-	<message key="plugins.reports.counter.1a.title">Αναφορά Περιοδικού 1 (R2): Αιτήματα για Πλήρες Κείμενο Άρθρων κατά Μήνα και Περιοδικό</message>
-	<message key="plugins.reports.counter.1a.title1">Αναφορά Περιοδικού 1 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Αναφορά Περιοδικού 1 (R3): Αιτήματα για Πλήρες Κείμενο Άρθρων κατά Μήνα και Περιοδικό</message>
+	<message key="plugins.reports.counter.1a.title1">Αναφορά Περιοδικού 1 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Αριθμός Επιτυχημένων Αιτημάτων για Πλήρες Κείμενο Άρθρων κατά Μήνα και Περιοδικό (Έτος {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Ημερομηνία:</message>
 	<message key="plugins.reports.counter.1a.publisher">Εκδότης</message>

--- a/plugins/reports/counter/locale/en_US/locale.xml
+++ b/plugins/reports/counter/locale/en_US/locale.xml
@@ -12,10 +12,14 @@
   -->
  
 <locale name="en_US" full_name="U.S. English">
-	<message key="plugins.reports.counter.description"><![CDATA[The COUNTER plugin allows reporting on site activity.]]></message>
-	<message key="plugins.reports.counter">COUNTER Report</message>
-	<message key="plugins.reports.counter.1a.title">Journal Report 1 (R2): Full-Text Article Requests by Month and Journal</message>
-	<message key="plugins.reports.counter.1a.title1">Journal Report 1 (R2)</message>
+	<message key="plugins.reports.counter.description"><![CDATA[The COUNTER plugin allows reporting on site activity, using the <a href="http://www.projectcounter.org">COUNTER standard</a>. These reports alone do not make a journal COUNTER compliant. To offer COUNTER compliance, review the requirements at the Project COUNTER website.]]></message>
+	<message key="plugins.reports.counter">COUNTER Reports</message>
+	<message key="plugins.reports.counter.1a.introduction">These links generate COUNTER-ready reports based on the obsolete Release 3. Use the later Releases instead, when possible.</message>
+	<message key="plugins.reports.counter.1a.name">COUNTER Report JR1 (R3)</message>
+	<message key="plugins.reports.counter.1a.xml">XML version</message>
+	<message key="plugins.reports.counter.1a.description">COUNTER Journal Report 1 (R3): Full-Text Article Requests by Month and Journal</message>
+	<message key="plugins.reports.counter.1a.title">Journal Report 1 (R3): Full-Text Article Requests by Month and Journal</message>
+	<message key="plugins.reports.counter.1a.title1">Journal Report 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Number of Successful Full-Text Article Requests by Month and Journal (Year {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Date run:</message>
 	<message key="plugins.reports.counter.1a.publisher">Publisher</message>
@@ -26,5 +30,6 @@
 	<message key="plugins.reports.counter.1a.ytdHtml">YTD HTML</message>
 	<message key="plugins.reports.counter.1a.ytdPdf">YTD PDF</message>
 	<message key="plugins.reports.counter.1a.totalForAllJournals">Total for all journals</message>
-	<message key="plugins.reports.counter.legacyStats">The links below generate reports using the old COUNTER plugin data. If you want to generate COUNTER reports using the new OJS COUNTER metric type, use the links above.</message>
+	<message key="plugins.reports.counter.1a.anonymous">anonymous</message>
+	<message key="plugins.reports.counter.legacyStats">The links below generate obsolete reports using the old plugin data, which is not COUNTER-ready. If you want to generate current COUNTER reports using the new OJS COUNTER metric type, use the links above.</message>
 </locale>

--- a/plugins/reports/counter/locale/es_ES/locale.xml
+++ b/plugins/reports/counter/locale/es_ES/locale.xml
@@ -15,8 +15,8 @@
 <locale name="es_ES" full_name="Español (España)">
     <message key="plugins.reports.counter.description"><![CDATA[El módulo COUNTER permite generar informes sobre la actividad del sitio web.]]></message>
 	<message key="plugins.reports.counter">Informe COUNTER</message>
-	<message key="plugins.reports.counter.1a.title">Informe de la revista 1 (R2): Solicitudes de artículos completos por mes y revista</message>
-	<message key="plugins.reports.counter.1a.title1">Informe de la revista 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Informe de la revista 1 (R3): Solicitudes de artículos completos por mes y revista</message>
+	<message key="plugins.reports.counter.1a.title1">Informe de la revista 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Número de solicitudes aceptadas de artículos completos por mes y revista (Año {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Fecha de inicio:</message>
 	<message key="plugins.reports.counter.1a.publisher">Editorial</message>

--- a/plugins/reports/counter/locale/eu_ES/locale.xml
+++ b/plugins/reports/counter/locale/eu_ES/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[COUNTER pluginak webgunearen jarduera erregistratzen du eta <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> moduko txostena ematen du.]]></message>
 	<message key="plugins.reports.counter">COUNTER estatistikak</message>
 	<message key="plugins.reports.counter.migrate">Migratu log-fitxategia</message>
-	<message key="plugins.reports.counter.1a.title">Aldizkariaren 1. txostena (R2): Testu osoko artikulu-eskaerak hilabetez eta aldizkariz</message>
-	<message key="plugins.reports.counter.1a.title1">Aldizkariaren 1. txostena (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Aldizkariaren 1. txostena (R3): Testu osoko artikulu-eskaerak hilabetez eta aldizkariz</message>
+	<message key="plugins.reports.counter.1a.title1">Aldizkariaren 1. txostena (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Testu osoko artikulu-eskaera zuzenak hilabetez eta egunkariz ({$year} urtea)</message>
 	<message key="plugins.reports.counter.1a.dateRun">Data:</message>
 	<message key="plugins.reports.counter.1a.publisher">Argitaratzailea</message>

--- a/plugins/reports/counter/locale/fr_CA/locale.xml
+++ b/plugins/reports/counter/locale/fr_CA/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[Le plugiciel COUNTER permet la consignation de données et la production de rapports <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> des activités du site.]]></message>
 	<message key="plugins.reports.counter">Statistiques COUNTER</message>
 
-	<message key="plugins.reports.counter.1a.title">Rapport de revue 1 (R2) : Demandes de texte intégral, par mois et par revue</message>
-	<message key="plugins.reports.counter.1a.title1">Rapport de revue 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Rapport de revue 1 (R3) : Demandes de texte intégral, par mois et par revue</message>
+	<message key="plugins.reports.counter.1a.title1">Rapport de revue 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Nombre de demandes de texte intégral acceptées, par mois et par revue (Année {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Date d'exécution :</message>
 	<message key="plugins.reports.counter.1a.publisher">Éditeur</message>

--- a/plugins/reports/counter/locale/fr_FR/locale.xml
+++ b/plugins/reports/counter/locale/fr_FR/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[Le plugiciel COUNTER permet la consignation de données et la production de rapports <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> des activités du site.]]></message>
 	<message key="plugins.reports.counter">Statistiques COUNTER</message>
 
-	<message key="plugins.reports.counter.1a.title">Rapport de revue 1 (R2) : Demandes de texte intégral, par mois et par revue</message>
-	<message key="plugins.reports.counter.1a.title1">Rapport de revue 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Rapport de revue 1 (R3) : Demandes de texte intégral, par mois et par revue</message>
+	<message key="plugins.reports.counter.1a.title1">Rapport de revue 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Nombre de demandes de texte intégral acceptées, par mois et par revue (Année {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Date d'exécution :</message>
 	<message key="plugins.reports.counter.1a.publisher">Éditeur</message>

--- a/plugins/reports/counter/locale/hr_HR/locale.xml
+++ b/plugins/reports/counter/locale/hr_HR/locale.xml
@@ -32,8 +32,8 @@
 	<message key="plugins.reports.counter.entry.type.search">Pretraživanje</message>
 	<message key="plugins.reports.counter.entry.value">Vrijednost</message>
 
-	<message key="plugins.reports.counter.1a.title">Izvješće časopisa 1 (R2): Broj zahtjeva za punim tekstom članka po mjesecu i časopisu</message>
-	<message key="plugins.reports.counter.1a.title1">Izvješće časopisa 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Izvješće časopisa 1 (R3): Broj zahtjeva za punim tekstom članka po mjesecu i časopisu</message>
+	<message key="plugins.reports.counter.1a.title1">Izvješće časopisa 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Broj uspješno ispunjenih zahtjeva za punim tekstom članka po mjesecu i časopisu (Godina: {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Datum izvršavanja:</message>
 	<message key="plugins.reports.counter.1a.publisher">Nakladnik</message>

--- a/plugins/reports/counter/locale/id_ID/locale.xml
+++ b/plugins/reports/counter/locale/id_ID/locale.xml
@@ -15,8 +15,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[COUNTER plugin bisa merekam dan <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> melaporkan di aktifitas situs.]]></message> 
 	<message key="plugins.reports.counter"> Statistik COUNTER </message> 
 	<message key="plugins.reports.counter.migrate"> Log Migrasi </message> 
-	<message key="plugins.reports.counter.1a.title"> Laporan Jurnal 1 (R2): Permintaan Artikel Lengkap berdasarkan Bulan dan Jurnal </message> 
-	<message key="plugins.reports.counter.1a.title1"> Laporan Jurnal 1 (R2)</message> 
+	<message key="plugins.reports.counter.1a.title"> Laporan Jurnal 1 (R3): Permintaan Artikel Lengkap berdasarkan Bulan dan Jurnal </message> 
+	<message key="plugins.reports.counter.1a.title1"> Laporan Jurnal 1 (R3)</message> 
 	<message key="plugins.reports.counter.1a.title2"> Jumlah Permintaan Artikel Full-Text yang sukses dari Bulan dan Jurnal (Year {$year})</message>	<message key="plugins.reports.counter.1a.dateRun"> Tanggal Operasi:</message> 
 	<message key="plugins.reports.counter.1a.publisher"> Penerbit </message> 
 	<message key="plugins.reports.counter.1a.platform">Platform</message> 

--- a/plugins/reports/counter/locale/it_IT/locale.xml
+++ b/plugins/reports/counter/locale/it_IT/locale.xml
@@ -17,8 +17,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[Il plugin COUNTER permette la registrazione e il report in formato <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> sull'attività nel sito.]]></message>
 	<message key="plugins.reports.counter">Statistiche COUNTER</message>
 
-	<message key="plugins.reports.counter.1a.title">Journal Report 1 (R2): Articoli Full-Text richiesti per mese e Journal</message>
-	<message key="plugins.reports.counter.1a.title1">Journal Report 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Journal Report 1 (R3): Articoli Full-Text richiesti per mese e Journal</message>
+	<message key="plugins.reports.counter.1a.title1">Journal Report 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Articoli ottenuti Full-Text Article per mese e rivista (Year {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Data:</message>
 	<message key="plugins.reports.counter.1a.publisher">Editore</message>

--- a/plugins/reports/counter/locale/ja_JP/locale.xml
+++ b/plugins/reports/counter/locale/ja_JP/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[サイトの運用状況を記録し、<a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>準拠の報告書を作成します。]]></message>
 	<message key="plugins.reports.counter">COUNTER統計</message>
 
-	<message key="plugins.reports.counter.1a.title">雑誌報告書 1 (R2): 月別・雑誌別の雑誌フルテキストへのリクエスト</message>
-	<message key="plugins.reports.counter.1a.title1">雑誌報告書 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">雑誌報告書 1 (R3): 月別・雑誌別の雑誌フルテキストへのリクエスト</message>
+	<message key="plugins.reports.counter.1a.title1">雑誌報告書 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">月別・雑誌別の成功した雑誌フルテキストへのリクエスト数（{$year}年）</message>
 	<message key="plugins.reports.counter.1a.dateRun">処理日:</message>
 	<message key="plugins.reports.counter.1a.publisher">出版者</message>

--- a/plugins/reports/counter/locale/nl_NL/locale.xml
+++ b/plugins/reports/counter/locale/nl_NL/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[De COUNTER plugin verzorgt het registreren en <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>-conform rapporteren van activiteit op de site.]]></message>
 	<message key="plugins.reports.counter">COUNTER statistieken</message>
 
-	<message key="plugins.reports.counter.1a.title">Tijdschrift rapport 1 (R2): Full-Text artikelen opgevraagd per maand en tijdschrift</message>
-	<message key="plugins.reports.counter.1a.title1">Tijdschriftrapport 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Tijdschrift rapport 1 (R3): Full-Text artikelen opgevraagd per maand en tijdschrift</message>
+	<message key="plugins.reports.counter.1a.title1">Tijdschriftrapport 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Aantal succesvol opgevraagde fulltext artikelen per maand en tijdschrift (jaar {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Gedraaid op datum:</message>
 	<message key="plugins.reports.counter.1a.publisher">Uitgever</message>

--- a/plugins/reports/counter/locale/no_NO/locale.xml
+++ b/plugins/reports/counter/locale/no_NO/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[COUNTER-programutvidelsen gjør det mulig å registrere og <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>-rapportere trafikken på siden.]]></message>
 	<message key="plugins.reports.counter">COUNTER-statistikk</message>
 
-	<message key="plugins.reports.counter.1a.title">Tidsskrift-rapport 1 (R2): Fulltekst artikkelforespørsler per måned og tidsskrift</message>
-	<message key="plugins.reports.counter.1a.title1">Tidsskrift-rapport 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Tidsskrift-rapport 1 (R3): Fulltekst artikkelforespørsler per måned og tidsskrift</message>
+	<message key="plugins.reports.counter.1a.title1">Tidsskrift-rapport 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Antall artikkelnedlastninger per måned og tidsskrift (År {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Kjørt dato:</message>
 	<message key="plugins.reports.counter.1a.publisher">Utgiver</message>

--- a/plugins/reports/counter/locale/pt_BR/locale.xml
+++ b/plugins/reports/counter/locale/pt_BR/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[Esta ferramenta permite armazenar e produzir relatórios compatíveis com a iniciativa <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>, sobre a atividade no portal.]]></message>
 	<message key="plugins.reports.counter">Estatísticas COUNTER</message>
 
-	<message key="plugins.reports.counter.1a.title">Relatório 1 (R2): Solicitações de texto completo de artigos por mês e revista</message>
-	<message key="plugins.reports.counter.1a.title1">Relatório 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Relatório 1 (R3): Solicitações de texto completo de artigos por mês e revista</message>
+	<message key="plugins.reports.counter.1a.title1">Relatório 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Número de solicitações bem-sucedidas de texto completo de artigos por mês e revista (Ano {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Data da execução:</message>
 	<message key="plugins.reports.counter.1a.publisher">Editora</message>

--- a/plugins/reports/counter/locale/pt_PT/locale.xml
+++ b/plugins/reports/counter/locale/pt_PT/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[O plugin COUNTER permite armazenar e produzir relatórios compatíveis com a iniciativa <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>, sobre a actividade no portal.]]></message>
 	<message key="plugins.reports.counter">Estatísticas COUNTER</message>
 
-	<message key="plugins.reports.counter.1a.title">Relatório 1 (R2): Solicitações de texto completo de artigos por mês e revista</message>
-	<message key="plugins.reports.counter.1a.title1">Relatório 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Relatório 1 (R3): Solicitações de texto completo de artigos por mês e revista</message>
+	<message key="plugins.reports.counter.1a.title1">Relatório 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Número de solicitações bem-sucedidas de texto completo de artigos por mês e revista (Ano {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Data da execução:</message>
 	<message key="plugins.reports.counter.1a.publisher">Editora</message>

--- a/plugins/reports/counter/locale/ro_RO/locale.xml
+++ b/plugins/reports/counter/locale/ro_RO/locale.xml
@@ -26,8 +26,8 @@
 
 		
 	
-	<message key="plugins.reports.counter.1a.title">Raportul pentru revista 1 (R2): Solicitări de text integral pe lună şi pe revistă</message>
-	<message key="plugins.reports.counter.1a.title1">Raportul pentru revista 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Raportul pentru revista 1 (R3): Solicitări de text integral pe lună şi pe revistă</message>
+	<message key="plugins.reports.counter.1a.title1">Raportul pentru revista 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Numărul de cereri înregistrate cu succes pentru articole cu text integral pe lună şi pe revistă (Anul {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Data:</message>
 	<message key="plugins.reports.counter.1a.publisher">Editor</message>

--- a/plugins/reports/counter/locale/ru_RU/locale.xml
+++ b/plugins/reports/counter/locale/ru_RU/locale.xml
@@ -15,8 +15,8 @@
 <locale name="ru_RU" full_name="Russian">
 	<message key="plugins.reports.counter.description"><![CDATA[Плагин «COUNTER» позволяет сформировать отчеты об активности сайта.]]></message>
 	<message key="plugins.reports.counter">Плагин «Отчет COUNTER»</message>
-	<message key="plugins.reports.counter.1a.title">Отчет журнала 1 (R2): Запросы полных текстов статей по месяцам и журналам</message>
-	<message key="plugins.reports.counter.1a.title1">Отчет журнала 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Отчет журнала 1 (R3): Запросы полных текстов статей по месяцам и журналам</message>
+	<message key="plugins.reports.counter.1a.title1">Отчет журнала 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Количество успешных запросов полных текстов статей по месяцам и журналам (год {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Дата запуска:</message>
 	<message key="plugins.reports.counter.1a.publisher">Издатель</message>

--- a/plugins/reports/counter/locale/sr_SR/locale.xml
+++ b/plugins/reports/counter/locale/sr_SR/locale.xml
@@ -16,8 +16,8 @@
 	<message key="plugins.reports.counter.description"><![CDATA[The COUNTER plugin allows recording and <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> reporting on site activity.]]></message>
 	<message key="plugins.reports.counter">COUNTER statistika</message>
 	<message key="plugins.reports.counter.migrate">Migriraj Log fajl</message>
-	<message key="plugins.reports.counter.1a.title">Izveštaj časopisa 1 (R2): Ceo tekst članka zahtevan od strane Month and Journal</message>
-	<message key="plugins.reports.counter.1a.title1">Izveštaj časopisa 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Izveštaj časopisa 1 (R3): Ceo tekst članka zahtevan od strane Month and Journal</message>
+	<message key="plugins.reports.counter.1a.title1">Izveštaj časopisa 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Broj časopisa sa celim tekstom zahtevanih od strane Month and Journal (Godina {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Datum pokretanja:</message>
 	<message key="plugins.reports.counter.1a.publisher">Izdavač</message>

--- a/plugins/reports/counter/locale/tr_TR/locale.xml
+++ b/plugins/reports/counter/locale/tr_TR/locale.xml
@@ -15,8 +15,8 @@
 <locale name="tr_TR" full_name="Türkiye Türkçesi">
 	<message key="plugins.reports.counter.description"><![CDATA[Sayaç Eklentisi, site aktivitesini <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a> uyumlu olarak raporlamak ve kayıt etmek için kullanılır.]]></message>
 	<message key="plugins.reports.counter">SAYAÇ İstatistikleri</message>
-	<message key="plugins.reports.counter.1a.title">Dergi Raporu 1 (R2): Aylık Tam Metin Makale İstekleri</message>
-	<message key="plugins.reports.counter.1a.title1">Dergi Raporu 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Dergi Raporu 1 (R3): Aylık Tam Metin Makale İstekleri</message>
+	<message key="plugins.reports.counter.1a.title1">Dergi Raporu 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Aylık Başarılı Tam Metin Makale İstekleri Sayısı (Yıl {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Başlangıç tarihi:</message>
 	<message key="plugins.reports.counter.1a.publisher">Yayncı</message>

--- a/plugins/reports/counter/locale/uk_UA/locale.xml
+++ b/plugins/reports/counter/locale/uk_UA/locale.xml
@@ -18,8 +18,8 @@
        <message key="plugins.reports.counter.description"><![CDATA[Модуль COUNTER дозволяє запис та створення звітів щодо активності на сайті за стандартом <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>.]]></message>
        <message key="plugins.reports.counter">Статистика COUNTER</message>
        <message key="plugins.reports.counter.migrate">Міграція лог-файлу</message>
-       <message key="plugins.reports.counter.1a.title">Журнальний звіт 1 (R2): Запити повних текстів статей за місяцями та журналами</message>
-       <message key="plugins.reports.counter.1a.title1">Журнальний звіт 1 (R2)</message>
+       <message key="plugins.reports.counter.1a.title">Журнальний звіт 1 (R3): Запити повних текстів статей за місяцями та журналами</message>
+       <message key="plugins.reports.counter.1a.title1">Журнальний звіт 1 (R3)</message>
        <message key="plugins.reports.counter.1a.title2">Кількість успішних запитів повних текстів статей за місяцями та журналами (Рік {$year})</message>
        <message key="plugins.reports.counter.1a.dateRun">Дата формування:</message>
        <message key="plugins.reports.counter.1a.publisher">Видавець</message>

--- a/plugins/reports/counter/locale/vi_VN/locale.xml
+++ b/plugins/reports/counter/locale/vi_VN/locale.xml
@@ -31,8 +31,8 @@
 	<message key="plugins.reports.counter.entry.type.search">Search</message>
 	<message key="plugins.reports.counter.entry.value">Value</message>
 
-	<message key="plugins.reports.counter.1a.title">Journal Report 1 (R2): Full-Text Article Requests by Month and Journal</message>
-	<message key="plugins.reports.counter.1a.title1">Journal Report 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">Journal Report 1 (R3): Full-Text Article Requests by Month and Journal</message>
+	<message key="plugins.reports.counter.1a.title1">Journal Report 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">Number of Successful Full-Text Article Requests by Month and Journal (Year {$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">Date run:</message>
 	<message key="plugins.reports.counter.1a.publisher">Publisher</message>

--- a/plugins/reports/counter/locale/zh_CN/locale.xml
+++ b/plugins/reports/counter/locale/zh_CN/locale.xml
@@ -15,8 +15,8 @@
 <locale name="zh_CN" full_name="China P.R">
 	<message key="plugins.reports.counter.description"><![CDATA[计数器插件提供关于站点活动的记录和<a href="http://www.projectcounter.org/about.html" target="_new">计数</a>报告.]]></message>
 	<message key="plugins.reports.counter">计数器统计</message>
-	<message key="plugins.reports.counter.1a.title">期刊报告1(R2): 按月份与杂志的全文文章点击请求</message>
-	<message key="plugins.reports.counter.1a.title1">期刊报告1(R2)</message>
+	<message key="plugins.reports.counter.1a.title">期刊报告1(R3): 按月份与杂志的全文文章点击请求</message>
+	<message key="plugins.reports.counter.1a.title1">期刊报告1(R3)</message>
 	<message key="plugins.reports.counter.1a.title2">按照月份与期刊的全文请求成功次数( 年{$year})</message>
 	<message key="plugins.reports.counter.1a.dateRun">日运行:</message>
 	<message key="plugins.reports.counter.1a.publisher">发行人</message>

--- a/plugins/reports/counter/locale/zh_TW/locale.xml
+++ b/plugins/reports/counter/locale/zh_TW/locale.xml
@@ -31,8 +31,8 @@
 	<message key="plugins.reports.counter.entry.type.search">搜尋</message>
 	<message key="plugins.reports.counter.entry.value">值</message>
 
-	<message key="plugins.reports.counter.1a.title">期刊報告 1 (R2): 調閱全文文章的月份和期刊。</message>
-	<message key="plugins.reports.counter.1a.title1">期刊報告 1 (R2)</message>
+	<message key="plugins.reports.counter.1a.title">期刊報告 1 (R3): 調閱全文文章的月份和期刊。</message>
+	<message key="plugins.reports.counter.1a.title1">期刊報告 1 (R3)</message>
 	<message key="plugins.reports.counter.1a.title2">成功調閱文章全文的月份和期刊數({$year}年)</message>
 	<message key="plugins.reports.counter.1a.dateRun">橫跨時間：</message>
 	<message key="plugins.reports.counter.1a.publisher">出版者</message>

--- a/plugins/reports/counter/templates/index.tpl
+++ b/plugins/reports/counter/templates/index.tpl
@@ -1,5 +1,5 @@
 {**
- * plugins/reports/counter/index.tpl
+ * plugins/reports/counter/templates/index.tpl
  *
  * Copyright (c) 2013-2015 Simon Fraser University Library
  * Copyright (c) 2003-2015 John Willinsky
@@ -14,16 +14,17 @@
 
 <p>{translate key="plugins.reports.counter.description"}</p>
 
+<p>{translate key="plugins.reports.counter.1a.introduction"}</p>
 <ul>
 	<li>{translate key="plugins.reports.counter.1a.title"}{foreach from=$years item=year}&nbsp;&nbsp;<a href="{url path="CounterReportPlugin" type="report" year=$year}">{$year|escape}</a>{/foreach}</li>
-	<li>XML version {foreach from=$years item=year}&nbsp;&nbsp;<a href="{url path="CounterReportPlugin" type="reportxml" year=$year}">{$year|escape}</a>{/foreach}</li>
+	<li>{translate key="plugins.reports.counter.1a.xml"} {foreach from=$years item=year}&nbsp;&nbsp;<a href="{url path="CounterReportPlugin" type="reportxml" year=$year}">{$year|escape}</a>{/foreach}</li>
 </ul>
 
 {if $legacyYears}
 	<p>{translate key="plugins.reports.counter.legacyStats"}</p>
 	<ul>
 		<li>{translate key="plugins.reports.counter.1a.title"}{foreach from=$legacyYears item=year}&nbsp;&nbsp;<a href="{url path="CounterReportPlugin" type="report" year=$year useOldCounterStats=true}">{$year|escape}</a>{/foreach}</li>
-		<li>XML version {foreach from=$legacyYears item=year}&nbsp;&nbsp;<a href="{url path="CounterReportPlugin" type="reportxml" year=$year useOldCounterStats=true}">{$year|escape}</a>{/foreach}</li>
+		<li>{translate key="plugins.reports.counter.1a.xml"} {foreach from=$legacyYears item=year}&nbsp;&nbsp;<a href="{url path="CounterReportPlugin" type="reportxml" year=$year useOldCounterStats=true}">{$year|escape}</a>{/foreach}</li>
 	</ul>
 {/if}
 

--- a/plugins/reports/counter/templates/reportxml.tpl
+++ b/plugins/reports/counter/templates/reportxml.tpl
@@ -1,5 +1,5 @@
 {**
- * plugins/reports/counter/reportxml.tpl
+ * plugins/reports/counter/templates/reportxml.tpl
  *
  * Copyright (c) 2013-2015 Simon Fraser University Library
  * Copyright (c) 2003-2015 John Willinsky
@@ -20,8 +20,8 @@
       <WebSiteUrl>{$base_url|escape:"html"}</WebSiteUrl>
     </Vendor>
     <Customer>
-      <Name>{$reqUser->getUserName()|escape:"html"}</Name>
-      <ID>{$reqUser->getUserID()|escape:"html"}</ID>
+      <Name>{$reqUserName|escape:"html"}</Name>
+      <ID>{$reqUserId|escape:"html"}</ID>
 
       {foreach from=$journalsArray key=journalkey item=journal}
 

--- a/plugins/reports/counter/templates/soaperror.tpl
+++ b/plugins/reports/counter/templates/soaperror.tpl
@@ -1,5 +1,5 @@
 {**
- * plugins/reports/counter/soaperror.tpl
+ * plugins/reports/counter/templates/soaperror.tpl
  *
  * Copyright (c) 2013-2015 Simon Fraser University Library
  * Copyright (c) 2003-2015 John Willinsky

--- a/plugins/reports/counter/templates/sushixml.tpl
+++ b/plugins/reports/counter/templates/sushixml.tpl
@@ -1,5 +1,5 @@
 {**
- * plugins/reports/counter/sushixml.tpl
+ * plugins/reports/counter/templates/sushixml.tpl
  *
  * Copyright (c) 2013-2015 Simon Fraser University Library
  * Copyright (c) 2003-2015 John Willinsky

--- a/plugins/reports/counter/version.xml
+++ b/plugins/reports/counter/version.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE version SYSTEM "../../../lib/pkp/dtd/pluginVersion.dtd">
 
 <!--
-  * plugins/reports/timedView/version.xml
+  * plugins/reports/counter/version.xml
   *
   * Copyright (c) 2013-2015 Simon Fraser University Library
   * Copyright (c) 2003-2015 John Willinsky


### PR DESCRIPTION
Some cleanup work in preparation for a retooling of the COUNTER plugin.
* Create and use a templates folder for a bit of orgainzation
* fix the mixed usage of ReportPlugin::report() parameterization
* Correct existing report release number in locale files.
* ~~Create classes folder for additional organization~~
* ~~Migrate legacy JR1 (R3) functionality to its own class~~
* Clarify relationship of Counter plugin to COUNTER compliance
* Addresses pkp/pkp-lib#274