### PR TITLE
Suppress warning from custom block plugin when new custom block has no content

### DIFF
--- a/plugins/generic/customBlockManager/CustomBlockPlugin.inc.php
+++ b/plugins/generic/customBlockManager/CustomBlockPlugin.inc.php
@@ -192,7 +192,7 @@ class CustomBlockPlugin extends BlockPlugin {
 		$blockContent = $this->getSetting($journalId, 'blockContent');
 		$blockContentLocale = '';
 	
-		if (array_key_exists($locale, $blockContent)) {
+		if (is_array($blockContent) && array_key_exists($locale, $blockContent)) {
 			$blockContentLocale = $blockContent[$locale];
 		}
 


### PR DESCRIPTION
Fetch of block content can be empty at:
https://github.com/ulsdevteam/ojs/blob/090c3f257077d9057c17c44efb0266bf16640e0a/plugins/generic/customBlockManager/CustomBlockPlugin.inc.php#L192

Don't use `array_key_exists()` if $blockContent isn't an array.