### PR TITLE
Remove invalid second parameter from TemplateManager::addStyleSheet() call.

### DIFF
--- a/plugins/blocks/languageToggle/LanguageToggleBlockPlugin.inc.php
+++ b/plugins/blocks/languageToggle/LanguageToggleBlockPlugin.inc.php
@@ -99,7 +99,7 @@ class LanguageToggleBlockPlugin extends BlockPlugin {
 			$templateMgr->assign('languageToggleLocales', $locales);
 		}
 
-		$templateMgr->addStyleSheet(Request::getBaseUrl() . '/' . $this->getPluginPath() . '/styles/languageToggle.css', STYLE_SEQUENCE_CORE);
+		$templateMgr->addStyleSheet(Request::getBaseUrl() . '/' . $this->getPluginPath() . '/styles/languageToggle.css');
 
 		return parent::getContents($templateMgr);
 	}


### PR DESCRIPTION
c.f. Error message in http://forum.pkp.sfu.ca/t/error-creating-new-issue-in-ojs-2-4-6/1206

$templateManager->addStyleSheet() resolves to PKPTemplateManager::addStyleSheet(), which has no second parameter:
https://github.com/pkp/pkp-lib/blob/ojs-dev-2_4/classes/template/PKPTemplateManager.inc.php#L259

Constant STYLE_SEQUENCE_CORE does not exist in the 2.4 codebase.