### PR TITLE
pkp/pkp-lib#1172: making section titles non-absolute positioning

### DIFF
--- a/plugins/themes/default/styles/objects/issue_toc.less
+++ b/plugins/themes/default/styles/objects/issue_toc.less
@@ -65,11 +65,8 @@
 			border-top: @bg-border;
 
 			h2 {
-				position: absolute;
-				top: -15px;
-				left: @triple / 2;
 				margin-top: 0;
-				padding: 0 (@triple / 2);
+				padding: 0;
 				background: @lift;
 				font-size: @font-bump;
 				font-weight: @normal;


### PR DESCRIPTION
Fixes pkp/pkp-lib#1172, minimally.