### PR TITLE
Add missing semicolon in JavaScript

### DIFF
--- a/plugins/pubIds/urn/js/checkNumber.js
+++ b/plugins/pubIds/urn/js/checkNumber.js
@@ -18,7 +18,7 @@
  *  the last number of the quotient before the decimal point is the check number.
  */
 function calculateCheckNo(urnPrefix) {
-	var urnSuffix = document.getElementById('urnSuffix').value
+    var urnSuffix = document.getElementById('urnSuffix').value;
     var urn = urnPrefix+urnSuffix;
     urn = urn.toLowerCase();
     


### PR DESCRIPTION
This issue was cleaned by PhpStorm.
Replace also a tab character by blanks.

Signed-off-by: Stefan Weil <sw@weilnetz.de>