### PR TITLE
Allow implicit authentication to the be optional

### DIFF
--- a/classes/manager/form/UserManagementForm.inc.php
+++ b/classes/manager/form/UserManagementForm.inc.php
@@ -37,7 +37,7 @@ class UserManagementForm extends Form {
 			$this->addCheck(new FormValidatorCustom($this, 'username', 'required', 'user.register.form.usernameExists', array(DAORegistry::getDAO('UserDAO'), 'userExistsByUsername'), array($this->userId, true), true));
 			$this->addCheck(new FormValidatorAlphaNum($this, 'username', 'required', 'user.register.form.usernameAlphaNumeric'));
 
-			if (!Config::getVar('security', 'implicit_auth')) {
+			if (!Config::getVar('security', 'implicit_auth') || strtolower(Config::getVar('security', 'implicit_auth')) === IMPLICIT_AUTH_OPTIONAL) {
 				$this->addCheck(new FormValidator($this, 'password', 'required', 'user.profile.form.passwordRequired'));
 				$this->addCheck(new FormValidatorLength($this, 'password', 'required', 'user.register.form.passwordLengthTooShort', '>=', $site->getMinPasswordLength()));
 				$this->addCheck(new FormValidatorCustom($this, 'password', 'required', 'user.register.form.passwordsDoNotMatch', create_function('$password,$form', 'return $password == $form->getData(\'password2\');'), array(&$this)));
@@ -112,7 +112,7 @@ class UserManagementForm extends Form {
 		);
 
 		// Send implicitAuth setting down to template
-		$templateMgr->assign('implicitAuth', Config::getVar('security', 'implicit_auth'));
+		$templateMgr->assign('implicitAuth', strtolower(Config::getVar('security', 'implicit_auth')));
 
 		$site =& Request::getSite();
 		$templateMgr->assign('availableLocales', $site->getSupportedLocaleNames());

--- a/classes/security/Validation.inc.php
+++ b/classes/security/Validation.inc.php
@@ -16,24 +16,26 @@
 import('classes.security.Role');
 import('classes.security.Hashing');
 
+define('IMPLICIT_AUTH_OPTIONAL', 'optional');
+
 class Validation {
 
 	/**
 	 * Authenticate user credentials and mark the user as logged in in the current session.
-	 * @param $username string
+	 * @param $username string authenticating user's id; null if implicit auth is happening
 	 * @param $password string unencrypted password
 	 * @param $reason string reference to string to receive the reason an account was disabled; null otherwise
 	 * @param $remember boolean remember a user's session past the current browser session
 	 * @return User the User associated with the login credentials, or false if the credentials are invalid
 	 */
 	function &login($username, $password, &$reason, $remember = false) {
-		$implicitAuth = Config::getVar('security', 'implicit_auth');
+		$implicitAuth = strtolower(Config::getVar('security', 'implicit_auth'));
 
 		$reason = null;
 		$valid = false;
 		$userDao =& DAORegistry::getDAO('UserDAO');
 
-		if ($implicitAuth) { // Implicit auth
+		if ($implicitAuth && !$username) { // Implicit auth, and not regular auth
 			if (!Validation::isLoggedIn()) {
 				PluginRegistry::loadCategory('implicitAuth');
 

--- a/classes/template/TemplateManager.inc.php
+++ b/classes/template/TemplateManager.inc.php
@@ -34,7 +34,7 @@ class TemplateManager extends PKPTemplateManager {
 		assert(is_a($router, 'PKPRouter'));
 
 		// Are we using implicit authentication?
-		$this->assign('implicitAuth', Config::getVar('security', 'implicit_auth'));
+		$this->assign('implicitAuth', strtolower(Config::getVar('security', 'implicit_auth')));
 
 		if (!defined('SESSION_DISABLE_INIT')) {
 			/**

--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -41,10 +41,10 @@ class RegistrationForm extends Form {
 	 */
 	function RegistrationForm() {
 		parent::Form('user/register.tpl');
-		$this->implicitAuth = Config::getVar('security', 'implicit_auth');
+		$this->implicitAuth = strtolower(Config::getVar('security', 'implicit_auth'));
 
-		if ($this->implicitAuth) {
-			// If implicit auth - it is always an existing user
+		if (Validation::isLoggedIn()) {
+			// If logged in
 			$this->existingUser = 1;
 		} else {
 			$this->existingUser = Request::getUserVar('existingUser') ? 1 : 0;

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -263,12 +263,14 @@ allowed_html = "<a href|target> <em> <strong> <cite> <code> <ul> <ol> <li> <dl> 
 ; </p></sub></sup></u></i></b></dd></dt></dl></li></ol></ul></code></cite></strong></em></a>
 
 
-;Is implicit authentication enabled or not
-
+; Configure whether implicit authentication (request headers) is used.
+; Valid values are: On, Off, Optional
+; If On or Optional, request headers are consulted for account metadata so
+; ensure that users cannot spoof headers. If Optional, users may use either
+; implicit authentication or local accounts to access the system.
 ;implicit_auth = On
 
-;Implicit Auth Header Variables
-
+; Implicit Auth Header Variables
 ;implicit_auth_header_first_name = HTTP_GIVENNAME
 ;implicit_auth_header_last_name = HTTP_SN
 ;implicit_auth_header_email = HTTP_MAIL
@@ -280,8 +282,8 @@ allowed_html = "<a href|target> <em> <strong> <cite> <code> <ul> <ol> <li> <dl> 
 ; A space delimited list of uins to make admin
 ;implicit_auth_admin_list = "jdoe@email.ca jshmo@email.ca"
 
-; URL of the implicit auth 'Way Finder' page. See pages/login/LoginHandler.inc.php for usage.
-
+; URL of the implicit auth 'Way Finder' (Discovery Service [DS]) page.
+; See pages/login/LoginHandler.inc.php for usage.
 ;implicit_auth_wayf_url = "/Shibboleth.sso/wayf"
 
 

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -236,6 +236,7 @@
 	<message key="user.orcid">ORCID iD</message>
 	<message key="user.orcid.description"><![CDATA[ORCID iDs can only be assigned by <a href="http://orcid.org/" target="_blank">the ORCID Registry</a>. You must conform to their standards for expressing ORCID iDs, and include the full URI (eg. <em>http://orcid.org/0000-0002-1825-0097</em>).]]></message>
 	<message key="user.profile.form.orcidInvalid">The ORCID iD you specified is invalid.</message>
+	<message key="user.profile.implicitAuthChangePasswordInstructions">If you have logged in via your Shibboleth, follow your organization's process if you need to change your password.  For local users, continue below.</message>
 
 	<!-- Roles -->
 	<message key="user.role.manager">Journal Manager</message>
@@ -729,6 +730,7 @@ Active is how many reviews are currently being considered or underway.]]></messa
 	<message key="user.login.registerNewAccount">Not a user? Register with this site</message>
 	<message key="user.login.resetPasswordInstructions"><![CDATA[For security reasons, this system emails a reset password to registered users, rather than recalling the
 current password.<br /><br />Enter your email address below to reset your password. A confirmation will be sent to this email address.]]></message>
+	<message key="user.login.implicitAuthLogin">Login via Shibboleth</message>
 
 	<!-- Registration -->
 	<message key="user.register.emailValidation">Email Validation Required</message>
@@ -747,6 +749,7 @@ current password.<br /><br />Enter your email address below to reset your passwo
 	<message key="user.register.reviewerDescriptionNoInterests">Willing to conduct peer review of submissions to the journal.</message>
 	<message key="user.register.reviewerDescription">Willing to conduct peer review of submissions to the site.</message>
 	<message key="user.register.reviewerInterests">Identify reviewing interests (substantive areas and research methods):</message>
+	<message key="user.register.implicitAuth">Login via Shibboleth with an existing organization account</message>
 
 	<!-- Subscriptions -->
 	<message key="user.subscriptions.mySubscriptions">My Subscriptions</message>

--- a/pages/user/RegistrationHandler.inc.php
+++ b/pages/user/RegistrationHandler.inc.php
@@ -81,8 +81,16 @@ class RegistrationHandler extends UserHandler {
 
 			$reason = null;
 
-			if (Config::getVar('security', 'implicit_auth')) {
+			$implicitAuth = strtolower(Config::getVar('security', 'implicit_auth'));
+			if ($implicitAuth === true) {
 				Validation::login('', '', $reason);
+			} elseif ($implicitAuth === IMPLICIT_AUTH_OPTIONAL) {
+				// Try both types of authentication
+				if ($regForm->getData('username') && $regForm->getData('password')) {
+					Validation::login($regForm->getData('username'), $regForm->getData('password'), $reason);
+				} else {
+					Validation::login('', '', $reason);
+				}
 			} else {
 				Validation::login($regForm->getData('username'), $regForm->getData('password'), $reason);
 			}

--- a/plugins/blocks/user/block.tpl
+++ b/plugins/blocks/user/block.tpl
@@ -9,7 +9,7 @@
  *
  *}
 <div class="block" id="sidebarUser">
-	{if !$implicitAuth}
+	{if !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
 		<span class="blockTitle">{translate key="navigation.user"}</span>
 	{/if}
 
@@ -28,28 +28,37 @@
 		</ul>
 	{else}
 		{if $implicitAuth}
+			{if $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
+				<span class="blockTitle">{translate key="user.login.implicitAuth"}</span>
+			{/if}
 			<a href="{url page="login" op="implicitAuthLogin"}">{translate key="plugins.block.user.implicitAuthLogin"}</a>
-		{elseif $userBlockLoginSSL}
-			<a href="{$userBlockLoginUrl}">{translate key="user.login"}</a>
-		{else}
-			<form method="post" action="{$userBlockLoginUrl}">
-				<table>
-					<tr>
-						<td><label for="sidebar-username">{translate key="user.username"}</label></td>
-						<td><input type="text" id="sidebar-username" name="username" value="" size="12" maxlength="32" class="textField" /></td>
-					</tr>
-					<tr>
-						<td><label for="sidebar-password">{translate key="user.password"}</label></td>
-						<td><input type="password" id="sidebar-password" name="password" value="{$password|escape}" size="12" class="textField" /></td>
-					</tr>
-					<tr>
-						<td colspan="2"><input type="checkbox" id="remember" name="remember" value="1" /> <label for="remember">{translate key="plugins.block.user.rememberMe"}</label></td>
-					</tr>
-					<tr>
-						<td colspan="2"><input type="submit" value="{translate key="user.login"}" class="button" /></td>
-					</tr>
-				</table>
-			</form>
+			{if $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
+				<span class="blockTitle">{translate key="user.login.localAuth"}</span>
+			{/if}
+		{/if}
+		{if !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
+			{if $userBlockLoginSSL}
+				<a href="{$userBlockLoginUrl}">{translate key="user.login"}</a>
+			{else}
+				<form method="post" action="{$userBlockLoginUrl}">
+					<table>
+						<tr>
+							<td><label for="sidebar-username">{translate key="user.username"}</label></td>
+							<td><input type="text" id="sidebar-username" name="username" value="" size="12" maxlength="32" class="textField" /></td>
+						</tr>
+						<tr>
+							<td><label for="sidebar-password">{translate key="user.password"}</label></td>
+							<td><input type="password" id="sidebar-password" name="password" value="{$password|escape}" size="12" class="textField" /></td>
+						</tr>
+						<tr>
+							<td colspan="2"><input type="checkbox" id="remember" name="remember" value="1" /> <label for="remember">{translate key="plugins.block.user.rememberMe"}</label></td>
+						</tr>
+						<tr>
+							<td colspan="2"><input type="submit" value="{translate key="user.login"}" class="button" /></td>
+						</tr>
+					</table>
+				</form>
+			{/if}
 		{/if}
 	{/if}
 </div>

--- a/templates/manager/people/userProfileForm.tpl
+++ b/templates/manager/people/userProfileForm.tpl
@@ -155,7 +155,7 @@
 	</tr>
 	{/if}
 
-	{if !$implicitAuth}
+	{if !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
 		<tr valign="top">
 			<td class="label">{fieldLabel name="password" required=$passwordRequired key="user.password"}</td>
 			<td class="value">
@@ -187,7 +187,7 @@
 			<td class="label">&nbsp;</td>
 			<td class="value"><input type="checkbox" name="mustChangePassword" id="mustChangePassword" value="1"{if $mustChangePassword} checked="checked"{/if} /> <label for="mustChangePassword">{translate key="manager.people.userMustChangePassword"}</label></td>
 		</tr>
-	{/if}{* !$implicitAuth *}
+	{/if}{* !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL *}
 
 	<tr valign="top">
 		<td class="label">{fieldLabel name="affiliation" key="user.affiliation"}</td>

--- a/templates/user/changePassword.tpl
+++ b/templates/user/changePassword.tpl
@@ -19,6 +19,9 @@
 
 {include file="common/formErrors.tpl"}
 
+{if $implicitAuth}
+<p><span class="instruct">{translate key="user.profile.implicitAuthChangePasswordInstructions"}</span></p>
+{/if}
 <p><span class="instruct">{translate key="user.profile.changePasswordInstructions"}</span></p>
 
 <table class="data" width="100%">

--- a/templates/user/index.tpl
+++ b/templates/user/index.tpl
@@ -223,7 +223,7 @@
 	{/if}
 	<li><a href="{url page="user" op="profile"}">{translate key="user.editMyProfile"}</a></li>
 
-	{if !$implicitAuth}
+	{if !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
 		<li><a href="{url page="user" op="changePassword"}">{translate key="user.changeMyPassword"}</a></li>
 	{/if}
 

--- a/templates/user/register.tpl
+++ b/templates/user/register.tpl
@@ -13,32 +13,41 @@
 {include file="common/header.tpl"}
 {/strip}
 
-<form id="registerForm" method="post" action="{url op="registerUser"}">
+{if $implicitAuth === true && !Validation::isLoggedIn()}
+	<p><a href="{url page="login" op="implicitAuthLogin"}">{translate key="user.register.implicitAuth"}</a></p>
+{else}
+	<form id="registerForm" method="post" action="{url op="registerUser"}">
 
-<p>{translate key="user.register.completeForm"}</p>
+	<p>{translate key="user.register.completeForm"}</p>
 
-{if !$implicitAuth}
-	{if !$existingUser}
-		{url|assign:"url" page="user" op="register" existingUser=1}
-		<p>{translate key="user.register.alreadyRegisteredOtherJournal" registerUrl=$url}</p>
-	{else}
-		{url|assign:"url" page="user" op="register"}
-		<p>{translate key="user.register.notAlreadyRegisteredOtherJournal" registerUrl=$url}</p>
-		<input type="hidden" name="existingUser" value="1"/>
+	{if !$implicitAuth || ($implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL && !Validation::isLoggedIn())}
+		{if !$existingUser}
+			{url|assign:"url" page="user" op="register" existingUser=1}
+			<p>{translate key="user.register.alreadyRegisteredOtherJournal" registerUrl=$url}</p>
+		{else}
+			{url|assign:"url" page="user" op="register"}
+			<p>{translate key="user.register.notAlreadyRegisteredOtherJournal" registerUrl=$url}</p>
+			<input type="hidden" name="existingUser" value="1"/>
+		{/if}
+
+		{if $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
+			<p><a href="{url page="login" op="implicitAuthLogin"}">{translate key="user.register.implicitAuth"}</a></p>
+		{/if}
+
+		<h3>{translate key="user.profile"}</h3>
+
+		{include file="common/formErrors.tpl"}
+
+		{if $existingUser}
+			<p>{translate key="user.register.loginToRegister"}</p>
+		{/if}
+	{/if}{* !$implicitAuth || ($implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL && !Validation::isLoggedIn()) *}
+
+	{if $source}
+		<input type="hidden" name="source" value="{$source|escape}" />
 	{/if}
+{/if}{* $implicitAuth === true && !Validation::isLoggedIn() *}
 
-	<h3>{translate key="user.profile"}</h3>
-
-	{include file="common/formErrors.tpl"}
-
-	{if $existingUser}
-		<p>{translate key="user.register.loginToRegister"}</p>
-	{/if}
-{/if}{* !$implicitAuth *}
-
-{if $source}
-	<input type="hidden" name="source" value="{$source|escape}" />
-{/if}
 
 <table class="data" width="100%">
 {if count($formLocales) > 1 && !$existingUser}
@@ -52,7 +61,7 @@
 	</tr>
 {/if}{* count($formLocales) > 1 && !$existingUser *}
 
-{if !$implicitAuth}
+{if !$implicitAuth || ($implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL && !Validation::isLoggedIn())}
 	<tr valign="top">
 		<td width="20%" class="label">{fieldLabel name="username" required="true" key="user.username"}</td>
 		<td width="80%" class="value"><input type="text" name="username" value="{$username|escape}" id="username" size="20" maxlength="32" class="textField" /></td>
@@ -210,32 +219,39 @@
 			</tr>
 		{/if}{* count($availableLocales) > 1 *}
 	{/if}{* !$existingUser *}
-{/if}{* !$implicitAuth *}
+{/if}{* !$implicitAuth || ($implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL && !Validation::isLoggedIn()) *}
 
-{if $allowRegReader || $allowRegReader === null || $allowRegAuthor || $allowRegAuthor === null || $allowRegReviewer || $allowRegReviewer === null || ($currentJournal && $currentJournal->getSetting('publishingMode') == $smarty.const.PUBLISHING_MODE_SUBSCRIPTION && $enableOpenAccessNotification)}
-	<tr valign="top">
-		<td class="label">{fieldLabel suppressId="true" name="registerAs" key="user.register.registerAs"}</td>
-		<td class="value">{if $allowRegReader || $allowRegReader === null}<input type="checkbox" name="registerAsReader" id="registerAsReader" value="1"{if $registerAsReader} checked="checked"{/if} /> <label for="registerAsReader">{translate key="user.role.reader"}</label>: {translate key="user.register.readerDescription"}<br />{/if}
-		{if $currentJournal && $currentJournal->getSetting('publishingMode') == $smarty.const.PUBLISHING_MODE_SUBSCRIPTION && $enableOpenAccessNotification}<input type="checkbox" name="openAccessNotification" id="openAccessNotification" value="1"{if $openAccessNotification} checked="checked"{/if} /> <label for="openAccessNotification">{translate key="user.role.reader"}</label>: {translate key="user.register.openAccessNotificationDescription"}<br />{/if}
-		{if $allowRegAuthor || $allowRegAuthor === null}<input type="checkbox" name="registerAsAuthor" id="registerAsAuthor" value="1"{if $registerAsAuthor} checked="checked"{/if} /> <label for="registerAsAuthor">{translate key="user.role.author"}</label>: {translate key="user.register.authorDescription"}<br />{/if}
-		{if $allowRegReviewer || $allowRegReviewer === null}<input type="checkbox" name="registerAsReviewer" id="registerAsReviewer" value="1"{if $registerAsReviewer} checked="checked"{/if} /> <label for="registerAsReviewer">{translate key="user.role.reviewer"}</label>: {if $existingUser}{translate key="user.register.reviewerDescriptionNoInterests"}{else}{translate key="user.register.reviewerDescription"}{/if}
-		<br /><div id="reviewerInterestsContainer" style="margin-left:25px;">
-			<label class="desc">{translate key="user.register.reviewerInterests"}</label>
-			{include file="form/interestsInput.tpl" FBV_interestsKeywords=$interestsKeywords FBV_interestsTextOnly=$interestsTextOnly}
-		</div>
-		</td>
-		{/if}
-	</tr>
-{/if}
 
-</table>
+{if !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL || ($implicitAuth === true && Validation::isLoggedIn())}
+	{if $allowRegReader || $allowRegReader === null || $allowRegAuthor || $allowRegAuthor === null || $allowRegReviewer || $allowRegReviewer === null || ($currentJournal && $currentJournal->getSetting('publishingMode') == $smarty.const.PUBLISHING_MODE_SUBSCRIPTION && $enableOpenAccessNotification)}
+		<tr valign="top">
+			<td class="label">{fieldLabel suppressId="true" name="registerAs" key="user.register.registerAs"}</td>
+			<td class="value">{if $allowRegReader || $allowRegReader === null}<input type="checkbox" name="registerAsReader" id="registerAsReader" value="1"{if $registerAsReader} checked="checked"{/if} /> <label for="registerAsReader">{translate key="user.role.reader"}</label>: {translate key="user.register.readerDescription"}<br />{/if}
+			{if $currentJournal && $currentJournal->getSetting('publishingMode') == $smarty.const.PUBLISHING_MODE_SUBSCRIPTION && $enableOpenAccessNotification}<input type="checkbox" name="openAccessNotification" id="openAccessNotification" value="1"{if $openAccessNotification} checked="checked"{/if} /> <label for="openAccessNotification">{translate key="user.role.reader"}</label>: {translate key="user.register.openAccessNotificationDescription"}<br />{/if}
+			{if $allowRegAuthor || $allowRegAuthor === null}<input type="checkbox" name="registerAsAuthor" id="registerAsAuthor" value="1"{if $registerAsAuthor} checked="checked"{/if} /> <label for="registerAsAuthor">{translate key="user.role.author"}</label>: {translate key="user.register.authorDescription"}<br />{/if}
+			{if $allowRegReviewer || $allowRegReviewer === null}<input type="checkbox" name="registerAsReviewer" id="registerAsReviewer" value="1"{if $registerAsReviewer} checked="checked"{/if} /> <label for="registerAsReviewer">{translate key="user.role.reviewer"}</label>: {if $existingUser}{translate key="user.register.reviewerDescriptionNoInterests"}{else}{translate key="user.register.reviewerDescription"}{/if}
+			<br /><div id="reviewerInterestsContainer" style="margin-left:25px;">
+				<label class="desc">{translate key="user.register.reviewerInterests"}</label>
+				{include file="form/interestsInput.tpl" FBV_interestsKeywords=$interestsKeywords FBV_interestsTextOnly=$interestsTextOnly}
+			</div>
+			</td>
+			{/if}
+		</tr>
+	{/if}
 
-<br />
-<p><input type="submit" value="{translate key="user.register"}" class="button defaultButton" /> <input type="button" value="{translate key="common.cancel"}" class="button" onclick="document.location.href='{url page="index" escape=false}'" /></p>
+	</table>
+	
+	<br />
+	<p><input type="submit" value="{translate key="user.register"}" class="button defaultButton" /> <input type="button" value="{translate key="common.cancel"}" class="button" onclick="document.location.href='{url page="index" escape=false}'" /></p>
+{/if}{* !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL || ($implicitAuth === true && Validation::isLoggedIn()) *}
 
-{if ! $implicitAuth}
+
+{if !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL}
 	<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
-{/if}{* !$implicitAuth *}
+
+{/if}{* !$implicitAuth || $implicitAuth === $smarty.const.IMPLICIT_AUTH_OPTIONAL *}
+
+</form>
 
 <div id="privacyStatement">
 {if $privacyStatement}
@@ -243,8 +259,6 @@
 	<p>{$privacyStatement|nl2br}</p>
 {/if}
 </div>
-
-</form>
 
 {include file="common/footer.tpl"}
 


### PR DESCRIPTION
As discussed at http://pkp.sfu.ca/support/forum/viewtopic.php?p=50029sid=d391a4ca8a1c1bb46ade0612db8e7fb4#p50029 onwards.

This patch for OJS comes from an install I've set up that required simultaneous local login and Shibboleth (implicit authentication) access.  It adds the ability to specify ``implicitAuth = Optional`` in the config.inc.php file.  This handles the use case of allowing users with Shibboleth/SSO users and users with local accounts (managers, anyone who can't login via Shibboleth, etc) to both access OJS via their respective methods.

This pull request is fully-backwards compatible with existing implicitAuth settings (``On`` and ``Off``). The only one difference that will be seen by users is a bugfix on the register form if ``implicitAuth = On``; see below.

This pull request consists of the following changes:

* Any checks for implicit auth (``On`` or ``Off``) now also check for ``Optional``, ensuring code paths or template content is shown in this case.
* User validation (Validation.inc.php) checks the type of auth being used before proceeding
* Updates config.TEMPLATE.inc.php with details about implicit auth
* Register form prompts users to login first when implicit auth set as ``On``.  Previously, when implicit auth was on, a non-functioning register form was shown (bugfix).  Other changes to this file are re-indentation.
* When ``implicitAuth = Optional``, display headings on login templates and sidebar to help users distinguish between implicit auth (Shibboleth) and local login.
* Updates pkp-lib to make the login.tpl compatible with optional implicit auth (see https://github.com/pkp/pkp-lib/pull/542 for the commit).
* Adds helper text to password change template when ``implicitAuth = Optional``; password change needs to be available for local accounts but can't be used for Shibboleth login so the page explains this.
* Adds relevant localisation for new strings.