### PR TITLE
Add check to ensure empty article object is not returned

### DIFF
--- a/classes/article/PublishedArticleDAO.inc.php
+++ b/classes/article/PublishedArticleDAO.inc.php
@@ -357,8 +357,11 @@ class PublishedArticleDAO extends DAO {
 		if ($useCache) {
 			$cache =& $this->_getPublishedArticleCache();
 			$returner = $cache->get($articleId);
-			if ($returner && $journalId != null && $journalId != $returner->getJournalId()) $returner = null;
-			return $returner;
+			$skip = $returner && $journalId != null && $journalId != $returner->getJournalId();
+			
+                        if ($returner && !$skip) {
+                            return $returner;
+                        }
 		}
 
 		$primaryLocale = AppLocale::getPrimaryLocale();


### PR DESCRIPTION
Apologies for the other pull request to master.

Was recieving this PHP error when viewing a particular journal article:
PHP Fatal error: Call to a member function getPublished() on a non-object in  xxx/journals/cache/t_compile/%%38^38D^38D7420B%%article.tpl.php on line 154

The $returner variable was being set to null due to a true result for $journalId != $returner->getJournalId(); 

The modified code means that the check will fail gracefully and allow the article to load properly if $returner is null.
