### PR TITLE
Add a configurable URL pointing to documentation for the PLN status page

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -525,3 +525,4 @@ log_web_service_info = Off
 ; Journal Management > System Plugins > Generic Plugins > PKP PLN Plugin
 ; 
 ; pln_url = http://pkp-pln.lib.sfu.ca
+; pln_status_docs = http://pkp-pln.lib.sfu.ca/docs/status

--- a/docs/release-notes/README-2.4.8
+++ b/docs/release-notes/README-2.4.8
@@ -17,6 +17,9 @@ New config.inc.php parameters:
 		the LOCKSS network will be sent. See http://pkp.sfu.ca/pkp-lockss
 		for more details.
 
+	- locks:pln_status_docs - The URL of a page describing the PLN deposit
+		processing status table, and the terms used in it.
+
 New Features
 ------------
 

--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -22,6 +22,7 @@ define('PLN_PLUGIN_NAME','plnplugin');
 
 // defined here in case an upgrade doesn't pick up the default value.
 define('PLN_DEFAULT_NETWORK', 'http://pkp-pln.lib.sfu.ca');
+define('PLN_DEFAULT_STATUS_SUFFIX', '/docs/status');
 
 define('PLN_PLUGIN_HTTP_STATUS_OK', 200);
 define('PLN_PLUGIN_HTTP_STATUS_CREATED', 201);
@@ -197,6 +198,8 @@ class PLNPlugin extends GenericPlugin {
 				break;
 			case 'pln_network':
 				return Config::getVar('lockss', 'pln_url', PLN_DEFAULT_NETWORK);
+			case 'pln_status_docs':
+				return Config::getVar('lockss', 'pln_status_docs', Config::getVar('lockss', 'pln_url', PLN_DEFAULT_NETWORK) . PLN_DEFAULT_STATUS_SUFFIX);
 			default:
 				break;
 		}

--- a/plugins/generic/pln/classes/form/PLNStatusForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNStatusForm.inc.php
@@ -59,6 +59,7 @@ class PLNStatusForm extends Form {
 		$templateMgr->assign('deposits', $depositDao->getDepositsByJournalId($journal->getId(),$rangeInfo));
 		$templateMgr->assign('networkStatus', $networkStatus);
 		$templateMgr->assign('networkStatusMessage', $networkStatusMessage);
+		$templateMgr->assign('plnStatusDocs', $this->_plugin->getSetting($journal->getId(), 'pln_status_docs'));
 		parent::display();
 	}
 	

--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -43,6 +43,7 @@
 	<message key="plugins.generic.pln.status">Status</message>
 
 	<!-- status page table headers -->	
+	<message key="plugins.generic.pln.status.docs"><![CDATA[The PLN <a href="{$statusDocsUrl}">deposit statuses are described here</a>.]]></message>
 	<message key="plugins.generic.pln.status.id">ID</message>
 	<message key="plugins.generic.pln.status.type">Type</message>
 	<message key="plugins.generic.pln.status.items">Items</message>

--- a/plugins/generic/pln/templates/status.tpl
+++ b/plugins/generic/pln/templates/status.tpl
@@ -54,6 +54,7 @@
 			{/if}
 		</table>
 	</form>
+		<p>{translate key='plugins.generic.pln.status.docs' statusDocsUrl=$plnStatusDocs}</p>
 </div>
 
 {include file="common/footer.tpl"}


### PR DESCRIPTION
The URL defaults to $PLN_URL/docs/status.html where $PLN_URL is the
config setting locks:pln_network, and can be overridden with
locks:pln_status_docs.

Usually, that URL will be http://pkp-pln.lib.sfu.ca/docs/status (which
is 404 at the moment).

Closes pkp/pkp-lib#1045.