### PR TITLE
pkp/pkp-lib#1303: fix Reload Default Email Templates: only erase main email templates, reload any missing templates

### DIFF
--- a/pages/admin/AdminLanguagesHandler.inc.php
+++ b/pages/admin/AdminLanguagesHandler.inc.php
@@ -199,7 +199,7 @@ class AdminLanguagesHandler extends AdminHandler {
 
 		if (in_array($locale, $site->getInstalledLocales())) {
 			$emailTemplateDao =& DAORegistry::getDAO('EmailTemplateDAO');
-			$emailTemplateDao->deleteDefaultEmailTemplatesByLocale($locale);
+			$emailTemplateDao->installEmailTemplates($emailTemplateDao->getMainEmailTemplatesFilename(), false, null, true);
 			$emailTemplateDao->installEmailTemplateData($emailTemplateDao->getMainEmailTemplateDataFilename($locale));
 
 			$user =& $request->getUser();


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-lib/issues/1303

Clearing the old default data is already handled by `installEmailTemplateData()`.
Reloading missing templates will be handled by `installEmailTemplates()`
