### PR TITLE
Report plugin prerequisites in the ping response.

### DIFF
--- a/plugins/generic/pln/PLNGatewayPlugin.inc.php
+++ b/plugins/generic/pln/PLNGatewayPlugin.inc.php
@@ -131,6 +131,23 @@ class PLNGatewayPlugin extends GatewayPlugin {
 		} else {
 			$templateMgr->assign('termsAccepted', 'no');
 		}
+		
+		$application =& PKPApplication::getApplication();
+		$products =& $application->getEnabledProducts('plugins.generic');
+		$curlVersion = 'not installed';
+		if(function_exists('curl_version')) {
+			$versionArray = curl_version();
+			$curlVersion = $versionArray['version'];
+		}
+		$prerequisites = array(
+			'phpVersion' => PHP_VERSION,
+			'curlVersion' => $curlVersion,
+			'zipInstalled' => class_exists('ZipArchive') ? 'yes' : 'no',
+			'tarInstalled' => class_exists('Archive_Tar') ? 'yes' : 'no',
+			'acron' => isset($products['acron']) ? 'yes' : 'no',
+			'tasks' => Config::getVar('scheduled_tasks', false) ? 'yes' : 'no',
+		);
+		$templateMgr->assign_by_ref('prerequisites', $prerequisites);
 
 		$termKeys = array_keys($terms);
 		$termsDisplay = array();

--- a/plugins/generic/pln/ping.dtd
+++ b/plugins/generic/pln/ping.dtd
@@ -14,9 +14,18 @@
 <!ELEMENT ojsInfo (release)>
 <!ELEMENT release (#PCDATA)>
 
-<!ELEMENT pluginInfo (release, releaseDate, installed, current, terms)>
+<!ELEMENT pluginInfo (release, releaseDate, installed, current, prerequisites, terms)>
 <!ELEMENT releaseDate (#PCDATA)>
 <!ELEMENT current (#PCDATA)>
+
+<!ELEMENT prerequisites (phpVersion, curlVersion, zipInstalled, tarInstalled, acron, tasks)>
+<!ELEMENT phpVersion (#PCDATA)>
+<!ELEMENT curlVersion (#PCDATA)>
+<!ELEMENT zipInstalled (#PCDATA)>
+<!ELEMENT tarInstalled (#PCDATA)>
+<!ELEMENT acron (#PCDATA)>
+<!ELEMENT tasks (#PCDATA)>
+
 <!ELEMENT terms (term*)>
 		<!ATTLIST terms
 				termsAccepted (yes|no) #REQUIRED>

--- a/plugins/generic/pln/templates/ping.tpl
+++ b/plugins/generic/pln/templates/ping.tpl
@@ -8,6 +8,14 @@
 		<release>{$pluginVersion.release|escape}</release>
 		<releaseDate>{$pluginVersion.date|escape}</releaseDate>
 		<current>{$pluginVersion.version->getCurrent()|escape}</current>
+		<prerequisites>
+			<phpVersion>{$prerequisites.phpVersion|escape}</phpVersion>
+			<curlVersion>{$prerequisites.curlVersion|escape}</curlVersion>
+			<zipInstalled>{$prerequisites.zipInstalled|escape}</zipInstalled>
+			<tarInstalled>{$prerequisites.tarInstalled|escape}</tarInstalled>
+			<acron>{$prerequisites.acron|escape}</acron>
+			<tasks>{$prerequisites.tasks|escape}</tasks>
+		</prerequisites>
 		<terms termsAccepted="{$termsAccepted|escape}">
 			{iterate from=termsDisplay item=term}
 			<term key="{$term.key|escape}" updated="{$term.updated|escape}" accepted="{$term.accepted|escape}">{$term.term|escape}</term>


### PR DESCRIPTION
Some journals seem to stop contacting the PLN once they've been whitelisted. It's probably a problem of missing prerequisites, but we have no way to tell without asking the journal manager to look for log files, check the prerequisites, or do other things.

This PR will add the prerequisites to the ping response, so we can check directly.

/cc @mjordan
