### PR TITLE
Removed typo in statistics plugin (+ updated de_DE locale)

### DIFF
--- a/locale/de_DE/manager.xml
+++ b/locale/de_DE/manager.xml
@@ -510,14 +510,15 @@
 	</message>
 	<message key="manager.statistics.reports">Berichterstellung</message>
 	<message key="manager.statistics.reports.aggregationColumns">Erzeuge Statistiken nach:</message>
+	<message key="manager.statistics.reports.optionalColumns.description">Elemente, die kursiv gesetzt und mit * markiert sind, stehen für optionale Daten fürdie momentane Statistikmethode in OJS sind (gewählte Metrik). Abhängig von Ihrer Konfiguration des Statistik-Plug-Ins haben Sie diese Daten oder nicht.</message>
 	<message key="manager.statistics.reports.defaultReportTemplates">Standard-Berichtsvorlagen</message>
 	<message key="manager.statistics.reports.defaultReport.articleDownloads">Downloads von Artikeldateien</message>
 	<message key="manager.statistics.reports.defaultReport.articleAbstract">Aufrufe der Abstractseiten von Artikeln</message>
-	<message key="manager.statistics.reports.defaultReport.articleAbstractAndDownloads">Article Abstracts und Downloads</message>
+	<message key="manager.statistics.reports.defaultReport.articleAbstractAndDownloads">Abstractseiten und Downloads</message>
 	<message key="manager.statistics.reports.defaultReport.issueDownloads">Downloads von Ausgabendateien</message>
-	<message key="manager.statistics.reports.defaultReport.issueTableOfContents">Issue Aufrufe der Inhaltsverzeichnis-Seiten</message>
-	<message key="manager.statistics.reports.defaultReport.issueTableOfContentsAndDownloads">Issue table of contents and downloads</message>
-	<message key="manager.statistics.reports.defaultReport.journalIndexPageViews">Journal Startseiten-Aufrufe</message>
+	<message key="manager.statistics.reports.defaultReport.issueTableOfContents">Aufrufe der Inhaltsverzeichnis-Seiten</message>
+	<message key="manager.statistics.reports.defaultReport.issueTableOfContentsAndDownloads">Inhaltsverzeichnisse und Downloads</message>
+	<message key="manager.statistics.reports.defaultReport.journalIndexPageViews">Startseiten-Aufrufe</message>
 	<message key="manager.statistics.reports.description">OJS erstellt Berichte, die die Details der Verarbeitung von Beiträgen aus der Perspektive von Beiträgen, Redakteur/innen, Gutachter/innen sowie Rubriken über einen festgelegten Zeitraum nachzeichnen. Die Berichte werden im CSV-Format erstellt, die mit einer Tabellenkalkulation betrachtet werden können.</message>
 	<message key="manager.statistics.reports.generateReport">Benutzerdefinierten Bericht erzeugen</message>
 	<message key="manager.statistics.reports.advancedOptions">Erweiterte Einstellungen</message>
@@ -529,7 +530,7 @@
 	<message key="manager.statistics.reports.objectType">Objekttyp</message>
 	<message key="manager.statistics.reports.objectId">Objekt-ID</message>
 	<message key="manager.statistics.reports.objectId.label">Definieren Sie eine oder mehrere Objekt-ID, jeweils mit Komma getrennt (z.B. 1,2,3,4,5).</message>
-	<message key="manager.statistics.reports.today">Heute</message>
+	<message key="manager.statistics.reports.yesterday">Gestern</message>
 	<message key="manager.statistics.reports.currentMonth">Aktueller Monat</message>
 	<message key="manager.statistics.reports.orderBy">Sortieren nach</message>
 	<message key="manager.statistics.reports.orderDir">Richtung</message>

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -510,7 +510,7 @@
 	</message>
 	<message key="manager.statistics.reports">Report Generator</message>
 	<message key="manager.statistics.reports.aggregationColumns">Aggregate stats by:</message>
