### PR TITLE
Remove duplicate translation key from objectsForReview

### DIFF
--- a/plugins/generic/objectsForReview/locale/ar_IQ/locale.xml
+++ b/plugins/generic/objectsForReview/locale/ar_IQ/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">للمحرر فقط. غير منشور كجزء من مكون للتحكيم.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">مكونات للتحكيم</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">مهام التحكيم</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">إختر</message>

--- a/plugins/generic/objectsForReview/locale/cs_CZ/locale.xml
+++ b/plugins/generic/objectsForReview/locale/cs_CZ/locale.xml
@@ -142,7 +142,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">Pouze pro editora. Nebude publikováno jako součást objektu pro recenzi.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Úkoly</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Vybrat</message>

--- a/plugins/generic/objectsForReview/locale/de_DE/locale.xml
+++ b/plugins/generic/objectsForReview/locale/de_DE/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">Nur für Redakteur/in. Wird nicht zusammen mit den Angaben zum Rezensionsobjekt aufgeführt.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objekte zur Rezension</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Zuteilungen</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Auswählen</message>

--- a/plugins/generic/objectsForReview/locale/en_US/locale.xml
+++ b/plugins/generic/objectsForReview/locale/en_US/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">For the editor only. Not published as part of the object for review.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Assignments</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Select</message>

--- a/plugins/generic/objectsForReview/locale/es_ES/locale.xml
+++ b/plugins/generic/objectsForReview/locale/es_ES/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">Sólo para el editor. No publicado como parte del objeto a revisar.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Asignaciones</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Seleccionar</message>

--- a/plugins/generic/objectsForReview/locale/fr_FR/locale.xml
+++ b/plugins/generic/objectsForReview/locale/fr_FR/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">Pour le rédacteur uniquement. Non publié comme partie intégrante du compte rendu de l'objet.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Assignations</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Sélectionner</message>

--- a/plugins/generic/objectsForReview/locale/nl_NL/locale.xml
+++ b/plugins/generic/objectsForReview/locale/nl_NL/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">Alleen voor de redacteur. Wordt niet gepubliceerd.</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Taken opnieuw laden</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Kies</message>

--- a/plugins/generic/objectsForReview/locale/ru_RU/locale.xml
+++ b/plugins/generic/objectsForReview/locale/ru_RU/locale.xml
@@ -142,7 +142,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">Только для редактора. Не будут публиковаться как часть объекта на рецензию.</message>
 
 	<!-- Управление назначениями объектов на рецензию со стороны редактора -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Объекты на рецензию</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Назначения</message>
 	<!--  Действия -->
 	<message key="plugins.generic.objectsForReview.editor.select">Выбрать</message>

--- a/plugins/generic/objectsForReview/locale/tr_TR/locale.xml
+++ b/plugins/generic/objectsForReview/locale/tr_TR/locale.xml
@@ -17,6 +17,7 @@
 	<message key="plugins.generic.objectsForReview.displayName">Nesneler için değerlendirme</message>
 
 	<!--  Editor -->
+	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 
 	<!-- Object Types Management -->
 
@@ -119,7 +120,6 @@
 
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">Atamalar</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">Seçim</message>

--- a/plugins/generic/objectsForReview/locale/zh_CN/locale.xml
+++ b/plugins/generic/objectsForReview/locale/zh_CN/locale.xml
@@ -141,7 +141,6 @@
 	<message key="plugins.generic.objectsForReview.objectForReviewAssignment.notesInstructions">仅限编辑。不会作为书评的一部分发表</message>
 
 	<!-- Objects For Review Assignments Management by Editor -->
-	<message key="plugins.generic.objectsForReview.editor.objectsForReview">Objects For Review</message>
 	<message key="plugins.generic.objectsForReview.editor.assignments">分配</message>
 	<!--  Actions -->
 	<message key="plugins.generic.objectsForReview.editor.select">选择</message>


### PR DESCRIPTION
While working on the Danish translation we found one key that seemingly could not be translated.
Inspecting the locale.xml file revealed a duplicate translation key as the cause of the problem.
This patch removes the duplicate key at the source and in also corrects the translations that this error has propagated into.