### PR TITLE
pkp/pkp-lib#523 Solve jQuery conflict in the ALM plugin

### DIFF
--- a/plugins/generic/alm/output.tpl
+++ b/plugins/generic/alm/output.tpl
@@ -43,13 +43,14 @@
 	// Import JQuery 1.10 version, needed for the tooltip plugin
 	// that we use below. jQuery.noConflict puts the old $ back.
 	$.getScript('{$jqueryImportPath}', function() {ldelim}
-		$.getScript('{$tooltipImportPath}', function() {ldelim}
+		var jquery_1_10 = jQuery.noConflict();
+		jquery_1_10.getScript('{$tooltipImportPath}', function() {ldelim}
 			// Assign the last inserted JQuery version to a new variable, to avoid
 			// conflicts with the current version in $ variable.
-			options.jQuery = $;
+			options.jQuery = jquery_1_10;
 			var almviz = new AlmViz(options);
 			almviz.initViz();
-			jQuery.noConflict(true);
+			jquery_1_10.noConflict(true);
 		{rdelim});
 	{rdelim});
 


### PR DESCRIPTION
Fix pkp/pkp-lib#523

The solution that I found to the problem is to disassociate $ from jQuery 1.10 before loading the tooltip plugin. It is important that the jQuery variable has jQuery 1.10 at line 46, because the tooltip plugin registers the plugin on the jQuery found in the variable "jQuery" . After the plugin is loaded, we can also disassociate the jQuery variable (line 53).

This hack solves the problem with pdf viewing. But it is not a generic solution because the jQuery var remains associated to the jQuery 1.10 until the tooltip plugin is loaded.