### PR TITLE
Present user email validation notification when registering

### DIFF
--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -731,6 +731,8 @@ Active is how many reviews are currently being considered or underway.]]></messa
 current password.<br /><br />Enter your email address below to reset your password. A confirmation will be sent to this email address.]]></message>
 
 	<!-- Registration -->
+	<message key="user.register.emailValidation">Email Validation Required</message>
+	<message key="user.register.emailValidationDescription">You are required to validate your email address before proceeding.  Please check your email account for further instructions.  Once you have validated your account, you may login.</message>
 	<message key="user.register.selectJournal">Select a journal to register with</message>
 	<message key="user.register.noJournals">There are no journals you may register with on this site.</message>
 	<message key="user.register.privacyStatement">Privacy Statement</message>

--- a/pages/user/RegistrationHandler.inc.php
+++ b/pages/user/RegistrationHandler.inc.php
@@ -78,10 +78,18 @@ class RegistrationHandler extends UserHandler {
 
 		if ($regForm->validate()) {
 			$regForm->execute();
-			if (Config::getVar('email', 'require_validation')) {
-				// Send them home; they need to deal with the
-				// registration email.
-				$request->redirect(null, 'index');
+			if (!Validation::isLoggedIn()) {
+				if (Config::getVar('email', 'require_validation')) {
+					// Inform the user that they need to deal with the
+					// registration email.
+					$this->setupTemplate($request, true);
+					$templateMgr =& TemplateManager::getManager();
+					$templateMgr->assign('pageTitle', 'user.register.emailValidation');
+					$templateMgr->assign('errorMsg', 'user.register.emailValidationDescription');
+					$templateMgr->assign('backLink', $request->url(null, 'login'));
+					$templateMgr->assign('backLinkLabel', 'user.login');
+					return $templateMgr->display('common/error.tpl');
+				}
 			}
 
 			$reason = null;


### PR DESCRIPTION
This ensures no confusion when a user needs to verify their email address in order to proceed with registration for a journal.  Previously, OJS simply redirected the user home, with no indication at all as to what happened.  This now presents the user with a page explaining what to do next -- eg check and validate the email in their inbox.