### PR TITLE
pkp/pkp-lib#798: Ensure cached objects are returned if available in DOIExportDom / DataciteExportDom.

### DIFF
--- a/plugins/importexport/datacite/classes/DOIExportDom.inc.php
+++ b/plugins/importexport/datacite/classes/DOIExportDom.inc.php
@@ -336,6 +336,8 @@ class DOIExportDom {
 				$cache->markComplete('articlesByIssue', $issueId);
 				$articlesByIssue = $cache->get('articlesByIssue', $issueId);
 			}
+		} else {
+			$articlesByIssue = $cache->get('articlesByIssue', $issueId);
 		}
 		return $articlesByIssue;
 	}
@@ -361,6 +363,8 @@ class DOIExportDom {
 				$cache->markComplete('galleysByArticle', $articleId);
 				$galleysByArticle = $cache->get('galleysByArticle', $articleId);
 			}
+		} else {
+			$galleysByArticle = $cache->get('galleysByArticle', $articleId);
 		}
 		return $galleysByArticle;
 	}

--- a/plugins/importexport/datacite/classes/DataciteExportDom.inc.php
+++ b/plugins/importexport/datacite/classes/DataciteExportDom.inc.php
@@ -285,6 +285,8 @@ class DataciteExportDom extends DOIExportDom {
 				$cache->markComplete('suppFilesByArticle', $articleId);
 				$suppFilesByArticle = $cache->get('suppFilesByArticle', $articleId);
 			}
+		} else {
+			$suppFilesByArticle = $cache->get('suppFilesByArticle', $articleId);
 		}
 		return $suppFilesByArticle;
 	}


### PR DESCRIPTION
Addresses https://github.com/pkp/pkp-lib/issues/798, in a way that I think avoids the unset array and uses the cache when available.