### PR TITLE
pkp/pkp-lib#1097: remove HTML and HTML entities from abstracts exported via CrossRef and PubMed plugins.

### DIFF
--- a/plugins/importexport/crossref/classes/CrossRefExportDom.inc.php
+++ b/plugins/importexport/crossref/classes/CrossRefExportDom.inc.php
@@ -340,7 +340,7 @@ class CrossRefExportDom extends DOIExportDom {
 		/* Abstracts */
 		if ($article->getAbstract($journal->getPrimaryLocale())) {
 			$abstractNode =& XMLCustomWriter::createElement($doc, 'jats:abstract');
-			XMLCustomWriter::createChildWithText($doc, $abstractNode, 'jats:p', $article->getAbstract($journal->getPrimaryLocale()));
+			XMLCustomWriter::createChildWithText($doc, $abstractNode, 'jats:p', String::html2utf(strip_tags($article->getAbstract($journal->getPrimaryLocale()))));
 			XMLCustomWriter::appendChild($journalArticleNode, $abstractNode);
 		}
 

--- a/plugins/importexport/pubmed/PubMedExportDom.inc.php
+++ b/plugins/importexport/pubmed/PubMedExportDom.inc.php
@@ -179,7 +179,7 @@ class PubMedExportDom {
 
 		/* --- Abstract --- */
 		if ($article->getAbstract($article->getLocale())) {
-			$abstractNode = XMLCustomWriter::createChildWithText($doc, $root, 'Abstract', strip_tags($article->getAbstract($article->getLocale())), false);
+			$abstractNode = XMLCustomWriter::createChildWithText($doc, $root, 'Abstract', String::html2utf(strip_tags($article->getAbstract($article->getLocale()))), false);
 		}
 
 		if ($subject = $article->getSubject($article->getLocale())) {


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-lib/issues/1097 by stripping HTML from the abstract.  A superior solution could perform a transform (as applicable) to JATS elements, but that is for https://github.com/pkp/pkp-lib/issues/1098.