### PR TITLE
Remove arbitrary maxlengths from article titles and section titles.

### DIFF
--- a/plugins/importexport/quickSubmit/index.tpl
+++ b/plugins/importexport/quickSubmit/index.tpl
@@ -365,7 +365,7 @@ function updateAbstractRequired() {
 
 		<tr valign="top">
 			<td width="30%" class="label">{fieldLabel name="title" required="true" key="article.title"}</td>
-			<td width="70%" class="value"><input type="text" class="textField" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="60" maxlength="255" /></td>
+			<td width="70%" class="value"><input type="text" class="textField" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="60" /></td>
 		</tr>
 
 		<tr valign="top">

--- a/templates/author/submit/step3.tpl
+++ b/templates/author/submit/step3.tpl
@@ -215,7 +215,7 @@ function moveAuthor(dir, authorIndex) {
 
 <tr valign="top">
 	<td width="20%" class="label">{fieldLabel name="title" required="true" key="article.title"}</td>
-	<td width="80%" class="value"><input type="text" class="textField" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="60" maxlength="255" /></td>
+	<td width="80%" class="value"><input type="text" class="textField" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="60" /></td>
 </tr>
 
 <tr valign="top">

--- a/templates/editor/issues/createIssue.tpl
+++ b/templates/editor/issues/createIssue.tpl
@@ -69,7 +69,7 @@
 	{/if}
 	<tr valign="top">
 		<td class="label">{fieldLabel name="title" key="issue.title"}</td>
-		<td class="value"><input type="text" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="40" maxlength="120" class="textField" /></td>
+		<td class="value"><input type="text" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="40" class="textField" /></td>
 	</tr>
 	<tr valign="top">
 		<td class="label">{fieldLabel name="description" key="editor.issues.description"}</td>

--- a/templates/editor/issues/issueData.tpl
+++ b/templates/editor/issues/issueData.tpl
@@ -80,7 +80,7 @@
 	{/if}
 	<tr valign="top">
 		<td class="label">{fieldLabel name="title" key="issue.title"}</td>
-		<td class="value"><input type="text" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="40" maxlength="120" class="textField" /></td>
+		<td class="value"><input type="text" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="40" class="textField" /></td>
 	</tr>
 	<tr valign="top">
 		<td class="label">{fieldLabel name="description" key="editor.issues.description"}</td>

--- a/templates/submission/metadata/metadataEdit.tpl
+++ b/templates/submission/metadata/metadataEdit.tpl
@@ -219,7 +219,7 @@ function moveAuthor(dir, authorIndex) {
 <table width="100%" class="data">
 	<tr>
 		<td width="20%" class="label">{fieldLabel name="title" required="true" key="article.title"}</td>
-		<td width="80%" class="value"><input type="text" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="60" maxlength="255" class="textField" /></td>
+		<td width="80%" class="value"><input type="text" name="title[{$formLocale|escape}]" id="title" value="{$title[$formLocale]|escape}" size="60" class="textField" /></td>
 	</tr>
 
 	<tr>


### PR DESCRIPTION
Arbitrary maxlengths on article and section titles are a source of client complaints.  Let's get rid of them.