-	<message key="manager.statistics.reports.optinoalColumns.description">Items in italic and marked with * represents data that is optional to the current way of counting statistics in OJS (metric type). You might have that data or not, depending on your statistics plugin configuration.</message>
+	<message key="manager.statistics.reports.optionalColumns.description">Items in italic and marked with * represent data that is optional to the current way of counting statistics in OJS (metric type). You might have that data or not, depending on your statistics plugin configuration.</message>
 	<message key="manager.statistics.reports.defaultReportTemplates">Default report templates</message>
 	<message key="manager.statistics.reports.defaultReport.articleDownloads">Article file downloads</message>
 	<message key="manager.statistics.reports.defaultReport.articleAbstract">Article abstract page views</message>

--- a/plugins/reports/counter/locale/de_DE/ar1.xml
+++ b/plugins/reports/counter/locale/de_DE/ar1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * plugins/reports/counter/locale/de_DE/ar1.xml
+  *
+  * Copyright (c) 2013-2015 Simon Fraser University Library
+  * Copyright (c) 2003-2015 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  * Localization strings for the de_DE (Deutsch (Deutschland)) locale.
+  * Please contact Marco Tullney, marco.tullney@fu-berlin.de, with any questions regarding this translation.
+  -->
+ 
+<locale name="de_DE" full_name="Deutsch (Deutschland)">
+	<message key="plugins.reports.counter.ar1.title">Artikel-Bericht 1</message>
+</locale>

--- a/plugins/reports/counter/locale/de_DE/jr1.xml
+++ b/plugins/reports/counter/locale/de_DE/jr1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * plugins/reports/counter/locale/de_DE/jr1.xml
+  *
+  * Copyright (c) 2013-2015 Simon Fraser University Library
+  * Copyright (c) 2003-2015 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  * Localization strings for the de_DE (Deutsch (Deutschland)) locale.
+  * Please contact Marco Tullney, marco.tullney@fu-berlin.de, with any questions regarding this translation.
+  -->
+ 
+<locale name="de_DE" full_name="Deutsch (Deutschland)">
+	<message key="plugins.reports.counter.jr1.title">Zeitschriften-Bericht 1</message>
+</locale>

--- a/plugins/reports/counter/locale/de_DE/locale.xml
+++ b/plugins/reports/counter/locale/de_DE/locale.xml
@@ -10,10 +10,16 @@
   * Localization strings for the de_DE (Deutsch (Deutschland)) locale.
   * Please contact Marco Tullney, marco.tullney@fu-berlin.de, with any questions regarding this translation.
   -->
-  
+ 
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
-	<message key="plugins.reports.counter.description"><![CDATA[Das Counter-Plug-In ermöglicht die Aufzeichnung und <a href="http://www.projectcounter.org/about.html" target="_new">COUNTER</a>-entsprechende Wiedergabe der Webseitenaktivität.]]></message>
+	<message key="plugins.reports.counter.description"><![CDATA[Das Counter-Plug-In ermöglicht Berichte über die Zeitschriftenaktivität entsprechend dem <a href="http://www.projectcounter.org">COUNTER-Standard</a>. Diese Berichte allein machen eine Zeitschrift nicht COUNTER-kompatibel. Um Counter-Kompatibilität zu erreichen, beachten Sie die Anforderungen auf der Website des COUNTER-Projekts.]]></message>
 	<message key="plugins.reports.counter">COUNTER-Bericht</message>
+	<message key="plugins.reports.counter.release">COUNTER-Release</message>
+	<message key="plugins.reports.counter.olderReports">Ältere Site-Berichte</message>
+	<message key="plugins.reports.counter.error.badParameters">Die Berichtsparameter waren ungültig.</message>
+	<message key="plugins.reports.counter.error.badRequest">Die Berichtsabfrage war ungültig.</message>
+	<message key="plugins.reports.counter.error.noResults">Für diesen Bericht wurden keine Ergebnisse gefunden.</message>
+	<message key="plugins.reports.counter.error.noXML">Die Ergebnisse konnten nicht als XML formatiert werden.</message>
 	<message key="plugins.reports.counter.1a.introduction">Diese Links erzeugen COUNTER-reife Berichte, die auf dem veralteten Release 3 basieren. Benutzen Sie neuere Releases, falls möglich.</message>
 	<message key="plugins.reports.counter.1a.name">COUNTER Report JR1 (R3)</message>
 	<message key="plugins.reports.counter.1a.xml">XML-Version</message>
