### PR TITLE
Add ID attributes to the checkboxes in the pln settings form.

### DIFF
--- a/plugins/generic/pln/templates/settings.tpl
+++ b/plugins/generic/pln/templates/settings.tpl
@@ -27,7 +27,7 @@
 					{if $hasIssn}
 						{foreach name=terms from=$terms_of_use key=term_name item=term_data}
 							<p>{$term_data.term}</p>
-							<input type="checkbox" name="terms_agreed[{$term_name|escape}]" value="1"{if $terms_of_use_agreement[$term_name]} checked{/if}><label class="agree" for="terms_agreed[{$term_name|escape}]">{translate key="plugins.generic.pln.settings.terms_of_use_agree"}</label>
+							<input type="checkbox" name="terms_agreed[{$term_name|escape}]" id="terms_agreed[{$term_name|escape}]" value="1"{if $terms_of_use_agreement[$term_name]} checked{/if}><label class="agree" for="terms_agreed[{$term_name|escape}]">{translate key="plugins.generic.pln.settings.terms_of_use_agree"}</label>
 							{if !$smarty.foreach.terms.last }<div class="separator">&nbsp;</div>{/if}
 						{/foreach}
 					{else}


### PR DESCRIPTION
Makes the labels clickable.

fixes pkp/pkp-lib#611