### PR TITLE
pkp/pkp-lib#384: make issue cover locale function consistent with article locale handling

### DIFF
--- a/pages/issue/IssueHandler.inc.php
+++ b/pages/issue/IssueHandler.inc.php
@@ -124,6 +124,7 @@ class IssueHandler extends Handler {
 		$templateMgr =& TemplateManager::getManager();
 		$templateMgr->assign('coverPagePath', $coverPagePath);
 		$templateMgr->assign('locale', AppLocale::getLocale());
+		$templateMgr->assign('primaryLocale', $journal->getPrimaryLocale());
 		$templateMgr->assign_by_ref('issues', $publishedIssuesIterator);
 		$templateMgr->assign('helpTopicId', 'user.currentAndArchives');
 		$templateMgr->display('issue/archive.tpl');
@@ -438,13 +439,13 @@ class IssueHandler extends Handler {
 			$templateMgr->assign('coverPagePath', $coverPagePath);
 			$templateMgr->assign('locale', $locale);
 
-
-			if (!$showToc && $issue->getFileName($locale) && $issue->getShowCoverPage($locale) && !$issue->getHideCoverPageCover($locale)) {
-				$templateMgr->assign('fileName', $issue->getFileName($locale));
-				$templateMgr->assign('width', $issue->getWidth($locale));
-				$templateMgr->assign('height', $issue->getHeight($locale));
-				$templateMgr->assign('coverPageAltText', $issue->getCoverPageAltText($locale));
-				$templateMgr->assign('originalFileName', $issue->getOriginalFileName($locale));
+			$coverLocale = $issue->getFileName($locale) ? $locale : $journal->getPrimaryLocale();
+			if (!$showToc && $issue->getFileName($coverLocale) && $issue->getShowCoverPage($coverLocale) && !$issue->getHideCoverPageCover($coverLocale)) {
+				$templateMgr->assign('fileName', $issue->getFileName($coverLocale));
+				$templateMgr->assign('width', $issue->getWidth($coverLocale));
+				$templateMgr->assign('height', $issue->getHeight($coverLocale));
+				$templateMgr->assign('coverPageAltText', $issue->getCoverPageAltText($coverLocale));
+				$templateMgr->assign('originalFileName', $issue->getOriginalFileName($coverLocale));
 
 				$showToc = false;
 			} else {

--- a/templates/issue/archive.tpl
+++ b/templates/issue/archive.tpl
@@ -29,8 +29,13 @@
 	{/if}
 
 	<div id="issue-{$issue->getId()}" style="clear:left;">
-	{if $issue->getLocalizedFileName() && $issue->getShowCoverPage($locale) && !$issue->getHideCoverPageArchives($locale)}
-		<div class="issueCoverImage"><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}"><img src="{$coverPagePath|escape}{$issue->getFileName($locale)|escape}"{if $issue->getCoverPageAltText($locale) != ''} alt="{$issue->getCoverPageAltText($locale)|escape}"{else} alt="{translate key="issue.coverPage.altText"}"{/if}/></a>
+	{if $issue->getFileName($locale)}
+		{assign var="coverLocale" value="$locale"}
+	{else}
+		{assign var="coverLocale" value="$primaryLocale"}
+	{/if}
+	{if $issue->getFileName($coverLocale) && $issue->getShowCoverPage($coverLocale) && !$issue->getHideCoverPageArchives($coverLocale)}
+		<div class="issueCoverImage"><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}"><img src="{$coverPagePath|escape}{$issue->getFileName($coverLocale)|escape}"{if $issue->getCoverPageAltText($coverLocale) != ''} alt="{$issue->getCoverPageAltText($coverLocale)|escape}"{else} alt="{translate key="issue.coverPage.altText"}"{/if}/></a>
 		</div>
 		<h4><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}">{$issue->getIssueIdentification()|escape}</a></h4>
 		<div class="issueCoverDescription">{$issue->getLocalizedCoverPageDescription()|strip_unsafe_html|nl2br}</div>


### PR DESCRIPTION
Set Issue Cover's locale to the Site's primary locale if no cover information is available for the locale.