### PR TITLE
Add error logging (and some general logging) to the pln plugin.

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -443,7 +443,7 @@ class PLNPlugin extends GenericPlugin {
 	/**
 	 * Request service document at specified URL
 	 * @param $journalId int The journal id for the service document we wish to fetch
-	 * @return int The HTTP response status
+	 * @return int The HTTP response status or FALSE for a network error.
 	 */
 	function getServiceDocument($journalId) {
 			
@@ -465,7 +465,14 @@ class PLNPlugin extends GenericPlugin {
 		);
 		
 		// stop here if we didn't get an OK
-		if ($result['status'] != PLN_PLUGIN_HTTP_STATUS_OK) return $result['status'];
+		if ($result['status'] != PLN_PLUGIN_HTTP_STATUS_OK) {
+			if($result['status'] === FALSE) {
+				error_log(__('plugins.generic.pln.error.network.servicedocument', array('error' => $result['error'])));
+			} else {
+				error_log(__('plugins.generic.pln.error.http.servicedocument', array('error' => $result['status'])));
+			}
+			return $result['status'];
+		}
 
 		$serviceDocument = new DOMDocument();
 		$serviceDocument->preserveWhiteSpace = false;

--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -14,6 +14,7 @@
  */
 
 import('classes.file.JournalFileManager');
+import('lib.pkp.classes.scheduledTask.ScheduledTask');
 
 require_once(dirname(__FILE__).'/../lib/bagit.php');
 
@@ -23,14 +24,41 @@ class DepositPackage {
 	 * @var $deposit Deposit
 	 */
 	var $_deposit;
+	
+	/**
+	 * If the DepositPackage object was created as part of a scheduled task
+	 * run, then save the task so error messages can be logged there.
+	 * @var ScheduledTask $_task;
+	 */
+	var $_task;
+	
 
 	/**
-	 * Constructor
+	 * Constructor. 
+	 * 
 	 * @param $deposit Deposit
+	 * @param $task ScheduledTask
+	 * 
 	 * @return DepositPackage
 	 */
-	function DepositPackage($deposit) {
+	function DepositPackage($deposit, $task = null) {
 		$this->_deposit = $deposit;
+		$this->_task = $task;
+	}
+	
+	/**
+	 * Send a message to a log. If the deposit package is aware of a 
+	 * a scheduled task, the message will be sent to the task's 
+	 * log. Otherwise it will be sent to error_log().
+	 * 
+	 * @param $message string Locale-specific message to be logged
+	 */
+	function _logMessage($message) {
+		if($this->_task) {
+			$task->addExecutionLogEntry($message, SCHEDULED_TASK_MESSAGE_TYPE_NOTICE);
+		} else {
+			error_log($message);
+		}
 	}
 
 	/**
@@ -75,9 +103,12 @@ class DepositPackage {
 		$packageFile = $this->getPackageFilePath();
 		
 		// make sure our bag is present
-		if (!$fileManager->fileExists($packageFile)) return false;
+		if (!$fileManager->fileExists($packageFile)) {
+			$this->_logMessage(__("plugins.generic.pln.error.depositor.missingpackage", array('file' => $packageFile)));
+			return false;
+		}
 		
-		$atom  = new DOMDocument('1.0', 'utf-8');
+		$atom = new DOMDocument('1.0', 'utf-8');
 		$entry = $atom->createElementNS('http://www.w3.org/2005/Atom', 'entry');
 		$entry->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:dcterms', 'http://purl.org/dc/terms/');
 		$entry->setAttributeNS('http://www.w3.org/2000/xmlns/' ,'xmlns:pkp', 'http://pkp.sfu.ca/SWORD');
@@ -218,7 +249,10 @@ class DepositPackage {
 				}
 				
 				// export all of the articles together
-				if ($exportPlugin->exportArticles($articles, $exportFile) !== true) return false;
+				if ($exportPlugin->exportArticles($articles, $exportFile) !== true) {
+					$this->_logMessage(__("plugins.generic.pln.error.depositor.export.articles.error"));
+					return false;
+				}
 				break;
 			case PLN_PLUGIN_DEPOSIT_OBJECT_ISSUE:
 			
@@ -227,7 +261,10 @@ class DepositPackage {
 				$issue =& $issueDao->getIssueByBestIssueId($depositObject->getObjectId(),$journal->getId());
 				
 				// export the issue
-				if ($exportPlugin->exportIssue($journal, $issue, $exportFile) !== true) return false;
+				if ($exportPlugin->exportIssue($journal, $issue, $exportFile) !== true) {
+					$this->_logMessage(__("plugins.generic.pln.error.depositor.export.issue.error"));
+					return false;
+				}
 				break;
 			default:
 		}
@@ -307,6 +344,11 @@ class DepositPackage {
 			$depositDao->updateDeposit($this->_deposit);
 		} else {
 			// we got an error back from the staging server
+			if($result['status'] == FALSE) {
+				$this->_logMessage(__("plugins.generic.pln.error.network.deposit", array('error' => $result['error'])));
+			} else {
+				$this->_logMessage(__("plugins.generic.pln.error.http.deposit", array('error' => $result['error'])));
+			}
 			$this->_deposit->setRemoteFailureStatus();
 			$this->_deposit->setLastStatusDate(time());
 			$depositDao->updateDeposit($this->_deposit);

--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -27,7 +27,7 @@
 	<message key="plugins.generic.pln.settings.refresh">Refresh</message>
 	<message key="plugins.generic.pln.settings.refresh_help">If for some reason there are no terms listed above or you know these terms have been updated, click Refresh to update the terms listed above.</message>
 	
-	<message key="plugins.generic.pln.required.object_type">Please choose an deposit object type.</message>
+	<message key="plugins.generic.pln.required.object_type">Please choose a deposit object type.</message>
 	<message key="plugins.generic.pln.required.object_threshold">Please choose a deposit object threshold.</message>
 	<message key="plugins.generic.pln.required.terms_of_use_agreement">Agreement to the network's terms of use is required in order to deposit to the PLN.</message>
 	
@@ -54,7 +54,8 @@
 	<message key="plugins.generic.pln.status.no">No</message>
 
 	<message key="plugins.generic.pln.depositorTask.name">PKP PLN Depositor Task</message>
-	<message key="plugins.generic.pln.notifications.processing_for">Depositor processing for</message>
+	<message key="plugins.generic.pln.notifications.processing_for">Depositor processing for {$title}.</message>
+	<message key="plugins.generic.pln.notifications.getting_servicedocument">Getting service document.</message>
 	<message key="plugins.generic.pln.notifications.pln_not_accepting">The PKP PLN is not currently accepting deposits.</message>
 	<message key="plugins.generic.pln.notifications.pln_accepting">The PKP PLN is accepting deposits.</message>
 	<message key="plugins.generic.pln.notifications.check_status">Check the status of your deposits.</message>
@@ -65,6 +66,21 @@
 	<message key="plugins.generic.pln.notifications.zip_missing">ZipArchive support must be enabled to proceed.</message>
 	<message key="plugins.generic.pln.notifications.issn_setting">Your journal must have an ISSN before you can agree to the terms of service. You can enter the ISSN on the Journal Settings page. Once the journal ISSN is entered, the terms of service will be shown below.</message>
 	<message key="plugins.generic.pln.notifications.tar_missing">Your system must have a tar executable.</message>
+	
+	<message key="plugins.generic.pln.error.network.servicedocument">Network error {$error} connecting to the PLN to get the service document.</message>
+	<message key="plugins.generic.pln.error.network.deposit">Network error {$error} connecting to the PLN to send the deposit.</message>
+	<message key="plugins.generic.pln.error.http.servicedocument">PLN server returned HTTP error {$error} when attempting to get the service document.</message>
+	<message key="plugins.generic.pln.error.http.deposit">PLN server returned HTTP error {$error} when sending the deposit.</message>
+	<message key="plugins.generic.pln.error.depositor.missingpackage">Cannot find package file {$file}.</message>
+	<message key="plugins.generic.pln.error.depositor.export.articles.error">An error occured while exporting articles. The server's error log may have more information.</message>
+	<message key="plugins.generic.pln.error.depositor.export.issue.error">An error occured while exporting an issue. The server's error log may have more information.</message>
+	
+	<message key="plugins.generic.pln.depositor.statusupdates">Processing deposit status updates.</message>
+	<message key="plugins.generic.pln.depositor.updatedcontent">Processing updated content.</message>
+	<message key="plugins.generic.pln.depositor.newcontent">Processing new content.</message>
+	<message key="plugins.generic.pln.depositor.packagingdeposits">Packaging content for deposit.</message>
+	<message key="plugins.generic.pln.depositor.transferringdeposits">Sending deposits to the PLN.</message>
+
 	
 	<message key="plugins.generic.plngateway.displayName">PLN Gateway</message>
 	<message key="plugins.generic.plngateway.description">Reports PLN Status and recent article titles for the staging server.</message>

--- a/plugins/generic/pln/pages/PLNHandler.inc.php
+++ b/plugins/generic/pln/pages/PLNHandler.inc.php
@@ -46,7 +46,7 @@ class PLNHandler extends Handler {
 		
 		if (!$deposit) return FALSE;
 		
-		$depositPackage = new DepositPackage($deposit);
+		$depositPackage = new DepositPackage($deposit, null);
 		$depositBag = $depositPackage->getPackageFilePath();
 		
 		if (!$fileManager->fileExists($depositBag)) return FALSE;


### PR DESCRIPTION
 * Add logging to Depositor task, to log process as the task runs.
 * Pass the scheduled task to DepositPackage, so its errors can be
   logged to the scheduledTaskLogs directory.
 * Add a task member to DepositPackage. If the object was created by a
   scheduled task, it will send log messages to the scheduledTaskLogs
   directory. Otherwise they are sent to error_log().
 * Add a bunch of error logging to DepositPackage.
 * Make sure that the plugin uses network error messages or HTTP
   response codes as appropriate.
 * Create locale keys for log messages.

closes pkp/pkp-lib#599