### PR TITLE
Switch to encrypted submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "lib/pkp"]
 	path = lib/pkp
-	url = git://github.com/pkp/pkp-lib
+	url = https://github.com/pkp/pkp-lib.git
 [submodule "plugins/generic/customBlockManager"]
 	path = plugins/generic/customBlockManager
-	url = git://github.com/pkp/customBlockManager
+	url = https://github.com/pkp/customBlockManager.git
 [submodule "plugins/generic/staticPages"]
 	path = plugins/generic/staticPages
-	url = git://github.com/pkp/staticPages
+	url = https://github.com/pkp/staticPages.git
 [submodule "plugins/generic/translator"]
 	path = plugins/generic/translator
-	url = git://github.com/pkp/translator
+	url = https://github.com/pkp/translator.git
 [submodule "plugins/generic/tinymce"]
 	path = plugins/generic/tinymce
-	url = git://github.com/pkp/tinymce
+	url = https://github.com/pkp/tinymce.git


### PR DESCRIPTION
The ``git://`` protocol is unencrypted so the suggested way of accessing GitHub repositories is via https:// (Git's Smart HTTP transport protocol).  This change will not affect or change the way this repo is cloned, just that the submodules' code is delivered securely.

In addition, in rare cases, the ``git://`` protocol may be blocked by some firewalls since it operates on an unusual port.  In the case of HTTPS, this is far less likely to be affected by such a firewall.