### PR TITLE
Style the PDF.js viewer galley page

### DIFF
--- a/plugins/themes/default/styles/pages/viewPdf.less
+++ b/plugins/themes/default/styles/pages/viewPdf.less
@@ -105,12 +105,19 @@
 	}
 }
 
-iframe.pdf {
+// @todo tie this to a class, not id
+#pdfCanvasContainer {
 	position: absolute;
-	z-index: 1;
+	top: 0;
+	left: 0;
+	right: 0;
 	bottom: 0;
-	width: 100%;
-	height: 100%;
-	padding-top: @line-header;
-	border: none;
+	overflow-y: hidden;
+
+	iframe {
+		width: 100%;
+		height: 100%;
+		padding-top: @line-header;
+		border: none;
+	}
 }


### PR DESCRIPTION
Full screen, no double scrollbars, etc. Probably needs some cross-browser testing.