### PR TITLE
pkp/pkp-lib#335: fix checks in GeoLocationTool instanciation

### DIFF
--- a/classes/statistics/StatisticsHelper.inc.php
+++ b/classes/statistics/StatisticsHelper.inc.php
@@ -297,7 +297,7 @@ class StatisticsHelper {
 
 	/**
 	* Get the geo location tool.
-	* @return GeoLocationTool
+	* @return mixed GeoLocationTool object or null
 	*/
 	function &getGeoLocationTool() {
 		$geoLocationTool = null;

--- a/plugins/generic/usageStats/GeoLocationTool.inc.php
+++ b/plugins/generic/usageStats/GeoLocationTool.inc.php
@@ -26,7 +26,8 @@ class GeoLocationTool {
 
 	/**
 	 * Constructor.
-	 * @param $argv array command-line arguments
+	 * If we cannot find the database file, an empty object will be constructed.
+	 * Use the method isPresent() to check if the database file is present before use.
 	 */
 	function GeoLocationTool() {
 		$geoLocationDbFile = dirname(__FILE__) . DIRECTORY_SEPARATOR . "GeoLiteCity.dat";
@@ -69,6 +70,14 @@ class GeoLocationTool {
 			utf8_encode($record->city),
 			$record->region
 		);
+	}
+
+	/**
+	 * Identify if the geolocation database tool is available for use.
+	 * @return boolean
+	 */
+	function isPresent() {
+		return $this->_isDbFilePresent;
 	}
 
 	/**

--- a/plugins/generic/usageStats/UsageStatsLoader.inc.php
+++ b/plugins/generic/usageStats/UsageStatsLoader.inc.php
@@ -181,7 +181,7 @@ class UsageStatsLoader extends FileLoader {
 			list($assocId, $assocType) = $this->_getAssocFromUrl($entryData['url'], $filePath, $lineNumber);
 			if(!$assocId || !$assocType) continue;
 
-			list($countryCode, $cityName, $region) = $geoTool->getGeoLocation($entryData['ip']);
+			list($countryCode, $cityName, $region) = $geoTool ? $geoTool->getGeoLocation($entryData['ip']) : array();
 			$day = date('Ymd', $entryData['date']);
 
 			$type = $this->_getFileType($assocType, $assocId);

--- a/plugins/generic/usageStats/UsageStatsPlugin.inc.php
+++ b/plugins/generic/usageStats/UsageStatsPlugin.inc.php
@@ -220,7 +220,7 @@ class UsageStatsPlugin extends GenericPlugin {
 	/**
 	 * Get the geolocation tool to process geo localization
 	 * data.
-	 * @return GeoLocationTool
+	 * @return mixed GeoLocationTool object or null
 	 */
 	function &getGeoLocationTool() {
 		/** Geo location tool wrapper class. If changing the geo location tool
@@ -229,7 +229,7 @@ class UsageStatsPlugin extends GenericPlugin {
 		$this->import('GeoLocationTool');
 
 		$tool = new GeoLocationTool();
-		return $tool;
+		return $tool->isPresent() ? $tool : null;
 	}
 
 	/**


### PR DESCRIPTION
Add new isPresent() method and utilize it instead of check of (boolean) $object.
