### PR TITLE
Include terms of use agreement date in deposit xml

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -434,7 +434,7 @@ class PLNPlugin extends GenericPlugin {
 		$termsAgreed = unserialize($this->getSetting($journalId, 'terms_of_use_agreement'));
 		
 		foreach (array_keys($terms) as $term) {
-			if (!isset($termsAgreed[$term]) || ($termsAgreed[$term])) return false;
+			if (!isset($termsAgreed[$term]) || (!$termsAgreed[$term])) return false;
 		}
 		
 		return true;

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -434,7 +434,7 @@ class PLNPlugin extends GenericPlugin {
 		$termsAgreed = unserialize($this->getSetting($journalId, 'terms_of_use_agreement'));
 		
 		foreach (array_keys($terms) as $term) {
-			if (!isset($termsAgreed[$term]) || ($termsAgreed[$term] == false)) return false;
+			if (!isset($termsAgreed[$term]) || ($termsAgreed[$term] == null)) return false;
 		}
 		
 		return true;
@@ -498,7 +498,7 @@ class PLNPlugin extends GenericPlugin {
 		if ($newTerms != $oldTerms) {
 			$termAgreements = array();
 			foreach($terms as $termName => $termText) {
-				$termAgreements[$termName] = false;
+				$termAgreements[$termName] = null;
 			}
 		
 			$this->updateSetting($journalId, 'terms_of_use', $newTerms, 'object');

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -434,7 +434,7 @@ class PLNPlugin extends GenericPlugin {
 		$termsAgreed = unserialize($this->getSetting($journalId, 'terms_of_use_agreement'));
 		
 		foreach (array_keys($terms) as $term) {
-			if (!isset($termsAgreed[$term]) || ($termsAgreed[$term] == null)) return false;
+			if (!isset($termsAgreed[$term]) || ($termsAgreed[$term])) return false;
 		}
 		
 		return true;

--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -239,11 +239,13 @@ class DepositPackage {
 		$entry->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:pkp', PLN_PLUGIN_NAME);
 
 		$terms = unserialize($plnPlugin->getSetting($this->_deposit->getJournalId(), 'terms_of_use'));
+		$agreement = unserialize($plnPlugin->getSetting($this->_deposit->getJournalId(), 'terms_of_use_agreement'));
 		
 		$pkpTermsOfUse = $termsXml->createElementNS(PLN_PLUGIN_NAME, 'pkp:terms_of_use');
 		foreach ($terms as $termName => $termData) {
 			$element = $termsXml->createElementNS(PLN_PLUGIN_NAME, $termName, $termData['term']);
 			$element->setAttribute('updated',$termData['updated']);
+			$element->setAttribute('agreed', $agreement[$termName]);
 			$pkpTermsOfUse->appendChild($element);
 		}
 

--- a/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
@@ -64,7 +64,7 @@ class PLNSettingsForm extends Form {
 		$terms_agreed = $this->getData('terms_of_use_agreement');
 		if (Request::getUserVar('terms_agreed')) {
 			foreach(array_keys(Request::getUserVar('terms_agreed')) as $term_agreed) {
-				$terms_agreed[$term_agreed] = TRUE;
+				$terms_agreed[$term_agreed] = date('c');
 			}
 			$this->setData('terms_of_use_agreement', $terms_agreed);
 		}

--- a/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
@@ -64,7 +64,7 @@ class PLNSettingsForm extends Form {
 		$terms_agreed = $this->getData('terms_of_use_agreement');
 		if (Request::getUserVar('terms_agreed')) {
 			foreach(array_keys(Request::getUserVar('terms_agreed')) as $term_agreed) {
-				$terms_agreed[$term_agreed] = date('c');
+				$terms_agreed[$term_agreed] = gmdate('c');
 			}
 			$this->setData('terms_of_use_agreement', $terms_agreed);
 		}

--- a/plugins/generic/pln/templates/settings.tpl
+++ b/plugins/generic/pln/templates/settings.tpl
@@ -27,7 +27,7 @@
 					{if $hasIssn}
 						{foreach name=terms from=$terms_of_use key=term_name item=term_data}
 							<p>{$term_data.term}</p>
-							<input type="checkbox" name="terms_agreed[{$term_name|escape}]" value="1"{if $terms_of_use_agreement[$term_name] == 1} checked{/if}><label class="agree" for="terms_agreed[{$term_name|escape}]">{translate key="plugins.generic.pln.settings.terms_of_use_agree"}</label>
+							<input type="checkbox" name="terms_agreed[{$term_name|escape}]" value="1"{if $terms_of_use_agreement[$term_name] != null} checked{/if}><label class="agree" for="terms_agreed[{$term_name|escape}]">{translate key="plugins.generic.pln.settings.terms_of_use_agree"}</label>
 							{if !$smarty.foreach.terms.last }<div class="separator">&nbsp;</div>{/if}
 						{/foreach}
 					{else}

--- a/plugins/generic/pln/templates/settings.tpl
+++ b/plugins/generic/pln/templates/settings.tpl
@@ -27,7 +27,7 @@
 					{if $hasIssn}
 						{foreach name=terms from=$terms_of_use key=term_name item=term_data}
 							<p>{$term_data.term}</p>
-							<input type="checkbox" name="terms_agreed[{$term_name|escape}]" value="1"{if $terms_of_use_agreement[$term_name] != null} checked{/if}><label class="agree" for="terms_agreed[{$term_name|escape}]">{translate key="plugins.generic.pln.settings.terms_of_use_agree"}</label>
+							<input type="checkbox" name="terms_agreed[{$term_name|escape}]" value="1"{if $terms_of_use_agreement[$term_name]} checked{/if}><label class="agree" for="terms_agreed[{$term_name|escape}]">{translate key="plugins.generic.pln.settings.terms_of_use_agree"}</label>
 							{if !$smarty.foreach.terms.last }<div class="separator">&nbsp;</div>{/if}
 						{/foreach}
 					{else}


### PR DESCRIPTION
Make the terms_of_use_agreement plugin setting a date (or null) instead of a boolean. Use the date in the terms of use XML with the deposit package.

Fixes pkp/pkp-lib#375