### PR TITLE
Check for mime_content_type in the PLN plugin before download.

### DIFF
--- a/plugins/generic/pln/pages/PLNHandler.inc.php
+++ b/plugins/generic/pln/pages/PLNHandler.inc.php
@@ -14,6 +14,7 @@
  */
 
 import('classes.handler.Handler');
+import('classes.core.String');
 
 class PLNHandler extends Handler {
 
@@ -62,8 +63,7 @@ class PLNHandler extends Handler {
 			$dispatcher->handle404();
 			return FALSE;
 		}
-				
-		return $fileManager->downloadFile($depositBag, mime_content_type($depositBag), TRUE);		
+		return $fileManager->downloadFile($depositBag, String::mime_content_type($depositBag), TRUE);		
 	}
 
 	/**


### PR DESCRIPTION
When streaming a download in the PLN plugin, check if the
mime_content_type function is available, fall back to finfo_open if
it's available, or fall back even further to no mime type.

Fixes pkp/pkp-lib#1242