### PR TITLE
add check to ensure empty article object is not returned

### DIFF
--- a/classes/article/PublishedArticleDAO.inc.php
+++ b/classes/article/PublishedArticleDAO.inc.php
@@ -300,8 +300,10 @@ class PublishedArticleDAO extends ArticleDAO {
 		if ($useCache) {
 			$cache = $this->_getPublishedArticleCache();
 			$returner = $cache->get($articleId);
-			if ($returner && $journalId != null && $journalId != $returner->getJournalId()) $returner = null;
-			return $returner;
+                        $skip = $returner && $journalId != null && $journalId != $returner->getJournalId();
+                        if ($returner && !$skip) {
+                            return $returner;
+                        }
 		}
 
 		$params = $this->getFetchParameters();


### PR DESCRIPTION
Prevents fatal error in template file if $returner = null
ie. PHP Fatal error:  Call to a member function getPublished() on a non-object in /xxx/journals/cache/t_compile/%%38^38D^38D7420B%%article.tpl.php on line 154