### PR TITLE
warn if the acron plugin is not enabled.

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -329,6 +329,12 @@ class PLNPlugin extends GenericPlugin {
 				$this->import('classes.form.PLNSettingsForm');
 				$form = new PLNSettingsForm($this, $journal->getId());
 				
+				$application =& PKPApplication::getApplication();
+				$products =& $application->getEnabledProducts('plugins.generic');
+				if( ! isset($products['acron']) && ! Config::getVar('scheduled_tasks', false)) {
+					$templateMgr->assign('acronRequired', __('plugins.generic.pln.settings.acron_required'));
+				}
+				
 				if (Request::getUserVar('save')) {
 					$form->readInputData();
 					if ($form->validate()) {

--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -18,6 +18,7 @@
 	
 	<message key="plugins.generic.pln.settings_page">PKP PLN Plugin - Settings</message>
 	<message key="plugins.generic.pln.settings">Settings</message>
+	<message key="plugins.generic.pln.settings.acron_required">The PLN plugin requires either the Acron plugin or a periodic scheduling tools such as 'cron.'</message>
 	<message key="plugins.generic.pln.settings.saved">PKP PLN settings saved.</message>
 	<message key="plugins.generic.pln.settings.terms_of_use">Terms of Use</message>
 	<message key="plugins.generic.pln.settings.terms_of_use_help">As Primary Contact, I, in good faith, accept and confirm the following terms and conditions for participation in the Public Knowledge Project’s Private LOCKSS Network (PKP-PLN):</message>

--- a/plugins/generic/pln/templates/settings.tpl
+++ b/plugins/generic/pln/templates/settings.tpl
@@ -16,8 +16,10 @@
 <div id="plnSettings">
 	<form class="pkp_form" id="plnSettingsForm" method="post" action="{plugin_url path="settings"}">
 		{include file="common/formErrors.tpl"}
+		{if isset($acronRequired)}
+		<p><span class="pkp_form_error">{$acronRequired}</span>
+		{/if}
 		<table class="data">
-
 			<tr>
 				<td class="label">
 					{fieldLabel name="terms_of_use" key="plugins.generic.pln.settings.terms_of_use"}


### PR DESCRIPTION
The PLN plugin requires the Acron plugin, in order to check the service document, make deposits, and check the status of the deposits in the PLN.

Check if the Acron plugin is enabled, and show a warning on the settings form if it isn't.

Closes pkp/pkp-lib#875