### PR TITLE
removed (dead) link to Google Doc Viewer

### DIFF
--- a/plugins/generic/googleViewer/locale/ar_IQ/locale.xml
+++ b/plugins/generic/googleViewer/locale/ar_IQ/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="ar_IQ" full_name="العربية">
 	<message key="plugins.generic.googleViewer.name">إضافة معاينة مضمنة من Google</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[هذه الإضافة تستعمل خدمة <a href="https://docs.google.com/viewer">معاين الملفات من Google</a> لتضمين ملفات PDF في صفحة معاينة المقال.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[هذه الإضافة تستعمل خدمة معاين الملفات من Google لتضمين ملفات PDF في صفحة معاينة المقال.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/ca_ES/locale.xml
+++ b/plugins/generic/googleViewer/locale/ca_ES/locale.xml
@@ -14,5 +14,5 @@
 
 <locale name="ca_ES" full_name="Català">
 	<message key="plugins.generic.googleViewer.name">Mòdul de visor incrustat de Google Docs</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Aquest mòdul utilitza el servei del <a href="https://docs.google.com/viewer">visor de Google Docs</a> per a incrustar els PDFs a la pàgina de l'article.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Aquest mòdul utilitza el servei del visor de Google Docs per a incrustar els PDFs a la pàgina de l'article.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/cs_CZ/locale.xml
+++ b/plugins/generic/googleViewer/locale/cs_CZ/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="cs_CZ" full_name="Čeština">
 	<message key="plugins.generic.googleViewer.name">Plugin pro Google vložený prohlížeč dokumentů</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Tento plugin používá <a href="https://docs.google.com/viewer">Prohlížeč dokumentů Google</a> - službu na prohlížení PDFs v rámci stránky článku.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Tento plugin používá Prohlížeč dokumentů Google - službu na prohlížení PDFs v rámci stránky článku.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/da_DK/locale.xml
+++ b/plugins/generic/googleViewer/locale/da_DK/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="da_DK" full_name="Dansk">
 	<message key="plugins.generic.googleViewer.name">Indlejret Googlefremviser Plugin</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Dette plugin anvender <a href="https://docs.google.com/viewer">Google dokumentfremviser</a> service til indlejring af PDF-filer på artikelsiden.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Dette plugin anvender Google dokumentfremviser service til indlejring af PDF-filer på artikelsiden.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/de_DE/locale.xml
+++ b/plugins/generic/googleViewer/locale/de_DE/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.generic.googleViewer.name">Eingebetteter Google-Viewer</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Dieses Plug-In benutzt den Dienst <a href="https://docs.google.com/viewer">Google Docs Viewer</a>, um PDF-Dateien in der Artikelansicht einzubinden.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Dieses Plug-In benutzt den Dienst Google Docs Viewer, um PDF-Dateien in der Artikelansicht einzubinden.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/en_US/locale.xml
+++ b/plugins/generic/googleViewer/locale/en_US/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="en_US" full_name="U.S. English">
 	<message key="plugins.generic.googleViewer.name">Google embedded viewer Plugin</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[This plugin uses the <a href="https://docs.google.com/viewer">Google Docs Viewer</a> service to embed PDFs on the article view page.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[This plugin uses the Google Docs Viewer service to embed PDFs on the article view page.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/es_AR/locale.xml
+++ b/plugins/generic/googleViewer/locale/es_AR/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="es_AR" full_name="Español (Argentina)">
 	<message key="plugins.generic.googleViewer.name">Plugin de visor embebido de Google</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Este plugin usa el servicio <a href="https://docs.google.com/viewer">Google Docs Viewer</a> para embeber los PDF en la pagina de vista de artículo.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Este plugin usa el servicio Google Docs Viewer para embeber los PDF en la pagina de vista de artículo.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/es_ES/locale.xml
+++ b/plugins/generic/googleViewer/locale/es_ES/locale.xml
@@ -14,5 +14,5 @@
 
 <locale name="es_ES" full_name="Español (España)">
 	<message key="plugins.generic.googleViewer.name">Módulo de visualización incrustrada de Google</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Este módulo utiliza el servicio de <a href="https://docs.google.com/viewer">visualización de Google Docs </a> para incrustar PDFs en la página de visualización del artículo.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Este módulo utiliza el servicio de visualización de Google Docs para incrustar PDFs en la página de visualización del artículo.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/eu_ES/locale.xml
+++ b/plugins/generic/googleViewer/locale/eu_ES/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="eu_ES" full_name="Euskara">
 	<message key="plugins.generic.googleViewer.name">Googlen txertatutako ikustaile plugina</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Plugin honek <a href="https://docs.google.com/viewer">Google Docs Viewer</a> zerbitzua erabiltzen du PDFak txertatzeko artikulua bistaratzen den orrian.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Plugin honek Google Docs Viewer zerbitzua erabiltzen du PDFak txertatzeko artikulua bistaratzen den orrian.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/fr_CA/locale.xml
+++ b/plugins/generic/googleViewer/locale/fr_CA/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="fr_CA" full_name="Français (Canada)">
 	<message key="plugins.generic.googleViewer.name">Plugiciel de visualisation Google incorporé</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Ce plugiciel utilise le  service<a href="https://docs.google.com/viewer">Google Docs Viewer</a> pour incorporer des PDFs dans la page de l'article.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Ce plugiciel utilise le  service Google Docs Viewer pour incorporer des PDFs dans la page de l'article.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/fr_FR/locale.xml
+++ b/plugins/generic/googleViewer/locale/fr_FR/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="fr_FR" full_name="Français (France)">
 	<message key="plugins.generic.googleViewer.name">Plugiciel de visualisation Google incorporé</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Ce plugiciel utilise le  service<a href="https://docs.google.com/viewer">Google Docs Viewer</a> pour incorporer des PDFs dans la page de l'article.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Ce plugiciel utilise le  service Google Docs Viewer pour incorporer des PDFs dans la page de l'article.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/it_IT/locale.xml
+++ b/plugins/generic/googleViewer/locale/it_IT/locale.xml
@@ -14,5 +14,5 @@
 
 <locale name="it_IT" full_name="Italiano">
 	<message key="plugins.generic.googleViewer.name">Plugin del visualizzatore integrato Google</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Questo plugin utilizza il  <a href='https://docs.google.com/viewer'>visualizzatore Google Docs </a> per mostrare i file nella pagina di ciascun articolo.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Questo plugin utilizza il visualizzatore Google Docs  per mostrare i file nella pagina di ciascun articolo.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/nl_NL/locale.xml
+++ b/plugins/generic/googleViewer/locale/nl_NL/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="nl_NL" full_name="Nederlands">
 	<message key="plugins.generic.googleViewer.name">Google embedded viewer Plugin</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Deze plugin gebruikt de  <a href='https://docs.google.com/viewer'>Google Docs Viewer</a> om PDF's te tonen op de artikelpagina.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Deze plugin gebruikt de Google Docs Viewer om PDF's te tonen op de artikelpagina.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/pt_BR/locale.xml
+++ b/plugins/generic/googleViewer/locale/pt_BR/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.generic.googleViewer.name">Plugin de visualização Google embutido</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Este plugin usa o servço <a href='https://docs.google.com/viewer'>Visualiador Google Docs</a> para embutir PDFs na página do artigo.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Este plugin usa o servço Visualiador Google Docs para embutir PDFs na página do artigo.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/ru_RU/locale.xml
+++ b/plugins/generic/googleViewer/locale/ru_RU/locale.xml
@@ -14,5 +14,5 @@
 
 <locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.googleViewer.name">Плагин «Встроенный просмотр Google»</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Этот плагин использует службу <a href="https://docs.google.com/viewer">«Средство просмотра Google Документы»</a> для встраивания PDF-файлов на страницу просмотра статьи.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Этот плагин использует службу «Средство просмотра Google Документы» для встраивания PDF-файлов на страницу просмотра статьи.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/sr_SR/locale.xml
+++ b/plugins/generic/googleViewer/locale/sr_SR/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.generic.googleViewer.name">Google dokument pregledač</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Ovaj dodatak koristi <a href="https://docs.google.com/viewer">Google Docs Viewer</a>servis da prikaže PDF-ove.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Ovaj dodatak koristi Google Docs Viewer servis da prikaže PDF-ove.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/tr_TR/locale.xml
+++ b/plugins/generic/googleViewer/locale/tr_TR/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.generic.googleViewer.name">Google gömülü görüntüleme eklentisi</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Bu eklenti makale görüntüleme sayfasında <a href="https://docs.google.com/viewer">Google Docs Viewer</a> gömülü PDF hizmetini sunar.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Bu eklenti makale görüntüleme sayfasında Google Docs Viewer gömülü PDF hizmetini sunar.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/uk_UA/locale.xml
+++ b/plugins/generic/googleViewer/locale/uk_UA/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="uk_UA" full_name="Українська">
 	<message key="plugins.generic.googleViewer.name">Модуль вбудованого переглядача Google</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[Цей модуль використовує службу <a href="https://docs.google.com/viewer">Google Docs Viewer</a> для вставки PDF на сторінки перегляду статей.]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[Цей модуль використовує службу Google Docs Viewer для вставки PDF на сторінки перегляду статей.]]></message>
 </locale>

--- a/plugins/generic/googleViewer/locale/zh_CN/locale.xml
+++ b/plugins/generic/googleViewer/locale/zh_CN/locale.xml
@@ -13,5 +13,5 @@
 
 <locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.generic.googleViewer.name">Google嵌入式浏览器插件</message>
-	<message key="plugins.generic.googleViewer.description"><![CDATA[该款插件使用<a href="https://docs.google.com/viewer">Google Docs 浏览器</a>服务在文章浏览页面潜入PDF格式。]]></message>
+	<message key="plugins.generic.googleViewer.description"><![CDATA[该款插件使用 Google Docs 浏览器 服务在文章浏览页面潜入PDF格式。]]></message>
 </locale>


### PR DESCRIPTION
* Google Doc Viewer web page/description does not exist anymore
* but service is still up
* see <http://googlesystem.blogspot.de/2015/02/google-docs-viewer-page-no-longer.html>