### PR TITLE
Show authors country in authors list

### DIFF
--- a/templates/search/authorIndex.tpl
+++ b/templates/search/authorIndex.tpl
@@ -27,7 +27,6 @@
 	{/if}
 
 	{assign var=lastAuthorName value=$authorName}
-	{assign var=lastAuthorCountry value=$authorCountry}
 
 	{assign var=authorAffiliation value=$author->getLocalizedAffiliation()}
 	{assign var=authorCountry value=$author->getCountry()}

--- a/templates/search/authorIndex.tpl
+++ b/templates/search/authorIndex.tpl
@@ -41,10 +41,7 @@
 	{strip}
 		<a href="{url op="authors" path="view" firstName=$authorFirstName middleName=$authorMiddleName lastName=$authorLastName affiliation=$authorAffiliation country=$authorCountry}">{$authorName|escape}</a>
 		{if $authorAffiliation}, {$authorAffiliation|escape}{/if}
-		{if $lastAuthorName == $authorName && $lastAuthorCountry != $authorCountry}
-			{* Disambiguate with country if necessary (i.e. if names are the same otherwise) *}
-			{if $authorCountry} ({$author->getCountryLocalized()}){/if}
-		{/if}
+		{if $authorCountry} ({$author->getCountryLocalized()}){/if}
 	{/strip}
 	<br/>
 {/iterate}


### PR DESCRIPTION
Since ERIH PLUS criteria for inclusion want "Information on author affiliation and address" https://dbh.nsd.uib.no/publiseringskanaler/erihplus/about/criteria_for_inclusion and in a mail exchange they that "It is sufficient that this information is displayed in the list Scorri l'indice degli autori (i.e. authors list)" I propose to ever show  athor's countries and not only for disambiguation purposes.