@@ -32,4 +38,5 @@
 	<message key="plugins.reports.counter.1a.totalForAllJournals">Gesamtsumme für alle Zeitschriften</message>
 	<message key="plugins.reports.counter.1a.anonymous">anonym</message>
 	<message key="plugins.reports.counter.legacyStats">Die Links unten erzeugen veraltete Berichte auf Basis der alten Plug-In-Daten. Wenn Sie aktuelle COUNTER-reife Berichte mit der neuen OJS-COUNTER-Metrik erzeugen wollen, benutzen Sie die Links oben.</message>
+	<message key="plugins.reports.counter.allCustomers">Alle Kund/innen</message>
 </locale>

--- a/templates/controllers/statistics/form/reportGeneratorForm.tpl
+++ b/templates/controllers/statistics/form/reportGeneratorForm.tpl
@@ -65,7 +65,7 @@
 			{fbvFormSection inline=true size=$fbvStyles.size.SMALL}
 				{fbvElement type="select" name="reportTemplate" id="reportTemplate" from=$reportTemplateOptions selected=$reportTemplate translate=false}
 			{/fbvFormSection}
-			{fbvFormSection for="aggregationColumns" label="manager.statistics.reports.aggregationColumns" description="manager.statistics.reports.optinoalColumns.description" list=true}
+			{fbvFormSection for="aggregationColumns" label="manager.statistics.reports.aggregationColumns" description="manager.statistics.reports.optionalColumns.description" list=true}
 				{fbvElement type="checkboxgroup" name="aggregationColumns" id="aggregationColumns" from=$aggregationOptions selected=$selectedAggregationOptions translate=false}
 			{/fbvFormSection}
 		{/fbvFormArea}
@@ -94,7 +94,7 @@
 	{capture assign="advancedOptionsContent"}
 		{fbvFormArea id="columnsFormArea" title="manager.statistics.reports.columns"}
 			<p>{translate key="manager.statistics.reports.columns.description"}</p>
-			{fbvFormSection description="manager.statistics.reports.optinoalColumns.description" inline=true size=$fbvStyles.size.MEDIUM}
+			{fbvFormSection description="manager.statistics.reports.optionalColumns.description" inline=true size=$fbvStyles.size.MEDIUM}
 				{fbvElement type="select" name="columns[]" id="columns" from=$columnsOptions multiple="multiple" selected=$columns translate=false required=true}
 			{/fbvFormSection}
 		{/fbvFormArea}
@@ -152,7 +152,7 @@
 		{/fbvFormArea}
 		
 		{fbvFormArea id="orderByFormArea" title="manager.statistics.reports.orderBy"}
-			{fbvFormSection description="manager.statistics.reports.optinoalColumns.description"}
+			{fbvFormSection description="manager.statistics.reports.optionalColumns.description"}
 				{foreach from=$orderColumnsOptions item=item key=key}
 					{fbvFormSection inline=true size=$fbvStyles.size.SMALL}
 						{fbvElement type="select" name="orderByColumn[]" id="orderByColumn-$key" from=$orderColumnsOptions defaultValue=0 defaultLabel="manager.statistics.reports.columns"|translate selected=$orderByColumn translate=false}


### PR DESCRIPTION
@beghelli, https://github.com/pkp/ojs/commit/9841786edc150436d57f0f338685cfdaa54c8eee introduced a typo in a key name: `manager.statistics.reports.optinoalColumns.description` instead of `manager.statistics.reports.optionalColumns.description`

Changed this in `locale/en_US/manager.xml` and `templates/controllers/statistics/form/reportGeneratorForm.tpl`

Also updated the de_DE locale according to these latest statistics plugin's updates.