### PR TITLE
* Fix path to tag-it jQuery lib CSS file in pkp-lib

### DIFF
--- a/styles/lib.css
+++ b/styles/lib.css
@@ -25,7 +25,7 @@
 @import url("../lib/pkp/js/lib/pnotify/buildcustom.php?mode=css&modules=");
 
 /* Tag it! - http://plugins.jquery.com/project/tag-it/ */
-@import url("lib/pkp/styles/lib/tagit.css");
+@import url("../lib/pkp/styles/lib/tagit.css");
 
 /**
  * The following libraries are compilable but compiling throws image paths off.


### PR DESCRIPTION
This PR fixes the path to load the CSS file for the jQuery library tag-it library. This file is required to properly display the "Reviewing Interests" input field in the user details section.