### PR TITLE
Change DC11SchemaArticleAdapter to "proper" format creator's tag

### DIFF
--- a/plugins/metadata/dc11/filter/Dc11SchemaArticleAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaArticleAdapter.inc.php
@@ -86,13 +86,7 @@ class Dc11SchemaArticleAdapter extends MetadataDataObjectAdapter {
 		// Creator
 		$authors = $article->getAuthors();
 		foreach($authors as $author) {
-			$authorName = $author->getFullName(true);
-			$affiliation = $author->getLocalizedAffiliation();
-			if (!empty($affiliation)) {
-				$authorName .= '; ' . $affiliation;
-			}
-			$dc11Description->addStatement('dc:creator', $authorName);
-			unset($authorName);
+			$dc11Description->addStatement('dc:creator', $author->getFullName(true));
 		}
 
 		// Subject


### PR DESCRIPTION
//This PR is here to be discussed, since the devteam may disagree with my considerations and I may be wrong because I've only worked with VuFind and don't know if OHS would have this same problem.

The format of the DC for creator generated for OJS was 'authorname;affiliation', this causes stranges harvests from Vufind.

For example, same authors will be treated differently in VuFind if it harvest some articles from DSpace and others from OJS because the OJS's ones will have its creators declared as 'authorname;affiliation' instead of only 'authorname'.

We've also had problems with users writing wrongs affiliations and then causing a mess in everyone who harvest from us without considering the different creator tag with ';', but this kind of problem is not meant to be a proof of concept since it's bad user input.

Currently we have a VuFind harvesting a lot of OJS in Brazil (http://oasisbr.ibict.br/vufind/), and they seem to be troubleshooting this by forcing VuFind to get the creator field only until the ';'.

Making OJS export DC with a clean creator tag should make it easier for people to harvest from it, without making changes to VuFind or other harvesters.

Also, if you open the web page's source of an article that is on OJS [the XHTML], you'll find that the creator tag there will be clean [only the names].

And I think this PR will make OJS more compliant to DC usage as seem in
http://dublincore.org/documents/usageguide/elements.shtml#creator