### PR TITLE
pkp/pkp-lib#808: In Crossref Issue export page, make update/register link issue-dependent

### DIFF
--- a/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
+++ b/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
@@ -127,15 +127,15 @@ class CrossRefExportPlugin extends DOIExportPlugin {
 		while ($issue =& $issueIterator->next()) {
 			$issueArticles =& $publishedArticleDao->getPublishedArticles($issue->getId());
 			$issueArticlesNo = 0;
-			$allArticlesRegistered = true;
+			$allArticlesRegistered[$issue->getId()] = true;
 			foreach ($issueArticles as $issueArticle) {
-				$articleRegistered = $issueArticle->getData('crossref::registeredDoi');
+				$articleRegistered = $issueArticle->getData($this->getPluginId().'::registeredDoi');
 				if ($issueArticle->getPubId('doi') && !isset($articleRegistered)) {
 					if (!in_array($issue, $issues)) $issues[] = $issue;
 					$issueArticlesNo++;
 				}
-				if ($allArticlesRegistered && !isset($articleRegistered)) {
-					$allArticlesRegistered = false;
+				if ($allArticlesRegistered[$issue->getId()] && !isset($articleRegistered)) {
+					$allArticlesRegistered[$issue->getId()] = false;
 				}
 			}
 			$numArticles[$issue->getId()] = $issueArticlesNo;

--- a/plugins/importexport/crossref/templates/articles.tpl
+++ b/plugins/importexport/crossref/templates/articles.tpl
@@ -88,7 +88,7 @@
 			{else}
 				<tr>
 					<td colspan="2" align="left">{page_info iterator=$articles}</td>
-					<td colspan="3" align="right">{page_links anchor="articles" name="articles" iterator=$articles}</td>
+					<td colspan="4" align="right">{page_links anchor="articles" name="articles" iterator=$articles}</td>
 				</tr>
 			{/if}
 		</table>

--- a/plugins/importexport/crossref/templates/issues.tpl
+++ b/plugins/importexport/crossref/templates/issues.tpl
@@ -46,7 +46,7 @@
 
 			{iterate from=issues item=issue}
 				{assign var="issueId" value=$issue->getId()}
-				{if $allArticlesRegistered}
+				{if $allArticlesRegistered[$issueId]}
 					{capture assign="updateOrRegister"}{translate key="plugins.importexport.common.update"}{/capture}
 					{capture assign="updateOrRegisterDescription"}{translate key="plugins.importexport.common.updateDescription"}{/capture}
 				{else}


### PR DESCRIPTION
Resolves the first noted problem in https://github.com/pkp/pkp-lib/issues/808 .

Does not address the second issue of whether to display the registered issues or fix the "No issues" message.

Also abstracts the check on the "*pluginname*::registeredDoi" setting so that plugins which extend this plugin will be able to function correctly.
