### PR TITLE
fix - access to submission information even self registration is disabled

### DIFF
--- a/templates/about/index.tpl
+++ b/templates/about/index.tpl
@@ -51,7 +51,7 @@
 <div id="aboutSubmissions">
 <h3>{translate key="about.submissions"}</h3>
 <ul>
-	{if !$currentJournal->getSetting('disableUserReg')}<li><a href="{url op="submissions" anchor="onlineSubmissions"}">{translate key="about.onlineSubmissions"}</a></li>{/if}
+	<li><a href="{url op="submissions" anchor="onlineSubmissions"}">{translate key="about.onlineSubmissions"}</a></li>
 	{if $currentJournal->getLocalizedSetting('authorGuidelines') != ''}<li><a href="{url op="submissions" anchor="authorGuidelines"}">{translate key="about.authorGuidelines"}</a></li>{/if}
 	{if $currentJournal->getLocalizedSetting('copyrightNotice') != ''}<li><a href="{url op="submissions" anchor="copyrightNotice"}">{translate key="about.copyrightNotice"}</a></li>{/if}
 	{if $currentJournal->getLocalizedSetting('privacyStatement') != ''}<li><a href="{url op="submissions" anchor="privacyStatement"}">{translate key="about.privacyStatement"}</a></li>{/if}

--- a/templates/about/submissions.tpl
+++ b/templates/about/submissions.tpl
@@ -19,27 +19,27 @@
 {/if}
 
 <ul>
-	{if !$currentJournal->getSetting('disableUserReg')}<li id="linkDisableUserReg"><a href="{url page="about" op="submissions" anchor="onlineSubmissions"}">{translate key="about.onlineSubmissions"}</a></li>{/if}
+	<li id="linkDisableUserReg"><a href="{url page="about" op="submissions" anchor="onlineSubmissions"}">{translate key="about.onlineSubmissions"}</a></li>
 	{if $currentJournal->getLocalizedSetting('authorGuidelines') != ''}<li id="linkAuthorGuidelines"><a href="{url page="about" op="submissions" anchor="authorGuidelines"}">{translate key="about.authorGuidelines"}</a></li>{/if}
 	{if $currentJournal->getLocalizedSetting('copyrightNotice') != ''}<li id="linkCopyrightNotice"><a href="{url page="about" op="submissions" anchor="copyrightNotice"}">{translate key="about.copyrightNotice"}</a></li>{/if}
 	{if $currentJournal->getLocalizedSetting('privacyStatement') != ''}<li id="linkPrivacyStatement"><a href="{url page="about" op="submissions" anchor="privacyStatement"}">{translate key="about.privacyStatement"}</a></li>{/if}
 	{if $authorFees}<li id="linkAuthorFees"><a href="{url page="about" op="submissions" anchor="authorFees"}">{translate key="about.authorFees"}</a></li>{/if}
 </ul>
 
-{if !$currentJournal->getSetting('disableUserReg')}
-	<div id="onlineSubmissions">
-		<h3>{translate key="about.onlineSubmissions"}</h3>
-		<p>
-			{translate key="about.onlineSubmissions.haveAccount" journalTitle=$siteTitle|escape}<br />
-			<a href="{url page="login"}" class="action">{translate key="about.onlineSubmissions.login"}</a>
-		</p>
+<div id="onlineSubmissions">
+	<h3>{translate key="about.onlineSubmissions"}</h3>
+	<p>
+		{translate key="about.onlineSubmissions.haveAccount" journalTitle=$siteTitle|escape}<br />
+		<a href="{url page="login"}" class="action">{translate key="about.onlineSubmissions.login"}</a>
+	</p>
+	{if !$currentJournal->getSetting('disableUserReg')}
 		<p>
 			{translate key="about.onlineSubmissions.needAccount"}<br />
 			<a href="{url page="user" op="register"}" class="action">{translate key="about.onlineSubmissions.registration"}</a>
 		</p>
 		<p>{translate key="about.onlineSubmissions.registrationRequired"}</p>
-	</div>
-{/if}
+	{/if}
+</div>
 
 <div class="separator">&nbsp;</div>
 


### PR DESCRIPTION
Now, when the user doesn't have the ability to self registration, the user doesn't have access to the Online Submissions (index of about template). 

I think that users should have access to it. In "Online Submissions" template the only thing that should be cutted is the Self-Registration, but the other information could be relevant (Submission Preparation Checklist, Privacy statement ...) because the user could be registered by the Journal Manager.

![submissions](https://cloud.githubusercontent.com/assets/206690/9757662/41d94610-56e2-11e5-9b13-b4759d6fe7d9.jpg)
