### PR TITLE
Silence MySQL error 1055 (42000) warning about non-aggregated columns.

### DIFF
--- a/plugins/generic/pln/classes/DepositObjectDAO.inc.php
+++ b/plugins/generic/pln/classes/DepositObjectDAO.inc.php
@@ -112,7 +112,7 @@ class DepositObjectDAO extends DAO {
 				break;
 			case PLN_PLUGIN_DEPOSIT_OBJECT_ISSUE:
 				$result =& $this->retrieve(
-					'SELECT DISTINCT pdo.deposit_object_id, i.last_modified as issue_modified, a.last_modified as article_modified
+					'SELECT DISTINCT pdo.deposit_object_id, i.last_modified as issue_modified, max(a.last_modified) as article_modified
 					FROM issues i
 					LEFT JOIN pln_deposit_objects pdo ON pdo.object_id = i.issue_id
 					LEFT JOIN published_articles pa ON pa.issue_id = i.issue_id


### PR DESCRIPTION
Fixes pkp/pkp-lib#1038

max() seems to be the right aggregate function to use here, using the most recently modified date in a comparison later.
