### PR TITLE
problem with subscription type form (format is always invalid)

### DIFF
--- a/classes/subscription/form/SubscriptionTypeForm.inc.php
+++ b/classes/subscription/form/SubscriptionTypeForm.inc.php
@@ -65,7 +65,7 @@ class SubscriptionTypeForm extends Form {
 
 		// Format is provided and is valid value
 		$this->addCheck(new FormValidator($this, 'format', 'required', 'manager.subscriptionTypes.form.formatRequired'));	
-		$this->addCheck(new FormValidatorInSet($this, 'format', 'required', 'manager.subscriptionTypes.form.formatValid', array_keys($this->validFormats)));
+		$this->addCheck(new FormValidatorInSet($this, 'format', 'required', 'manager.subscriptionTypes.form.formatValid', array_map('strval', array_keys($this->validFormats))));
 
 		// Institutional flag is valid value
 		$this->addCheck(new FormValidatorInSet($this, 'institutional', 'optional', 'manager.subscriptionTypes.form.institutionalValid', array('0', '1')));


### PR DESCRIPTION
ValidatorInSet uses strict in_array, value from the form (string) is always in valid (array contains only integers)