### PR TITLE
Correctly set date_assigned and date_notified in EditAssignments

### DIFF
--- a/classes/submission/editAssignment/EditAssignment.inc.php
+++ b/classes/submission/editAssignment/EditAssignment.inc.php
@@ -125,6 +125,22 @@ class EditAssignment extends DataObject {
 	}
 
 	/**
+	 * Get date editor assigned.
+	 * @return timestamp
+	 */
+	function getDateAssigned() {
+		return $this->getData('dateAssigned');
+	}
+
+	/**
+	 * Set date editor assigned.
+	 * @param $dateAssigned timestamp
+	 */
+	function setDateAssigned($dateAssigned) {
+		return $this->setData('dateAssigned', $dateAssigned);
+	}
+        
+	/**
 	 * Get date editor notified.
 	 * @return timestamp
 	 */

--- a/classes/submission/editAssignment/EditAssignmentDAO.inc.php
+++ b/classes/submission/editAssignment/EditAssignmentDAO.inc.php
@@ -144,6 +144,7 @@ class EditAssignmentDAO extends DAO {
 		$editAssignment->setIsEditor($row['editor_role_id']==ROLE_ID_EDITOR?1:0);
 		$editAssignment->setDateUnderway($this->datetimeFromDB($row['date_underway']));
 		$editAssignment->setDateNotified($this->datetimeFromDB($row['date_notified']));
+		$editAssignment->setDateAssigned($this->datetimeFromDB($row['date_assigned']));
 
 		HookRegistry::call('EditAssignmentDAO::_returnEditAssignmentFromRow', array(&$editAssignment, &$row));
 
@@ -157,9 +158,10 @@ class EditAssignmentDAO extends DAO {
 	function insertEditAssignment(&$editAssignment) {
 		$this->update(
 			sprintf('INSERT INTO edit_assignments
-				(article_id, editor_id, can_edit, can_review, date_notified, date_underway)
+				(article_id, editor_id, can_edit, can_review, date_assigned, date_notified, date_underway)
 				VALUES
-				(?, ?, ?, ?, %s, %s)',
+				(?, ?, ?, ?, %s, %s, %s)',
+				$this->datetimeToDB($editAssignment->getDateAssigned()),
 				$this->datetimeToDB($editAssignment->getDateNotified()),
 				$this->datetimeToDB($editAssignment->getDateUnderway())),
 			array(
@@ -185,9 +187,11 @@ class EditAssignmentDAO extends DAO {
 					editor_id = ?,
 					can_review = ?,
 					can_edit = ?,
+					date_assigned = %s,                                        
 					date_notified = %s,
 					date_underway = %s
 				WHERE edit_id = ?',
+				$this->datetimeToDB($editAssignment->getDateAssigned()),
 				$this->datetimeToDB($editAssignment->getDateNotified()),
 				$this->datetimeToDB($editAssignment->getDateUnderway())),
 			array(

--- a/classes/submission/editor/EditorAction.inc.php
+++ b/classes/submission/editor/EditorAction.inc.php
@@ -63,7 +63,8 @@ class EditorAction extends SectionEditorAction {
 
 			// Make the selected editor the new editor
 			$editAssignment->setEditorId($sectionEditorId);
-			$editAssignment->setDateNotified(Core::getCurrentDate());
+			$editAssignment->setDateAssigned(Core::getCurrentDate()); 
+			$editAssignment->setDateNotified((is_array($send) && isset($send['skip']))?null:Core::getCurrentDate());
 			$editAssignment->setDateUnderway(null);
 
 			$editAssignments =& $editorSubmission->getEditAssignments();


### PR DESCRIPTION
Currently, the date_assigned field in edit_assignments is always null and the date_notified field is set regardless if the SectionEditor is emailed or not about an edit assignment.  This change corrects this behavior by adding get/set methods for dateAssigned to the EditAssignment class and using them in the EditorAction class.