### PR TITLE
pkp/pkp-lib#653: don't try to delete a non-existent issue in the native importexport plugin's cleanup phase after error.

### DIFF
--- a/plugins/importexport/native/NativeImportDom.inc.php
+++ b/plugins/importexport/native/NativeImportDom.inc.php
@@ -71,8 +71,13 @@ class NativeImportDom {
 			// successfully created.
 			NativeImportDom::cleanupFailure ($dependentItems);
 			$issueDao =& DAORegistry::getDAO('IssueDAO');
+			// Deprecate this call.  Shouldn't this be handled entirely by cleanupFailure($dependentItems) above?
+			// passing an already deleted issue causes a fatal error when instanciating a new IssueFileManager()
 			foreach ($issues as $issue) {
-				$issueDao->deleteIssue($issue);
+				if ($issueDao->getIssueById($issue->getId())) {
+					if (Config::getVar('debug', 'deprecation_warnings')) trigger_error('Deprecated functionality.  Trace and report this use-case.');
+					$issueDao->deleteIssue($issue);
+				}
 			}
 			return false;
 		}


### PR DESCRIPTION
https://github.com/pkp/pkp-lib/issues/653

I think the whole `foreach ($issues as $issue)` can be deleted, but I'm not confident.
