### PR TITLE
Clean up the deposits page handler a little.

### DIFF
--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -78,6 +78,9 @@
 	<message key="plugins.generic.pln.error.depositor.missingpackage">Cannot find package file {$file}.</message>
 	<message key="plugins.generic.pln.error.depositor.export.articles.error">An error occured while exporting articles. The server's error log may have more information.</message>
 	<message key="plugins.generic.pln.error.depositor.export.issue.error">An error occured while exporting an issue. The server's error log may have more information.</message>
+	<message key="plugins.generic.pln.error.handler.uuid.invalid">The requested UUID is not valid or is not formatted correctly.</message>
+	<message key="plugins.generic.pln.error.handler.uuid.notfound">There is no deposit with the requested UUID.</message>
+	<message key="plugins.generic.pln.error.handler.file.notfound">The deposit file cannot be found. It may not have been packaged yet, or the package may have been removed.</message>
 
 	<message key="plugins.generic.pln.depositor.statusupdates">Processing deposit status updates.</message>
 	<message key="plugins.generic.pln.depositor.updatedcontent">Processing updated content.</message>

--- a/plugins/generic/pln/pages/PLNHandler.inc.php
+++ b/plugins/generic/pln/pages/PLNHandler.inc.php
@@ -33,28 +33,37 @@ class PLNHandler extends Handler {
 	 */
 	function deposits($args, &$request) {
 		$journal =& $request->getJournal();
-		$plnPlugin =& PluginRegistry::getPlugin('generic', PLN_PLUGIN_NAME);
 		$depositDao =& DAORegistry::getDAO('DepositDAO');
 		$fileManager = new FileManager();
+		$dispatcher = $request->getDispatcher();
 		
 		$depositUuid = (!isset($args[0]) || empty($args[0])) ? null : $args[0];
 
 		// sanitize the input
-		if (!preg_match('/^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$/',$depositUuid)) return FALSE;
+		if (!preg_match('/^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$/',$depositUuid)) {
+			error_log(__("plugins.generic.pln.error.handler.uuid.invalid"));
+			$dispatcher->handle404();
+			return FALSE;
+		}
 		
 		$deposit =& $depositDao->getDepositByUUID($journal->getId(),$depositUuid);
 		
-		if (!$deposit) return FALSE;
+		if (!$deposit) {
+			error_log(__("plugins.generic.pln.error.handler.uuid.notfound"));
+			$dispatcher->handle404();
+			return FALSE;
+		}
 		
 		$depositPackage = new DepositPackage($deposit, null);
 		$depositBag = $depositPackage->getPackageFilePath();
 		
-		if (!$fileManager->fileExists($depositBag)) return FALSE;
+		if (!$fileManager->fileExists($depositBag)) {
+			error_log("plugins.generic.pln.error.handler.file.notfound");
+			$dispatcher->handle404();
+			return FALSE;
+		}
 				
-		//TODO: Additional check here for journal UUID in HTTP header from staging server
-		
-		return $fileManager->downloadFile($depositBag, mime_content_type($depositBag), TRUE);
-		
+		return $fileManager->downloadFile($depositBag, mime_content_type($depositBag), TRUE);		
 	}
 
 	/**


### PR DESCRIPTION
 * Remove unused variable
 * Add error logging
 * Return 404 errors when deposits aren't available or the UUID looks
   bogus.
 * Add locale keys for error messages in the error log.

Fixes pkp/pkp-lib#612