### PR TITLE
Broaden regex to get pages info [NLM_OAI]

### DIFF
--- a/plugins/oaiMetadataFormats/nlm/OAIMetadataFormat_NLM.inc.php
+++ b/plugins/oaiMetadataFormats/nlm/OAIMetadataFormat_NLM.inc.php
@@ -141,9 +141,9 @@ class OAIMetadataFormat_NLM extends OAIMetadataFormat {
 			$matchedPage = htmlspecialchars(Core::cleanVar($matches[1]));
 			$response .= "\t\t\t\t<fpage>$matchedPage</fpage><lpage>$matchedPage</lpage>\n";
 			$pageCount = 1;
-		} elseif (PKPString::regexp_match_get('/^[Pp][Pp]?[.]?[ ]?(\d+)[ ]?-[ ]?([Pp][Pp]?[.]?[ ]?)?(\d+)$/', $article->getPages(), $matches)) {
+		} elseif (PKPString::regexp_match_get('/^[Pp][Pp]?[.]?[ ]?(\d+)[ ]?(-|–)[ ]?([Pp][Pp]?[.]?[ ]?)?(\d+)$/', $article->getPages(), $matches)) {
 			$matchedPageFrom = htmlspecialchars(Core::cleanVar($matches[1]));
-			$matchedPageTo = htmlspecialchars(Core::cleanVar($matches[3]));
+			$matchedPageTo = htmlspecialchars(Core::cleanVar($matches[4]));
 			$response .=
 				"\t\t\t\t<fpage>$matchedPageFrom</fpage>\n" .
 				"\t\t\t\t<lpage>$matchedPageTo</lpage>\n";


### PR DESCRIPTION
Our journals happens to not export the pagerange through NLM.

It happens that ojs's regex is catching  hyphen-minus instead of normal hyphen.

PS.: Could you please cherry pick it to ojs-dev-2_4?