### PR TITLE
pkp/pkp-lib#1175: allow variable locale file lists in Translator

### DIFF
--- a/plugins/generic/translator/TranslatorAction.inc.php
+++ b/plugins/generic/translator/TranslatorAction.inc.php
@@ -159,10 +159,10 @@ class TranslatorAction {
 				if (is_scalar($referenceLocaleFilenames)) $referenceLocaleFilenames = array($referenceLocaleFilenames);
 				$localeFilenames = $plugin->getLocaleFilename($locale);
 				if (is_scalar($localeFilenames)) $localeFilenames = array($localeFilenames);
-				assert(count($localeFilenames) == count($referenceLocaleFilenames));
-				foreach($referenceLocaleFilenames as $index => $referenceLocaleFilename) {
-					assert(isset($localeFilenames[$index]));
-					$localeFile = new LocaleFile($locale, $localeFilenames[$index]);
+				foreach($referenceLocaleFilenames as $referenceLocaleFilename) {
+					$localeFilename = $referenceLocaleFilename;
+					$localeFilename = str_replace('/'.$referenceLocale.'/', '/'.$locale.'/', $referenceLocaleFilename);
+					$localeFile = new LocaleFile($locale, $localeFilename);
 					$referenceLocaleFile = new LocaleFile($referenceLocale, $referenceLocaleFilename);
 					$errors = array_merge_recursive($errors, $localeFile->testLocale($referenceLocaleFile));
 					unset($localeFile);


### PR DESCRIPTION
Switch Translator plugin processing of plugin locale files from ordered array assumption to calculated names.

The `str_replace` is a weak assumption, but not as weak as the assumption of a consistently ordered list.