### PR TITLE
Use deposit UUID as name of working directory when creating deposit

### DIFF
--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -221,7 +221,7 @@ class DepositPackage {
 		$depositObjects = $this->_deposit->getDepositObjects();
 		
 		// set up folder and file locations
-		$bagDir = $this->getDepositDir() . DIRECTORY_SEPARATOR . 'bag';
+		$bagDir = $this->getDepositDir() . DIRECTORY_SEPARATOR . $this->_deposit->getUUID();
 		$packageFile = $this->getPackageFilePath();
 		$exportFile =  tempnam(sys_get_temp_dir(), 'ojs-pln-export-');
 		$termsFile =  tempnam(sys_get_temp_dir(), 'ojs-pln-terms-');


### PR DESCRIPTION
Remove hardcoded 'bag' and use UUID in its place.

Closes pkp/pkp-lib#621