### PR TITLE
pkp/pkp-lib#1326: Prevent PHP errors/warnings when bypassing counter plugin load for old PHP versions

### DIFF
--- a/plugins/reports/counter/CounterReportPluginUnsupported.inc.php
+++ b/plugins/reports/counter/CounterReportPluginUnsupported.inc.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file plugins/reports/counter/CounterReportPluginUnsupported.inc.php
+ *
+ * Copyright (c) 2013-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class CounterReportPlugin
+ * @ingroup plugins_reports_counter
+ *
+ * @brief Counter report plugin
+ */
+
+import('classes.plugins.ReportPlugin');
+
+class CounterReportPlugin extends ReportPlugin {
+
+	/**
+	 * @see PKPPlugin::register($category, $path)
+	 */
+	function register($category, $path) {
+		$success = parent::register($category, $path);
+	}
+
+	/**
+	 * @see PKPPlugin::getName()
+	 */
+	function getName() {
+		return 'CounterReportPlugin';
+	}
+
+	/**
+	 * @see PKPPlugin::getHideManagement()
+	 */
+	function getHideManagement() {
+		return true;
+	}
+
+}
+
+?>

--- a/plugins/reports/counter/index.php
+++ b/plugins/reports/counter/index.php
@@ -18,11 +18,11 @@
 
 // Because of the use of Namespaces, this plugin now requires PHP 5.3 or better
 if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
-
-require_once(dirname(__FILE__) . '/CounterReportPlugin.inc.php');
+	require_once(dirname(__FILE__) . '/CounterReportPlugin.inc.php');
+} else {
+	require_once(dirname(__FILE__) . '/CounterReportPluginUnsupported.inc.php');
+}
 
 return new CounterReportPlugin();
-
-}
 
 ?>


### PR DESCRIPTION
Resolves pkp/pkp-lib#1326.

Instanciate an empty, hidden ReportPlugin if PHP doesn't support objects and namespaces.
