### PR TITLE
Attempt login first during registration before checking email validation

### DIFF
--- a/pages/user/RegistrationHandler.inc.php
+++ b/pages/user/RegistrationHandler.inc.php
@@ -78,6 +78,15 @@ class RegistrationHandler extends UserHandler {
 
 		if ($regForm->validate()) {
 			$regForm->execute();
+
+			$reason = null;
+
+			if (Config::getVar('security', 'implicit_auth')) {
+				Validation::login('', '', $reason);
+			} else {
+				Validation::login($regForm->getData('username'), $regForm->getData('password'), $reason);
+			}
+
 			if (!Validation::isLoggedIn()) {
 				if (Config::getVar('email', 'require_validation')) {
 					// Inform the user that they need to deal with the
@@ -90,14 +99,6 @@ class RegistrationHandler extends UserHandler {
 					$templateMgr->assign('backLinkLabel', 'user.login');
 					return $templateMgr->display('common/error.tpl');
 				}
-			}
-
-			$reason = null;
-
-			if (Config::getVar('security', 'implicit_auth')) {
-				Validation::login('', '', $reason);
-			} else {
-				Validation::login($regForm->getData('username'), $regForm->getData('password'), $reason);
 			}
 
 			if ($reason !== null) {


### PR DESCRIPTION
Without this change, attempting to login on the Registration form with standard authentication (eg ``ImplicitAuth = Off``) & a validated account will always result in the "Email Validation Required" message appearing, preventing login.  This is because the new "is logged in" check from my PR #500 happens before login is tried.

This change resolves this by attempting login with the user's submitted credentials.  If that fails, we know they're registering for the first time so prompt them to validate their email address.

Apologies for missing this in the original PR.