### PR TITLE
pkp/pkp-lib#685 the opt-out block is not a site plugin

### DIFF
--- a/plugins/generic/usageStats/UsageStatsOptoutBlockPlugin.inc.php
+++ b/plugins/generic/usageStats/UsageStatsOptoutBlockPlugin.inc.php
@@ -63,6 +63,13 @@ class UsageStatsOptoutBlockPlugin extends BlockPlugin {
 	}
 
 	/**
+	* @see PKPPlugin::isSitePlugin()
+	*/
+	function isSitePlugin() {
+		return false;
+	}
+
+	/**
 	 * @see PKPPlugin::getPluginPath()
 	 */
 	function getPluginPath() {


### PR DESCRIPTION
S. https://github.com/pkp/pkp-lib/issues/685
This is a fix: the opt-out block plug-in should be only displayed on the journal pages.