### PR TITLE
fixed: acron plugin language, s/OCS/OJS

### DIFF
--- a/plugins/generic/acron/locale/ar_IQ/locale.xml
+++ b/plugins/generic/acron/locale/ar_IQ/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="ar_IQ" full_name="العربية">
 	<message key="plugins.generic.acron.name">إضافة Acron</message>
-	<message key="plugins.generic.acron.description"><![CDATA[هذه الإضافة تحاول تقليل إعتمادية OCS على أدوات الجدولة الدورية، مثل: 'cron.']]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[هذه الإضافة تحاول تقليل إعتمادية OJS على أدوات الجدولة الدورية، مثل: 'cron.']]></message>
 	<message key="plugins.generic.acron.enabled">إضافة Acron تم تمكينها.</message>
 	<message key="plugins.generic.acron.disabled">إضافة Acron تم تعطيلها.</message>
 

--- a/plugins/generic/acron/locale/ca_ES/locale.xml
+++ b/plugins/generic/acron/locale/ca_ES/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="ca_ES" full_name="Català">
 	<message key="plugins.generic.acron.name">Mòdul Acron</message>
-	<message key="plugins.generic.acron.description"><![CDATA[Aquest mòdul intenta reduir la dependència que tenen els OCS d'eines de planificació periòdica com ara «cron.»]]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[Aquest mòdul intenta reduir la dependència que tenen els OJS d'eines de planificació periòdica com ara «cron.»]]></message>
 	<message key="plugins.generic.acron.enabled">S'ha habilitat el mòdul Acron.</message>
 	<message key="plugins.generic.acron.disabled">S'ha deshabilitat el mòdul Acron.</message>
 

--- a/plugins/generic/acron/locale/cs_CZ/locale.xml
+++ b/plugins/generic/acron/locale/cs_CZ/locale.xml
@@ -15,7 +15,7 @@
  
 <locale name="cs_CZ" full_name="Čeština">
 	<message key="plugins.generic.acron.name">Doplněk Acron</message>
-	<message key="plugins.generic.acron.description">Doplněk omezuje závislost OCS na pravidelném spouštění naplánovaných úloh pomocí služby 'cron.'</message>
+	<message key="plugins.generic.acron.description">Doplněk omezuje závislost OJS na pravidelném spouštění naplánovaných úloh pomocí služby 'cron.'</message>
 	<message key="plugins.generic.acron.enabled">Doplněk Acron byl povolen.</message>
 	<message key="plugins.generic.acron.disabled">Doplněk Acron byl zakázán.</message>
  	<message key="plugins.generic.acron.reload">Znovu nahrát naplánované úlohy</message>

--- a/plugins/generic/acron/locale/de_DE/locale.xml
+++ b/plugins/generic/acron/locale/de_DE/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.generic.acron.name">Acron-Plug-In</message>
-	<message key="plugins.generic.acron.description"><![CDATA[Dieses Plug-In versucht, OCS' Abhängigkeit von Zeitplanungswerkzeugen wie 'cron' zu reduzieren.]]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[Dieses Plug-In versucht, OJS' Abhängigkeit von Zeitplanungswerkzeugen wie 'cron' zu reduzieren.]]></message>
 	<message key="plugins.generic.acron.enabled">Das Acron-Plugin ist aktiviert.</message>
 	<message key="plugins.generic.acron.disabled">Das Acron-Plugin ist deaktiviert.</message>
 

--- a/plugins/generic/acron/locale/en_US/locale.xml
+++ b/plugins/generic/acron/locale/en_US/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="en_US" full_name="U.S. English">
 	<message key="plugins.generic.acron.name">Acron Plugin</message>
-	<message key="plugins.generic.acron.description"><![CDATA[This plugin attempts to reduce the dependance of OCS on periodic scheduling tools such as 'cron.']]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[This plugin attempts to reduce the dependance of OJS on periodic scheduling tools such as 'cron.']]></message>
 	<message key="plugins.generic.acron.enabled">The Acron Plugin has been enabled.</message>
 	<message key="plugins.generic.acron.disabled">The Acron Plugin has been disabled.</message>
 

--- a/plugins/generic/acron/locale/es_ES/locale.xml
+++ b/plugins/generic/acron/locale/es_ES/locale.xml
@@ -15,7 +15,7 @@
  
 <locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.generic.acron.name">Módulo Acron</message>
-	<message key="plugins.generic.acron.description"><![CDATA[Este módulo intenta reducir la dependencia de OCS en herramientas de programación periódica, como "cron".]]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[Este módulo intenta reducir la dependencia de OJS en herramientas de programación periódica, como "cron".]]></message>
 	<message key="plugins.generic.acron.enabled">Se habilitó el módulo Acron.</message>
 	<message key="plugins.generic.acron.disabled">Se deshabilitó el módulo Acron.</message>
 

--- a/plugins/generic/acron/locale/eu_ES/locale.xml
+++ b/plugins/generic/acron/locale/eu_ES/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="eu_ES" full_name="Euskara">
 	<message key="plugins.generic.acron.name">Acron plugina</message>
-	<message key="plugins.generic.acron.description"><![CDATA[Plugin honen xedea OCSk 'cron' eta atazak programatzeko antzeko tresnekiko duen dependentzia murriztea da.]]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[Plugin honen xedea OJSk 'cron' eta atazak programatzeko antzeko tresnekiko duen dependentzia murriztea da.]]></message>
 
 	<message key="plugins.generic.acron.reload">Birkargatu ataza programatuak</message>
 	<message key="plugins.generic.acron.enabled">Acron plugin-a gaitu da.</message>

