### PR TITLE
pkp/pkp-lib#1087: Update Crossref schema for export to 4.3.6

### DIFF
--- a/plugins/importexport/crossref/classes/CrossRefExportDom.inc.php
+++ b/plugins/importexport/crossref/classes/CrossRefExportDom.inc.php
@@ -20,10 +20,10 @@ if (!class_exists('DOIExportDom')) { // Bug #7848
 
 // XML attributes
 define('CROSSREF_XMLNS_XSI' , 'http://www.w3.org/2001/XMLSchema-instance');
-define('CROSSREF_XMLNS' , 'http://www.crossref.org/schema/4.3.3');
-define('CROSSREF_VERSION' , '4.3.3');
-define('CROSSREF_XSI_SCHEMAVERSION' , '4.3.3');
-define('CROSSREF_XSI_SCHEMALOCATION' , 'http://www.crossref.org/schema/4.3.3 http://www.crossref.org/schema/deposit/crossref4.3.3.xsd');
+define('CROSSREF_XMLNS' , 'http://www.crossref.org/schema/4.3.6');
+define('CROSSREF_VERSION' , '4.3.6');
+define('CROSSREF_XSI_SCHEMAVERSION' , '4.3.6');
+define('CROSSREF_XSI_SCHEMALOCATION' , 'http://www.crossref.org/schema/4.3.6 http://www.crossref.org/schema/deposit/crossref4.3.6.xsd');
 
 class CrossRefExportDom extends DOIExportDom {
 
@@ -199,7 +199,7 @@ class CrossRefExportDom extends DOIExportDom {
 	 */
 	function &_generateDepositorDom(&$doc, $name, $email) {
 		$depositor =& XMLCustomWriter::createElement($doc, 'depositor');
-		XMLCustomWriter::createChildWithText($doc, $depositor, 'name', $name);
+		XMLCustomWriter::createChildWithText($doc, $depositor, 'depositor_name', $name);
 		XMLCustomWriter::createChildWithText($doc, $depositor, 'email_address', $email);
 
 		return $depositor;


### PR DESCRIPTION
We are primarily interested in:
>   4.3.5, 4.3.6 (PDF) 5/14/2015 added text/rtf as mime type
[Source](http://doi.crossref.org/schemas/common4.3.6.xsd)

There are a number of backwards compatible changes in 4.3.3 -> 4.3.6, and some *not* backwards compatible changes in the updated Common reference of 4.3.2 -> 4.3.6.

The only change we found in the common include that affected our export was depositor/name -> depositor/depositor_name, but others may exist.
