### PR TITLE
Check for missing prerequisites and report them in the plugin settings page

### DIFF
--- a/plugins/generic/pln/PLNPlugin.inc.php
+++ b/plugins/generic/pln/PLNPlugin.inc.php
@@ -369,13 +369,7 @@ class PLNPlugin extends GenericPlugin {
 				$templateMgr->register_function('plugin_url', array(&$this, 'smartyPluginUrl'));
 				$this->import('classes.form.PLNSettingsForm');
 				$form = new PLNSettingsForm($this, $journal->getId());
-				
-				$application =& PKPApplication::getApplication();
-				$products =& $application->getEnabledProducts('plugins.generic');
-				if( ! isset($products['acron']) && ! Config::getVar('scheduled_tasks', false)) {
-					$templateMgr->assign('acronRequired', __('plugins.generic.pln.settings.acron_required'));
-				}
-				
+
 				if (Request::getUserVar('save')) {
 					$form->readInputData();
 					if ($form->validate()) {
@@ -620,14 +614,29 @@ class PLNPlugin extends GenericPlugin {
 		return class_exists('ZipArchive');
 	}
         
-        /**
-         * Check if the Archive_Tar extension is installed and available. BagIt
-         * requires it, and will not function without it.
-         */
-        function tarInstalled() {
-                return class_exists('Archive_Tar');
-        }
-	
+	/**
+	 * Check if the Archive_Tar extension is installed and available. BagIt
+	 * requires it, and will not function without it.
+	 * 
+	 * @return boolean
+	 */
+	function tarInstalled() {
+		@include_once('Archive/Tar.php');
+		return class_exists('Archive_Tar');
+	}
+
+	/**
+	 * Check if acron is enabled, or if the scheduled_tasks config var is set.
+	 * The plugin needs to run periodically through one of those systems.
+	 * 
+	 * @return boolean
+	 */
+	function cronEnabled() {
+		$application =& PKPApplication::getApplication();
+		$products =& $application->getEnabledProducts('plugins.generic');
+		return isset($products['acron']) || Config::getVar('scheduled_tasks', false);
+	}
+		
 	/**
 	 * Get resource using CURL
 	 * @param $url string

--- a/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
+++ b/plugins/generic/pln/classes/form/PLNSettingsForm.inc.php
@@ -68,6 +68,36 @@ class PLNSettingsForm extends Form {
 			$this->setData('terms_of_use_agreement', $terms_agreed);
 		}
 	}
+	
+	/**
+	 * Check for the prerequisites for the plugin, and return a translated 
+	 * message for each missing requirement.
+	 * 
+	 * @return array
+	 */
+	function _checkPrerequisites() {
+		$messages = array();
+		
+		if( ! $this->_plugin->php5Installed()) {
+			// If php5 isn't available, then the other checks are not 
+			// useful.
+			$messages[] =  __('plugins.generic.pln.notifications.php5_missing');
+			return $messages;
+		}
+		if( ! @include_once('Archive/Tar.php')) {
+			$messages[] = __('plugins.generic.pln.notifications.archive_tar_missing');
+		}
+		if( ! $this->_plugin->curlInstalled()) {
+			$messages[] = __('plugins.generic.pln.notifications.curl_missing');
+		}
+		if( ! $this->_plugin->zipInstalled()) {
+			$messages = __('plugins.generic.pln.notifications.zip_missing');
+		}
+		if( ! $this->_plugin->cronEnabled()) {
+			$messages = __('plugins.generic.pln.settings.acron_required');
+		}
+		return $messages;
+	}
 
 	/**
 	 * @see Form::display()
@@ -86,6 +116,7 @@ class PLNSettingsForm extends Form {
 		}
 		$templateMgr =& TemplateManager::getManager();
 		$templateMgr->assign('hasIssn', $hasIssn);
+		$templateMgr->assign('prerequisitesMissing', $this->_checkPrerequisites());
 		$templateMgr->assign('journal_uuid', $this->_plugin->getSetting($this->_journalId, 'journal_uuid'));
 		$templateMgr->assign('terms_of_use', unserialize($this->_plugin->getSetting($this->_journalId, 'terms_of_use')));
 		$templateMgr->assign('terms_of_use_agreement', $this->getData('terms_of_use_agreement'));

--- a/plugins/generic/pln/locale/en_US/locale.xml
+++ b/plugins/generic/pln/locale/en_US/locale.xml
@@ -84,6 +84,7 @@
 	<message key="plugins.generic.pln.notifications.archive_tar_missing">The Archive_Tar PHP extension must be installed before the PKP PLN can be enabled.</message>
 	<message key="plugins.generic.pln.notifications.php5_missing">The PKP PLN requires PHP version 5 or higher.</message>
 
+	<message key="plugins.generic.pln.error.include.bagit">The BagIt library, which is included with OJS, cannot be loaded, probably due to a missing prerequisite.</message>
 	<message key="plugins.generic.pln.error.network.servicedocument">Network error {$error} connecting to the PLN to get the service document.</message>
 	<message key="plugins.generic.pln.error.network.deposit">Network error {$error} connecting to the PLN to send the deposit.</message>
 	<message key="plugins.generic.pln.error.network.swordstatement">Network error {$error} connecting to the PLN to get a status update for deposit.</message>

--- a/plugins/generic/pln/templates/settings.tpl
+++ b/plugins/generic/pln/templates/settings.tpl
@@ -12,13 +12,16 @@
 	{assign var="pageTitle" value="plugins.generic.pln.settings_page"}
 	{include file="common/header.tpl"}
 {/strip}
-
+		{if $prerequisitesMissing|@count > 0}
+			<ul>
+				{foreach from=$prerequisitesMissing item=message}
+					<li><span class='pkp_form_error'>{$message}</span></li>
+				{/foreach}
+			</ul>
+		{/if}
 <div id="plnSettings">
 	<form class="pkp_form" id="plnSettingsForm" method="post" action="{plugin_url path="settings"}">
 		{include file="common/formErrors.tpl"}
-		{if isset($acronRequired)}
-		<p><span class="pkp_form_error">{$acronRequired}</span>
-		{/if}
 		<table class="data">
 			<tr>
 				<td class="label">


### PR DESCRIPTION
 * Refactor checking for acron/scheduled tasks into a plugin method.
 * Check and report acron and the other prerequisites in a unified
   manner.
 * Add a locale key for bagit loading errors.
 * Be more careful about how the bagit library is imported, to prevent
   WSOD when Archive_Tar isn't available. Only import bagit as needed.

Fixes pkp/pkp-lib#1105

I'll add some notes to the commit below.