### PR TITLE
Add reply-to headers to scheduled tasks

### DIFF
--- a/classes/tasks/OpenAccessNotification.inc.php
+++ b/classes/tasks/OpenAccessNotification.inc.php
@@ -42,8 +42,16 @@ class OpenAccessNotification extends ScheduledTask {
 			$email = new MailTemplate('OPEN_ACCESS_NOTIFY', $journal->getPrimaryLocale(), false, $journal, false, true);
 
 			$email->setSubject($email->getSubject($journal->getPrimaryLocale()));
-			$email->setReplyTo(null);
-			$email->addRecipient($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
+
+			$contactEmail = $journal->getSetting('contactEmail');
+			$contactName = $journal->getSetting('contactName');
+			if ($contactEmail != '' && $contactName != '') {
+				$email->setReplyTo($contactEmail, $contactName);
+			} else {
+				$email->setReplyTo(null);
+			}
+
+			$email->addRecipient($contactEmail, $contactName);
 
 			$paramArray = array(
 				'journalName' => $journal->getLocalizedTitle(),

--- a/classes/tasks/ReviewReminder.inc.php
+++ b/classes/tasks/ReviewReminder.inc.php
@@ -48,7 +48,15 @@ class ReviewReminder extends ScheduledTask {
 
 		$email = new ArticleMailTemplate($article, $reviewerAccessKeysEnabled ? $reminderType . '_ONECLICK' : $reminderType, $journal->getPrimaryLocale(), false, $journal, false, true);
 		$email->setJournal($journal);
-		$email->setReplyTo(null);
+
+		$contactEmail = $journal->getSetting('contactEmail');
+		$contactName = $journal->getSetting('contactName');
+		if ($contactEmail != '' && $contactName != '') {
+			$email->setReplyTo($contactEmail, $contactName);
+		} else {
+			$email->setReplyTo(null);
+		}
+
 		$email->addRecipient($reviewer->getEmail(), $reviewer->getFullName());
 		$email->setSubject($email->getSubject($journal->getPrimaryLocale()));
 		$email->setBody($email->getBody($journal->getPrimaryLocale()));


### PR DESCRIPTION
These two scheduled tasks specifically set the reply-to header to null which led to some rather broken sender envelopes.  Set the header to the primary contact for the journal instead.