### PR TITLE
pkp/pkp-lib#869: Only show plugin install/upgrade/delete options in plugin management if filesystem permissions allow for it.

### DIFF
--- a/pages/manager/PluginHandler.inc.php
+++ b/pages/manager/PluginHandler.inc.php
@@ -68,6 +68,21 @@ class PluginHandler extends ManagerHandler {
 		$templateMgr->assign('helpTopicId', 'journal.managementPages.plugins');
 
 		$site =& $request->getSite();
+		$pluginDir = dirname(dirname(dirname(__FILE__))).'/plugins/';
+		// Don't show the install link unless something can be installed somewhere
+		$preventPluginInstall = true;
+		// must be able to write into one of the existing category directories
+		foreach (glob($pluginDir.'*', GLOB_ONLYDIR) as $file) {
+			if (is_writable($file)) {
+				$preventPluginInstall = false;
+			}
+		}
+		// or create a new category directory (unlikely)
+		if (is_writable($pluginDir)) {
+			$preventPluginInstall = false;
+		}
+		$templateMgr->assign('preventPluginInstall', $preventPluginInstall);
+
 		$preventManagerPluginManagement = $site->getSetting('preventManagerPluginManagement');
 		$templateMgr->assign('preventManagerPluginManagement', !Validation::isSiteAdmin() && $preventManagerPluginManagement);
 

--- a/templates/manager/plugins/plugins.tpl
+++ b/templates/manager/plugins/plugins.tpl
@@ -23,7 +23,7 @@
 		{/foreach}
 	</ul>
 
-	{if !$preventManagerPluginManagement}
+	{if !$preventManagerPluginManagement && !$preventPluginInstall}
 		<ul id="pluginManagement">
 			<li><b><a href="{url op="managePlugins" path=install}">{translate key="manager.plugins.install"}</a></b></li>
 		</ul>
@@ -59,7 +59,7 @@
 					<a class="action" href="{url op="plugin" path=$category|to_array:$plugin->getName():$verb[0]}">{$verb[1]|escape}</a>&nbsp;
 				{/foreach}
 			{/if}
-			{if $plugin->getCurrentVersion() && !$preventManagerPluginManagement}
+			{if $plugin->getPluginPathIsWritable() && $plugin->getCurrentVersion() && !$preventManagerPluginManagement}
 				{assign var=pluginInstallName value=$plugin->getPluginPath()|basename}
 				<a class="action" href="{url op="managePlugins" path="upgrade"|to_array:$category:$pluginInstallName}">{translate key="manager.plugins.upgrade"}</a>&nbsp;
 				<a class="action" href="{url op="managePlugins" path="delete"|to_array:$category:$pluginInstallName}">{translate key="manager.plugins.delete"}</a>&nbsp;


### PR DESCRIPTION
Iterate each directory under plugins and examine the plugins directory itself to see if "Install" should be shown.

Poll each plugin to see if "Upgrade" and "Delete" should be shown.
