### PR TITLE
Update the message about the PLN Staging URL

### DIFF
--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -30,7 +30,7 @@
 	<message key="plugins.generic.pln.settings.refresh">Refresh</message>
 	<message key="plugins.generic.pln.settings.refresh_help">If for some reason there are no terms listed above or you know these terms have been updated, click Refresh to update the terms listed above.</message>
 	<message key="plugins.generic.pln.settings.pln_network">PLN Network URL</message>
-	<message key="plugins.generic.pln.settings.pln_network_help">The URL of your network's staging server. Do not change this unless instructed to do so by someone from your network.</message>
+	<message key="plugins.generic.pln.settings.pln_network_help">The URL of your network's staging server. Do not change this unless instructed to do so by someone from your network. You do not need to create an account or login on this server.</message>
 	<message key="plugins.generic.pln.settings.pln_network_invalid">The specified URL is not valid. Please double-check the URL and try again.</message>
 	<message key="plugins.generic.pln.settings.pln_network_path_invalid">PLN Network URLs must include the scheme and host name, and may include a port number. They must not include paths, query strings, user names or passwords, or URL fragments.</message>
 


### PR DESCRIPTION
OJS journal managers don't need to create an account or login to
it. In general, they won't be able to do that at all.