### PR TITLE
pkp/pkp-lib#741 Enable Google Analytics to extend the journal settings to the site level

### DIFF
--- a/plugins/generic/googleAnalytics/GoogleAnalyticsPlugin.inc.php
+++ b/plugins/generic/googleAnalytics/GoogleAnalyticsPlugin.inc.php
@@ -175,8 +175,12 @@ class GoogleAnalyticsPlugin extends GenericPlugin {
 
 		if (!empty($currentJournal)) {
 			$journal =& Request::getJournal();
-			$journalId = $journal->getId();
-			$googleAnalyticsSiteId = $this->getSetting($journalId, 'googleAnalyticsSiteId');
+			$contextId = $journal->getId();
+		} else {
+			$contextId = CONTEXT_ID_NONE;
+		}
+		if ($contextId || $this->getSetting($contextId, 'enabled')) {
+			$googleAnalyticsSiteId = $this->getSetting($contextId, 'googleAnalyticsSiteId');
 
 			$article = $templateMgr->get_template_vars('article');
 			if (Request::getRequestedPage() == 'article' && $article) {
@@ -190,7 +194,7 @@ class GoogleAnalyticsPlugin extends GenericPlugin {
 
 			if (!empty($googleAnalyticsSiteId) || !empty($authorAccounts)) {
 				$templateMgr->assign('googleAnalyticsSiteId', $googleAnalyticsSiteId);
-				$trackingCode = $this->getSetting($journalId, 'trackingCode');
+				$trackingCode = $this->getSetting($contextId, 'trackingCode');
 				if ($trackingCode == "ga") {
 					$output .= $templateMgr->fetch($this->getTemplatePath() . 'pageTagGa.tpl');
 				} elseif ($trackingCode == "urchin") {

--- a/plugins/generic/googleAnalytics/locale/en_US/locale.xml
+++ b/plugins/generic/googleAnalytics/locale/en_US/locale.xml
@@ -29,6 +29,12 @@
 	<message key="plugins.generic.googleAnalytics.manager.settings.urchin">Legacy tracking code (urchin.js)</message>
 	<message key="plugins.generic.googleAnalytics.manager.settings.ga">Legacy tracking code (ga.js)</message>
 	<message key="plugins.generic.googleAnalytics.manager.settings.analytics">New tracking code for Universal Analytics (analytics.js)</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.enableSite">Site Homepage</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.siteEnable">Enable this journal's settings on the site homepage</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.siteDisable">Disable existing settings on the site homepage</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.siteUnchanged">Leave the site hompage settings as-is</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.disabled">Disabled</message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.enableSiteInstructions">These settings can be applied when users browse at the site level as well.  If no settings are applied at the site level, Google Analytics will only be active at the journal level.</message>
 	<message key="plugins.generic.googleAnalytics.authorAccount">Google Analytics account number</message>
 	<message key="plugins.generic.googleAnalytics.authorAccount.description">To track published article readership using Google Analytics, enter an account number here (e.g. UA-xxxxxx-x).</message>
 	<message key="plugins.generic.googleAnalytics.authorAccountInvalid">One or more Google Analytics account numbers entered for submission authors are not valid.</message>

--- a/plugins/generic/googleAnalytics/settingsForm.tpl
+++ b/plugins/generic/googleAnalytics/settingsForm.tpl
@@ -32,16 +32,41 @@
 	</tr>
 	<tr valign="top">
 		<td width="20%" class="label">{fieldLabel name="trackingCode-urchin" required="true" key="plugins.generic.googleAnalytics.manager.settings.trackingCode"}</td>
-		<td width="80%" class="value"><input type="radio" name="trackingCode" id="trackingCode-urchin" value="urchin" {if $trackingCode eq "urchin" || $trackingCode eq ""}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.urchin"}</td>
+		<td width="80%" class="value">
+			<div><input type="radio" name="trackingCode" id="trackingCode-urchin" value="urchin" {if $trackingCode eq "urchin" || $trackingCode eq ""}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.urchin"}</div>
+			<div><input type="radio" name="trackingCode" id="trackingCode-ga" value="ga" {if $trackingCode eq "ga"}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.ga"}</div>
+			<div><input type="radio" name="trackingCode" id="trackingCode-analytics" value="analytics" {if $trackingCode eq "analytics"}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.analytics"}</div>
+		</td>
 	</tr>
+	{if $siteAdmin}
 	<tr valign="top">
-		<td width="20%" class="label">&nbsp;</td>
-		<td width="80%" class="value"><input type="radio" name="trackingCode" id="trackingCode-ga" value="ga" {if $trackingCode eq "ga"}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.ga"}</td>
+		<td width="20%" class="label">{fieldLabel name="enableSite" key="plugins.generic.googleAnalytics.manager.settings.enableSite"}</td>
+		<td width="80%" class="value">
+			<div>
+				<span class="instruct">{translate key="plugins.generic.googleAnalytics.manager.settings.enableSiteInstructions"}</span>
+			</div>
+			<div><input type="radio" name="enableSite" id="enableSite-true" value="{$smarty.const.GOOGLE_ANALYTICS_SITE_ENABLE}" {if $trackingCode eq GOOGLE_ANALYTICS_SITE_ENABLE}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.siteEnable"}</div>
+			<div>
+				<input type="radio" name="enableSite" id="enableSite-unchanged" value="{$smarty.const.GOOGLE_ANALYTICS_SITE_UNCHANGED}" {if $trackingCode eq GOOGLE_ANALYTICS_SITE_UNCHANGED || $trackingCode eq ""}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.siteUnchanged"}
+				<dl>
+					<dt>{translate key="plugins.generic.googleAnalytics.manager.settings.googleAnalyticsSiteId"}</dt>
+					<dd>{$siteGoogleAnalyticsSiteId}</dd>
+					<dt>{translate key="plugins.generic.googleAnalytics.manager.settings.trackingCode"}</dt>
+					<dd>
+						{if $siteTrackingCode eq "analytics"}{translate key="plugins.generic.googleAnalytics.manager.settings.analytics"}
+						{elseif $siteTrackingCode eq "ga"}{translate key="plugins.generic.googleAnalytics.manager.settings.ga"}
+						{elseif $siteTrackingCode eq "urchin"}{translate key="plugins.generic.googleAnalytics.manager.settings.urchin"}
+						{else}{$siteTrackingCode}
+						{/if}
+					</dd>
+				</dl>
+			</div>
+			{if $siteEnabled}
+			<div><input type="radio" name="enableSite" id="enableSite-false" value="{$smarty.const.GOOGLE_ANALYTICS_SITE_DISABLE}" {if $trackingCode eq GOOGLE_ANALYTICS_SITE_DISABLE}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.siteDisable"}</div>
+			{/if}
+		</td>
 	</tr>
-	<tr valign="top">
-		<td width="20%" class="label">&nbsp;</td>
-		<td width="80%" class="value"><input type="radio" name="trackingCode" id="trackingCode-analytics" value="analytics" {if $trackingCode eq "analytics"}checked="checked" {/if}/> {translate key="plugins.generic.googleAnalytics.manager.settings.analytics"}</td>
-	</tr>
+	{/if}
 </table>
 
 <br/>


### PR DESCRIPTION
See http://forum.pkp.sfu.ca/t/google-analytics-homepage/3561

This allows the Site Admin, when looking at a journal's Google Analytics settings, to enable those settings within the Site context as well.