### PR TITLE
small bug fixes from making the screen cast.

### DIFF
--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -55,7 +55,7 @@ class DepositPackage {
 	 */
 	function _logMessage($message) {
 		if($this->_task) {
-			$task->addExecutionLogEntry($message, SCHEDULED_TASK_MESSAGE_TYPE_NOTICE);
+			$this->_task->addExecutionLogEntry($message, SCHEDULED_TASK_MESSAGE_TYPE_NOTICE);
 		} else {
 			error_log($message);
 		}
@@ -347,7 +347,7 @@ class DepositPackage {
 			if($result['status'] == FALSE) {
 				$this->_logMessage(__("plugins.generic.pln.error.network.deposit", array('error' => $result['error'])));
 			} else {
-				$this->_logMessage(__("plugins.generic.pln.error.http.deposit", array('error' => $result['error'])));
+				$this->_logMessage(__("plugins.generic.pln.error.http.deposit", array('error' => $result['status'])));
 			}
 			$this->_deposit->setRemoteFailureStatus();
 			$this->_deposit->setLastStatusDate(time());

--- a/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
@@ -140,9 +140,8 @@ class PLNSettingsForm extends Form {
 			return false;
 		if(isset($parts['user']) 
 				|| isset($parts['pass'])
-				|| (isset($parts['path']) && $parts['path'] != '/')
 				|| isset($parts['query'])
-				|| $parts['fragment']) {
+				|| isset($parts['fragment'])) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Fix pkp/pkp-lib#676

* Use $this instead of $task (undefined) when logging messages in
   DepositPackage.
* Log the HTTP status of an error when available in DepositPackage.
* Check that $parts['fragment'] is set explicitly in PLNSettingsForm,
   to prevent an error in the logs.
* Accept staging server URLs that include paths.