--- a/plugins/generic/acron/locale/fr_CA/locale.xml
+++ b/plugins/generic/acron/locale/fr_CA/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.generic.acron.name">Plugiciel Acron</message>
-	<message key="plugins.generic.acron.description">Ce plugiciel tente de réduire la dépendance d'OCS aux outils de planificiation périodique tel que 'cron.'</message>
+	<message key="plugins.generic.acron.description">Ce plugiciel tente de réduire la dépendance d'OJS aux outils de planificiation périodique tel que 'cron.'</message>
 
 	<message key="plugins.generic.acron.reload">Recharger les tâches planifiées</message>
 	<message key="plugins.generic.acron.enabled">Le plugiciel Acron a été activé.</message>

--- a/plugins/generic/acron/locale/fr_FR/locale.xml
+++ b/plugins/generic/acron/locale/fr_FR/locale.xml
@@ -14,7 +14,7 @@
 
 <locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.generic.acron.name">Plugin Acron</message>
-	<message key="plugins.generic.acron.description"><![CDATA[This plugin attempts to reduce the dependance of OCS on periodic scheduling tools such as 'cron.']]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[This plugin attempts to reduce the dependance of OJS on periodic scheduling tools such as 'cron.']]></message>
 
 	<message key="plugins.generic.acron.reload">Recharger des tâches programmées</message>
 	<message key="plugins.generic.acron.disabled">Le plugiciel Acron a été activé.</message>

--- a/plugins/generic/acron/locale/pt_BR/locale.xml
+++ b/plugins/generic/acron/locale/pt_BR/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.generic.acron.name">Plugin Acron</message>
-	<message key="plugins.generic.acron.description">Este plugin tem a intenção de reduzir a dependência do OCS em ferramentas de agendamento periódico, tais como a 'cron.'</message>
+	<message key="plugins.generic.acron.description">Este plugin tem a intenção de reduzir a dependência do OJS em ferramentas de agendamento periódico, tais como a 'cron.'</message>
 
 	<message key="plugins.generic.acron.reload">Recarregar Tarefas Agendadas</message>
 	<message key="plugins.generic.acron.disabled">O Plugin Acron foi desabilitado.</message>

--- a/plugins/generic/acron/locale/pt_PT/locale.xml
+++ b/plugins/generic/acron/locale/pt_PT/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.generic.acron.name">Plugin Acron</message>
-	<message key="plugins.generic.acron.description">Este plugin tem por objectivo reduzir a dependência do OCS em ferramentas de agendamento periódico, tais como a 'cron.'</message>
+	<message key="plugins.generic.acron.description">Este plugin tem por objectivo reduzir a dependência do OJS em ferramentas de agendamento periódico, tais como a 'cron.'</message>
 
 	<message key="plugins.generic.acron.reload">Recarregar Tarefas Agendadas</message>
 	<message key="plugins.generic.acron.enabled">O Plugin Acron foi activado.</message>

--- a/plugins/generic/acron/locale/ru_RU/locale.xml
+++ b/plugins/generic/acron/locale/ru_RU/locale.xml
@@ -15,7 +15,7 @@
  
 <locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.acron.name">Плагин «Acron»</message>
-	<message key="plugins.generic.acron.description"><![CDATA[Этот плагин пытается уменьшить зависимость OCS от инструментов периодического запуска по расписанию, таких как cron.]]></message>
+	<message key="plugins.generic.acron.description"><![CDATA[Этот плагин пытается уменьшить зависимость OJS от инструментов периодического запуска по расписанию, таких как cron.]]></message>
 	<message key="plugins.generic.acron.enabled">Плагин «Acron» был включен.</message>
 	<message key="plugins.generic.acron.disabled">Плагин «Acron» был отключен.</message>
 

--- a/plugins/generic/acron/locale/tr_TR/locale.xml
+++ b/plugins/generic/acron/locale/tr_TR/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.generic.acron.name">Acron Eklentisi</message>
-	<message key="plugins.generic.acron.description">This plugin attempts to reduce the dependance of OCS on periodic scheduling tools such as 'cron.'</message>
+	<message key="plugins.generic.acron.description">This plugin attempts to reduce the dependance of OJS on periodic scheduling tools such as 'cron.'</message>
 	<message key="plugins.generic.acron.enabled">Acron Eklentisi etkinleştirildi.</message>
 	<message key="plugins.generic.acron.disabled">Acron Eklentisi pasifleştirildi.</message>
 

--- a/plugins/generic/acron/locale/zh_CN/locale.xml
+++ b/plugins/generic/acron/locale/zh_CN/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.generic.acron.name">Acron插件</message>
-	<message key="plugins.generic.acron.description">该款插件试图减轻周期性调度工具如cron对OCS的依赖。”</message>
+	<message key="plugins.generic.acron.description">该款插件试图减轻周期性调度工具如cron对OJS的依赖。”</message>
 	<message key="plugins.generic.acron.enabled">Acron插件已启用</message>
 	<message key="plugins.generic.acron.disabled">Acron插件已被禁用</message>
 

--- a/plugins/generic/acron/locale/zh_TW/locale.xml
+++ b/plugins/generic/acron/locale/zh_TW/locale.xml
@@ -14,7 +14,7 @@
  
 <locale name="zh_TW" full_name="繁體中文">
 	<message key="plugins.generic.acron.name">Acron 外掛程式</message>
-	<message key="plugins.generic.acron.description">這個外掛程式可以用來降低 OCS 系統對於周期性行事曆工具 (例如 cron)的依賴性。</message>
+	<message key="plugins.generic.acron.description">這個外掛程式可以用來降低 OJS 系統對於周期性行事曆工具 (例如 cron)的依賴性。</message>
 
 	<message key="plugins.generic.acron.reload">重新載入行事曆中的工作</message>
 </locale>


### PR DESCRIPTION
acron plugin referred to "OCS" instead of "OJS"