### PR TITLE
Fix for the User XML Import's username creation function

### DIFF
--- a/plugins/importexport/users/UserXMLParser.inc.php
+++ b/plugins/importexport/users/UserXMLParser.inc.php
@@ -354,7 +354,7 @@ class UserXMLParser {
 		if (empty($baseUsername)) {
 			$baseUsername = String::regexp_replace('/[^A-Z0-9]/i', '', $user->getFirstName());
 		}
-		if (empty($username)) {
+		if (empty($baseUsername)) {
 			// Default username if we can't use the user's last or first name
 			$baseUsername = 'user';
 		}


### PR DESCRIPTION
The function wasn't correctly checking whether a firstname was in place before generating a username.
This was leading to a situation where imported users had "user1", "user2", etc. as their username.