### PR TITLE
pkp/pkp-lib#1433 Revert SPF changes and improve SPF compliance

### DIFF
--- a/classes/author/form/submit/AuthorSubmitStep5Form.inc.php
+++ b/classes/author/form/submit/AuthorSubmitStep5Form.inc.php
@@ -181,7 +181,14 @@ class AuthorSubmitStep5Form extends AuthorSubmitForm {
 		// Send author notification email
 		import('classes.mail.ArticleMailTemplate');
 		$mail = new ArticleMailTemplate($article, 'SUBMISSION_ACK', null, null, null, false);
-		$mail->setReplyTo(null);
+
+		if (is_null($journal->getSetting('contactEmail'))) {
+			$site =& Request::getSite();
+			$mail->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+		} else {
+			$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
+		}
+
 		if ($mail->isEnabled()) {
 			$mail->addRecipient($user->getEmail(), $user->getFullName());
 			// If necessary, BCC the acknowledgement to someone.

--- a/classes/author/form/submit/AuthorSubmitStep5Form.inc.php
+++ b/classes/author/form/submit/AuthorSubmitStep5Form.inc.php
@@ -181,14 +181,7 @@ class AuthorSubmitStep5Form extends AuthorSubmitForm {
 		// Send author notification email
 		import('classes.mail.ArticleMailTemplate');
 		$mail = new ArticleMailTemplate($article, 'SUBMISSION_ACK', null, null, null, false);
-
-		if (is_null($journal->getSetting('contactEmail'))) {
-			$site =& Request::getSite();
-			$mail->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
-		} else {
-			$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
-		}
-
+		$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 		if ($mail->isEnabled()) {
 			$mail->addRecipient($user->getEmail(), $user->getFullName());
 			// If necessary, BCC the acknowledgement to someone.

--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -87,16 +87,16 @@ class MailTemplate extends PKPMailTemplate {
 		// Default "From" to user if available, otherwise site/journal principal contact
 		$user =& Request::getUser();
 		if ($user) {
-			$this->setReplyTo($user->getEmail(), $user->getFullName());
-		}
-		if (is_null($journal) || is_null($journal->getSetting('contactEmail'))) {
-			$site =& Request::getSite();
-			$this->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
-
+			$this->setFrom($user->getEmail(), $user->getFullName());
 		} else {
-			$this->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
-		}
+			if (is_null($journal) || is_null($journal->getSetting('contactEmail'))) {
+				$site =& Request::getSite();
+				$this->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
 
+			} else {
+				$this->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
+			}
+		}
 		if ($journal && !Request::getUserVar('continued')) {
 			$this->setSubject('[' . $journal->getLocalizedSetting('initials') . '] ' . $this->getSubject());
 		}

--- a/classes/mail/MailTemplate.inc.php
+++ b/classes/mail/MailTemplate.inc.php
@@ -88,15 +88,14 @@ class MailTemplate extends PKPMailTemplate {
 		$user =& Request::getUser();
 		if ($user) {
 			$this->setFrom($user->getEmail(), $user->getFullName());
-		} else {
-			if (is_null($journal) || is_null($journal->getSetting('contactEmail'))) {
-				$site =& Request::getSite();
-				$this->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+		} elseif (is_null($journal) || is_null($journal->getSetting('contactEmail'))) {
+			$site =& Request::getSite();
+			$this->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
 
-			} else {
-				$this->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
-			}
+		} else {
+			$this->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 		}
+
 		if ($journal && !Request::getUserVar('continued')) {
 			$this->setSubject('[' . $journal->getLocalizedSetting('initials') . '] ' . $this->getSubject());
 		}
@@ -145,24 +144,16 @@ class MailTemplate extends PKPMailTemplate {
 	 */
 	function send($clearAttachments = true) {
 		if (isset($this->journal)) {
-			//If {$templateSignature} and/or {$templateHeader}
-			// exist in the body of the message, replace them with
-			// the journal signature; otherwise just pre/append
-			// them. This is here to accomodate MIME-encoded
-			// messages or other cases where the signature cannot
-			// just be appended.
-			$header = $this->journal->getSetting('emailHeader');
-			if (strstr($this->getBody(), '{$templateHeader}') === false) {
-				$this->setBody($header . "\n" . $this->getBody());
+			//If {$templateSignature} exists in the body of the
+			// message, replace it with the journal signature;
+			// otherwise just append it. This is here to
+			// accomodate MIME-encoded messages or other cases
+			// where the signature cannot just be appended.
+			$searchString = '{$templateSignature}';
+			if (strstr($this->getBody(), $searchString) === false) {
+				$this->setBody($this->getBody() . "\n" . $this->journal->getSetting('emailSignature'));
 			} else {
-				$this->setBody(str_replace('{$templateHeader}', $header, $this->getBody()));
-			}
-
-			$signature = $this->journal->getSetting('emailSignature');
-			if (strstr($this->getBody(), '{$templateSignature}') === false) {
-				$this->setBody($this->getBody() . "\n" . $signature);
-			} else {
-				$this->setBody(str_replace('{$templateSignature}', $signature, $this->getBody()));
+				$this->setBody(str_replace($searchString, $this->journal->getSetting('emailSignature'), $this->getBody()));
 			}
 
 			$envelopeSender = $this->journal->getSetting('envelopeSender');

--- a/classes/manager/form/UserManagementForm.inc.php
+++ b/classes/manager/form/UserManagementForm.inc.php
@@ -431,7 +431,7 @@ class UserManagementForm extends Form {
 				// Send welcome email to user
 				import('classes.mail.MailTemplate');
 				$mail = new MailTemplate('USER_REGISTER');
-				$mail->setReplyTo(null);
+				$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 				$mail->assignParams(array('username' => $this->getData('username'), 'password' => $password, 'userFullName' => $user->getFullName()));
 				$mail->addRecipient($user->getEmail(), $user->getFullName());
 				$mail->send();

--- a/classes/manager/form/setup/JournalSetupStep1Form.inc.php
+++ b/classes/manager/form/setup/JournalSetupStep1Form.inc.php
@@ -50,7 +50,6 @@ class JournalSetupStep1Form extends JournalSetupForm {
 				'contributors' => 'object',
 				'history' => 'string',
 				'envelopeSender' => 'string',
-				'emailHeader' => 'string',
 				'emailSignature' => 'string',
 				'searchDescription' => 'string',
 				'searchKeywords' => 'string',
@@ -65,7 +64,6 @@ class JournalSetupStep1Form extends JournalSetupForm {
 		$this->addCheck(new FormValidatorEmail($this, 'contactEmail', 'required', 'manager.setup.form.contactEmailRequired'));
 		$this->addCheck(new FormValidator($this, 'supportName', 'required', 'manager.setup.form.supportNameRequired'));
 		$this->addCheck(new FormValidatorEmail($this, 'supportEmail', 'required', 'manager.setup.form.supportEmailRequired'));
-		$this->addCheck(new FormValidatorEmail($this, 'envelopeSender', 'optional', 'user.profile.form.emailRequired'));
 	}
 
 	/**
@@ -108,7 +106,7 @@ class JournalSetupStep1Form extends JournalSetupForm {
 	 */
 	function display($request, $dispatcher) {
 		$templateMgr =& TemplateManager::getManager();
-		if (Config::getVar('email', 'allow_envelope_sender') && !(Config::getVar('email', 'force_default_envelope_sender') && Config::getVar('email', 'default_envelope_sender')))
+		if (Config::getVar('email', 'allow_envelope_sender'))
 			$templateMgr->assign('envelopeSenderEnabled', true);
 
 		// If Categories are enabled by Site Admin, make selection

--- a/classes/manager/form/setup/JournalSetupStep2Form.inc.php
+++ b/classes/manager/form/setup/JournalSetupStep2Form.inc.php
@@ -46,6 +46,7 @@ class JournalSetupStep2Form extends JournalSetupForm {
 			)
 		);
 
+		$this->addCheck(new FormValidatorEmail($this, 'envelopeSender', 'optional', 'user.profile.form.emailRequired'));
 	}
 
 	/**

--- a/classes/payment/ojs/OJSPaymentManager.inc.php
+++ b/classes/payment/ojs/OJSPaymentManager.inc.php
@@ -426,7 +426,7 @@ class OJSPaymentManager extends PaymentManager {
 
 				import('classes.mail.MailTemplate');
 				$mail = new MailTemplate('GIFT_AVAILABLE', $giftLocale);
-				$mail->setReplyTo(null);
+				$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 				$mail->assignParams(array(
 					'giftJournalName' => $giftJournalName,
 					'giftNoteTitle' => $giftNoteTitle,
@@ -459,7 +459,7 @@ class OJSPaymentManager extends PaymentManager {
 					$mail = new MailTemplate('GIFT_USER_LOGIN', $giftLocale);
 				}
 
-				$mail->setReplyTo(null);
+				$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 				$mail->assignParams($params);
 				$mail->addRecipient($recipientEmail, $user->getFullName());
 				$mail->send();

--- a/classes/sectionEditor/form/CreateReviewerForm.inc.php
+++ b/classes/sectionEditor/form/CreateReviewerForm.inc.php
@@ -197,7 +197,7 @@ class CreateReviewerForm extends Form {
 			// Send welcome email to user
 			import('classes.mail.MailTemplate');
 			$mail = new MailTemplate('REVIEWER_REGISTER');
-			$mail->setReplyTo(null);
+			$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 			$mail->assignParams(array('username' => $this->getData('username'), 'password' => $password, 'userFullName' => $user->getFullName()));
 			$mail->addRecipient($user->getEmail(), $user->getFullName());
 			$mail->send();

--- a/classes/submission/form/comment/CommentForm.inc.php
+++ b/classes/submission/form/comment/CommentForm.inc.php
@@ -132,7 +132,7 @@ class CommentForm extends Form {
 
 		import('classes.mail.ArticleMailTemplate');
 		$email = new ArticleMailTemplate($article, 'SUBMISSION_COMMENT');
-		$email->setReplyTo($this->user->getEmail(), $this->user->getFullName());
+		$email->setFrom($this->user->getEmail(), $this->user->getFullName());
 
 		$commentText = $this->getData('comments');
 

--- a/classes/submission/form/comment/EditCommentForm.inc.php
+++ b/classes/submission/form/comment/EditCommentForm.inc.php
@@ -293,7 +293,7 @@ class EditCommentForm extends Form {
 		import('classes.mail.ArticleMailTemplate');
 		$email = new ArticleMailTemplate($this->article, 'SUBMISSION_COMMENT');
 		$journal =& $request->getJournal();
-		$email->setReplyTo(null);
+		if ($journal) $email->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 
 		foreach ($recipients as $emailAddress => $name) {
 			$email->addRecipient($emailAddress, $name);

--- a/classes/submission/reviewer/ReviewerAction.inc.php
+++ b/classes/submission/reviewer/ReviewerAction.inc.php
@@ -52,7 +52,7 @@ class ReviewerAction extends Action {
 			$email = new ArticleMailTemplate($reviewerSubmission, $decline?'REVIEW_DECLINE':'REVIEW_CONFIRM');
 			// Must explicitly set sender because we may be here on an access
 			// key, in which case the user is not technically logged in
-			$email->setReplyTo($reviewer->getEmail(), $reviewer->getFullName());
+			$email->setFrom($reviewer->getEmail(), $reviewer->getFullName());
 			if (!$email->isEnabled() || ($send && !$email->hasErrors())) {
 				HookRegistry::call('ReviewerAction::confirmReview', array(&$reviewerSubmission, &$email, $decline));
 				if ($email->isEnabled()) {
@@ -132,7 +132,7 @@ class ReviewerAction extends Action {
 			$email = new ArticleMailTemplate($reviewerSubmission, 'REVIEW_COMPLETE');
 			// Must explicitly set sender because we may be here on an access
 			// key, in which case the user is not technically logged in
-			$email->setReplyTo($reviewer->getEmail(), $reviewer->getFullName());
+			$email->setFrom($reviewer->getEmail(), $reviewer->getFullName());
 
 			if (!$email->isEnabled() || ($send && !$email->hasErrors())) {
 				HookRegistry::call('ReviewerAction::recordRecommendation', array(&$reviewerSubmission, &$email, $recommendation));

--- a/classes/subscription/SubscriptionAction.inc.php
+++ b/classes/subscription/SubscriptionAction.inc.php
@@ -675,7 +675,7 @@ class SubscriptionAction {
 
 		import('classes.mail.MailTemplate');
 		$mail = new MailTemplate($mailTemplateKey);
-		$mail->setReplyTo($subscriptionContactEmail, $subscriptionContactName);
+		$mail->setFrom($subscriptionContactEmail, $subscriptionContactName);
 		$mail->addRecipient($subscriptionContactEmail, $subscriptionContactName);
 		$mail->setSubject($mail->getSubject($journal->getPrimaryLocale()));
 		$mail->setBody($mail->getBody($journal->getPrimaryLocale()));

--- a/classes/subscription/form/SubscriptionForm.inc.php
+++ b/classes/subscription/form/SubscriptionForm.inc.php
@@ -305,7 +305,7 @@ class SubscriptionForm extends Form {
 
 		import('classes.mail.MailTemplate');
 		$mail = new MailTemplate($mailTemplateKey);
-		$mail->setReplyTo($subscriptionEmail, $subscriptionName);
+		$mail->setFrom($subscriptionEmail, $subscriptionName);
 		$mail->addRecipient($user->getEmail(), $user->getFullName());
 		$mail->setSubject($mail->getSubject($journal->getPrimaryLocale()));
 		$mail->setBody($mail->getBody($journal->getPrimaryLocale()));

--- a/classes/tasks/OpenAccessNotification.inc.php
+++ b/classes/tasks/OpenAccessNotification.inc.php
@@ -42,7 +42,7 @@ class OpenAccessNotification extends ScheduledTask {
 			$email = new MailTemplate('OPEN_ACCESS_NOTIFY', $journal->getPrimaryLocale(), false, $journal, false, true);
 
 			$email->setSubject($email->getSubject($journal->getPrimaryLocale()));
-			$email->setReplyTo(null);
+			$email->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 			$email->addRecipient($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 
 			$paramArray = array(

--- a/classes/tasks/ReviewReminder.inc.php
+++ b/classes/tasks/ReviewReminder.inc.php
@@ -48,7 +48,7 @@ class ReviewReminder extends ScheduledTask {
 
 		$email = new ArticleMailTemplate($article, $reviewerAccessKeysEnabled ? $reminderType . '_ONECLICK' : $reminderType, $journal->getPrimaryLocale(), false, $journal, false, true);
 		$email->setJournal($journal);
-		$email->setReplyTo(null);
+		$email->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 		$email->addRecipient($reviewer->getEmail(), $reviewer->getFullName());
 		$email->setSubject($email->getSubject($journal->getPrimaryLocale()));
 		$email->setBody($email->getBody($journal->getPrimaryLocale()));

--- a/classes/tasks/SubscriptionExpiryReminder.inc.php
+++ b/classes/tasks/SubscriptionExpiryReminder.inc.php
@@ -78,7 +78,7 @@ class SubscriptionExpiryReminder extends ScheduledTask {
 
 		import('classes.mail.MailTemplate');
 		$mail = new MailTemplate($emailKey, $journal->getPrimaryLocale(), false, $journal, false, true);
-		$mail->setReplyTo($subscriptionEmail, $subscriptionName);
+		$mail->setFrom($subscriptionEmail, $subscriptionName);
 		$mail->addRecipient($user->getEmail(), $user->getFullName());
 		$mail->setSubject($mail->getSubject($journal->getPrimaryLocale()));
 		$mail->setBody($mail->getBody($journal->getPrimaryLocale()));

--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -336,7 +336,7 @@ class RegistrationForm extends Form {
 
 				// Send email validation request to user
 				$mail = new MailTemplate('USER_VALIDATE');
-				$mail->setReplyTo(null);
+				$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 				$mail->assignParams(array(
 					'userFullName' => $user->getFullName(),
 					'activateUrl' => Request::url($journal->getPath(), 'user', 'activateUser', array($this->getData('username'), $accessKey))
@@ -348,7 +348,7 @@ class RegistrationForm extends Form {
 			if ($this->getData('sendPassword')) {
 				// Send welcome email to user
 				$mail = new MailTemplate('USER_REGISTER');
-				$mail->setReplyTo(null);
+				$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 				$mail->assignParams(array(
 					'username' => $this->getData('username'),
 					'password' => String::substr($this->getData('password'), 0, 30), // Prevent mailer abuse via long passwords

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -316,8 +316,7 @@ allowed_html = "<a href|target> <em> <strong> <cite> <code> <ul> <ol> <li> <dl> 
 ; default_envelope_sender = my_address@my_host.com
 
 ; Force the default envelope sender (if present)
-; This is useful if setting up a site-wide noreply address
-; The reply-to field will be set with the reply-to or from address.
+; This is useful if setting up a site-wide return-path address
 ; force_default_envelope_sender = Off
 
 ; Enable attachments in the various "Send Email" pages.

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -302,6 +302,11 @@ allowed_html = "<a href|target> <em> <strong> <cite> <code> <ul> <ol> <li> <dl> 
 ; smtp_server = mail.example.com
 ; smtp_port = 25
 
+; Force the default envelope sender (if present)
+; This is useful if setting up a site-wide noreply address
+; The reply-to field will be set with the reply-to or from address.
+; force_default_envelope_sender = Off
+
 ; Enable SMTP authentication
 ; Supported mechanisms: PLAIN, LOGIN, CRAM-MD5, and DIGEST-MD5
 ; smtp_auth = PLAIN
@@ -314,10 +319,6 @@ allowed_html = "<a href|target> <em> <strong> <cite> <code> <ul> <ol> <li> <dl> 
 
 ; Default envelope sender to use if none is specified elsewhere
 ; default_envelope_sender = my_address@my_host.com
-
-; Force the default envelope sender (if present)
-; This is useful if setting up a site-wide return-path address
-; force_default_envelope_sender = Off
 
 ; Enable attachments in the various "Send Email" pages.
 ; (Disabling here will not disable attachments on features that

--- a/locale/en_US/default.xml
+++ b/locale/en_US/default.xml
@@ -130,8 +130,6 @@ Please follow the following protocol for making electronic revisions to your man
 	<pre>4. FORMATTING
 	The paragraph that begins "This last topic..." is not indented.</pre>]]></message>
 
-	<message key="default.journalSettings.emailHeader">The following message is being delivered on behalf of {$journalName}.
-________________________________________________________________________</message>
 	<message key="default.journalSettings.emailSignature">________________________________________________________________________
 {$journalName}
 {$indexUrl}/{$journalPath}</message>

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -271,8 +271,6 @@
 	<message key="manager.setup.emailBounceAddressDescription">Any undeliverable emails will result in an error message to this address.</message>
 	<message key="manager.setup.emailBounceAddressDisabled"><![CDATA[<strong>Note:</strong> To activate this option, the site administrator must enable the <tt>allow_envelope_sender</tt> option in the OJS configuration file. Additional server configuration may be required to support this functionality (which may not be possible on all servers), as indicated in the OJS documentation.]]></message>
 	<message key="manager.setup.emails">Email Identification</message>
-	<message key="manager.setup.emailHeader">Email Header</message>
-	<message key="manager.setup.emailHeaderDescription">The prepared emails that are sent by the system on behalf of the journal will begin with the following header. These emails will be addressed from the Principal Contact, so it's important to clarify that the Primary Contact is not necessarily responsible for the message content, which may be sent on behalf of a different user.</message>
 	<message key="manager.setup.emailSignature">Signature</message>
 	<message key="manager.setup.emailSignatureDescription">The prepared emails that are sent by the system on behalf of the journal will have the following signature added to the end. The body of the prepared emails are available for editing under Journal Management.</message>
 	<message key="manager.setup.enableAnnouncements">Enable Journal Managers to add journal announcements.</message>

--- a/pages/login/LoginHandler.inc.php
+++ b/pages/login/LoginHandler.inc.php
@@ -108,9 +108,9 @@ class LoginHandler extends PKPLoginHandler {
 		
 		// Set the sender based on the current context
 		if ($journal && $journal->getSetting('supportEmail')) {
-			$mail->setReplyTo($journal->getSetting('supportEmail'), $journal->getSetting('supportName'));
+			$mail->setFrom($journal->getSetting('supportEmail'), $journal->getSetting('supportName'));
 		} else { 
-			$mail->setReplyTo($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
+			$mail->setFrom($site->getLocalizedContactEmail(), $site->getLocalizedContactName());
 		}
 	}
 

--- a/plugins/generic/booksForReview/classes/BooksForReviewReminder.inc.php
+++ b/plugins/generic/booksForReview/classes/BooksForReviewReminder.inc.php
@@ -48,7 +48,7 @@ class BooksForReviewReminder extends ScheduledTask {
 		import('classes.mail.MailTemplate');
 		$mail = new MailTemplate($emailKey);
 
-		$mail->setReplyTo($book->getEditorEmail(), $book->getEditorFullName());
+		$mail->setFrom($book->getEditorEmail(), $book->getEditorFullName());
 		$mail->addRecipient($book->getUserEmail(), $book->getUserFullName());
 		$mail->setSubject($mail->getSubject($journal->getPrimaryLocale()));
 		$mail->setBody($mail->getBody($journal->getPrimaryLocale()));

--- a/plugins/generic/booksForReview/pages/BooksForReviewAuthorHandler.inc.php
+++ b/plugins/generic/booksForReview/pages/BooksForReviewAuthorHandler.inc.php
@@ -125,6 +125,9 @@ class BooksForReviewAuthorHandler extends Handler {
 						$user =& $request->getUser();
 						$userId = $user->getId();
 
+						$userFullName = $user->getFullName();
+						$userEmail = $user->getEmail();
+
 						$editorFullName = $book->getEditorFullName();
 						$editorEmail = $book->getEditorEmail();
 
@@ -135,6 +138,7 @@ class BooksForReviewAuthorHandler extends Handler {
 						);
 
 						$email->addRecipient($editorEmail, $editorFullName);
+						$email->setFrom($userEmail, $userFullName);
 						$email->assignParams($paramArray);
 					}
 					$returnUrl = $request->url(null, 'author', 'requestBookForReview', $bookId);

--- a/plugins/generic/booksForReview/pages/BooksForReviewEditorHandler.inc.php
+++ b/plugins/generic/booksForReview/pages/BooksForReviewEditorHandler.inc.php
@@ -666,7 +666,7 @@ class BooksForReviewEditorHandler extends Handler {
 						);
 
 						$email->addRecipient($userEmail, $userName);
-						$email->setReplyTo($book->getEditorEmail(), $book->getEditorFullName());
+						$email->setFrom($book->getEditorEmail(), $book->getEditorFullName());
 						$email->assignParams($paramArray);
 					}
 					$returnUrl = $request->url(null, 'editor', 'assignBookForReviewAuthor', $bookId, array('returnPage' => $returnPage, 'userId' => $userId));
@@ -742,7 +742,7 @@ class BooksForReviewEditorHandler extends Handler {
 					);
 
 					$email->addRecipient($userEmail, $userFullName);
-					$email->setReplyTo($book->getEditorEmail(), $book->getEditorFullName());
+					$email->setFrom($book->getEditorEmail(), $book->getEditorFullName());
 					$email->assignParams($paramArray);
 				}
 				$returnUrl = $request->url(null, 'editor', 'denyBookForReviewAuthor', $bookId, array('returnPage' => $returnPage));
@@ -829,7 +829,7 @@ class BooksForReviewEditorHandler extends Handler {
 					);
 
 					$email->addRecipient($userEmail, $userFullName);
-					$email->setReplyTo($book->getEditorEmail(), $book->getEditorFullName());
+					$email->setFrom($book->getEditorEmail(), $book->getEditorFullName());
 					$email->assignParams($paramArray);
 				}
 				$returnUrl = $request->url(null, 'editor', 'notifyBookForReviewMailed', $bookId, array('returnPage' => $returnPage));
@@ -909,7 +909,7 @@ class BooksForReviewEditorHandler extends Handler {
 					);
 
 					$email->addRecipient($userEmail, $userFullName);
-					$email->setReplyTo($book->getEditorEmail(), $book->getEditorFullName());
+					$email->setFrom($book->getEditorEmail(), $book->getEditorFullName());
 					$email->assignParams($paramArray);
 				}
 				$returnUrl = $request->url(null, 'editor', 'removeBookForReviewAuthor', $bookId, array('returnPage' => $returnPage));

--- a/plugins/generic/objectsForReview/classes/tasks/ObjectsForReviewReminder.inc.php
+++ b/plugins/generic/objectsForReview/classes/tasks/ObjectsForReviewReminder.inc.php
@@ -53,7 +53,7 @@ class ObjectsForReviewReminder extends ScheduledTask {
 
 		import('classes.mail.MailTemplate');
 		$mail = new MailTemplate($emailKey);
-		$mail->setReplyTo($editor->getEmail(), $editor->getFullName());
+		$mail->setFrom($editor->getEmail(), $editor->getFullName());
 		$mail->addRecipient($author->getEmail(), $author->getFullName());
 		$mail->setSubject($mail->getSubject($journal->getPrimaryLocale()));
 		$mail->setBody($mail->getBody($journal->getPrimaryLocale()));

--- a/plugins/generic/objectsForReview/pages/ObjectsForReviewEditorHandler.inc.php
+++ b/plugins/generic/objectsForReview/pages/ObjectsForReviewEditorHandler.inc.php
@@ -1136,7 +1136,7 @@ class ObjectsForReviewEditorHandler extends Handler {
 				);
 			}
 			$email->addRecipient($userEmail, $userFullName);
-			$email->setReplyTo($editorEmail, $editorFullName);
+			$email->setFrom($editorEmail, $editorFullName);
 			$email->assignParams($paramArray);
 		}
 		$email->displayEditForm($returnUrl);

--- a/plugins/generic/sword/SwordPlugin.inc.php
+++ b/plugins/generic/sword/SwordPlugin.inc.php
@@ -166,8 +166,10 @@ class SwordPlugin extends GenericPlugin {
 			$submittingUser =& $sectionEditorSubmission->getUser();
 
 			import('classes.mail.ArticleMailTemplate');
+			$contactName = $journal->getSetting('contactName');
+			$contactEmail = $journal->getSetting('contactEmail');
 			$mail = new ArticleMailTemplate($sectionEditorSubmission, 'SWORD_DEPOSIT_NOTIFICATION', null, null, $journal, true, true);
-			$mail->setReplyTo(null);
+			$mail->setFrom($contactEmail, $contactName);
 			$mail->addRecipient($submittingUser->getEmail(), $submittingUser->getFullName());
 
 			$mail->assignParams(array(

--- a/plugins/generic/thesis/StudentThesisForm.inc.php
+++ b/plugins/generic/thesis/StudentThesisForm.inc.php
@@ -286,10 +286,10 @@ class StudentThesisForm extends Form {
 
 			import('classes.mail.MailTemplate');
 			$mail = new MailTemplate('THESIS_ABSTRACT_CONFIRM');
-			$mail->setReplyTo($thesisEmail, $thesisName);
+			$mail->setFrom($thesisEmail, "\"" . $thesisName . "\"");
 			$mail->assignParams($paramArray);
-			$mail->addRecipient($thesis->getSupervisorEmail(), $supervisorName);
-			$mail->addCc($thesis->getStudentEmail(), $studentName);
+			$mail->addRecipient($thesis->getSupervisorEmail(), "\"" . $supervisorName . "\"");
+			$mail->addCc($thesis->getStudentEmail(), "\"" . $studentName . "\"");
 			$mail->send();
 		}
 

--- a/plugins/generic/thesis/StudentThesisForm.inc.php
+++ b/plugins/generic/thesis/StudentThesisForm.inc.php
@@ -286,7 +286,7 @@ class StudentThesisForm extends Form {
 
 			import('classes.mail.MailTemplate');
 			$mail = new MailTemplate('THESIS_ABSTRACT_CONFIRM');
-			$mail->setFrom($thesisEmail, "\"" . $thesisName . "\"");
+			$mail->setFrom($thesisEmail, $thesisName);
 			$mail->assignParams($paramArray);
 			$mail->addRecipient($thesis->getSupervisorEmail(), "\"" . $supervisorName . "\"");
 			$mail->addCc($thesis->getStudentEmail(), "\"" . $studentName . "\"");

--- a/plugins/importexport/users/UserXMLParser.inc.php
+++ b/plugins/importexport/users/UserXMLParser.inc.php
@@ -196,7 +196,7 @@ class UserXMLParser {
 
 			$journalDao =& DAORegistry::getDAO('JournalDAO');
 			$journal =& $journalDao->getById($this->journalId);
-			$mail->setReplyTo($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
+			$mail->setFrom($journal->getSetting('contactEmail'), $journal->getSetting('contactName'));
 		}
 
 		for ($i=0, $count=count($this->usersToImport); $i < $count; $i++) {

--- a/plugins/paymethod/manual/ManualPaymentPlugin.inc.php
+++ b/plugins/paymethod/manual/ManualPaymentPlugin.inc.php
@@ -126,7 +126,7 @@ class ManualPaymentPlugin extends PaymethodPlugin {
 				$contactName = $journal->getSetting('contactName');
 				$contactEmail = $journal->getSetting('contactEmail');
 				$mail = new MailTemplate('MANUAL_PAYMENT_NOTIFICATION');
-				$mail->setReplyTo(null);
+				$mail->setFrom($contactEmail, $contactName);
 				$mail->addRecipient($contactEmail, $contactName);
 				$mail->assignParams(array(
 					'journalName' => $journal->getLocalizedTitle(),

--- a/plugins/paymethod/paypal/PayPalPlugin.inc.php
+++ b/plugins/paymethod/paypal/PayPalPlugin.inc.php
@@ -169,7 +169,7 @@ class PayPalPlugin extends PaymethodPlugin {
 			$contactEmail = $journal->getSetting('contactEmail');
 		}
 		$mail = new MailTemplate('PAYPAL_INVESTIGATE_PAYMENT');
-		$mail->setReplyTo(null);
+		$mail->setFrom($contactEmail, $contactName);
 		$mail->addRecipient($contactEmail, $contactName);
 
 		$paymentStatus = $request->getUserVar('payment_status');

--- a/registry/journalSettings.xml
+++ b/registry/journalSettings.xml
@@ -52,10 +52,6 @@
 		<value>{translate key="default.journalSettings.copyeditInstructions"}</value>
 	</setting>
 	<setting type="string" locale="0">
-		<name>emailHeader</name>
-		<value>{translate key="default.journalSettings.emailHeader"}</value>
-	</setting>
-	<setting type="string" locale="0">
 		<name>emailSignature</name>
 		<value>{translate key="default.journalSettings.emailSignature"}</value>
 	</setting>

--- a/templates/editor/notifyUsersEmail.tpl
+++ b/templates/editor/notifyUsersEmail.tpl
@@ -1,5 +1,3 @@
-{literal}{$templateHeader}{/literal}
-
 {$body}
 
 {$journal->getLocalizedTitle()|strip_tags}
@@ -11,7 +9,6 @@
 {if $section.title}{$section.title}{/if}
 
 --------
-{literal}{$templateHeader}{/literal}
 {foreach from=$section.articles item=article}
 {$article->getLocalizedTitle()|strip_tags}{if $article->getPages()} ({$article->getPages()}){/if}
 

--- a/templates/manager/people/email.tpl
+++ b/templates/manager/people/email.tpl
@@ -137,6 +137,10 @@ function deleteAttachment(fileId) {
 	<td colspan="2">&nbsp;</td>
 </tr>
 <tr valign="top">
+	<td class="label">{translate key="email.from"}</td>
+	<td class="value">{$from|escape}</td>
+</tr>
+<tr valign="top">
 	<td width="20%" class="label">{fieldLabel name="subject" key="email.subject"}</td>
 	<td width="80%" class="value"><input type="text" id="subject" name="subject" value="{$subject|escape}" size="60" maxlength="120" class="textField" /></td>
 </tr>

--- a/templates/manager/setup/step1.tpl
+++ b/templates/manager/setup/step1.tpl
@@ -144,13 +144,6 @@
 <div id="setupEmails">
 <h3>1.4 {translate key="manager.setup.emails"}</h3>
 <table width="100%" class="data">
-	<tr valign="top"><td colspan="2">{translate key="manager.setup.emailHeaderDescription"}<br />&nbsp;</td></tr>
-	<tr valign="top">
-		<td class="label">{fieldLabel name="emailHeader" key="manager.setup.emailHeader"}</td>
-		<td class="value">
-			<textarea name="emailHeader" id="emailHeader" rows="3" cols="60" class="textArea">{$emailHeader|escape}</textarea>
-		</td>
-	</tr>
 	<tr valign="top"><td colspan="2">{translate key="manager.setup.emailSignatureDescription"}<br />&nbsp;</td></tr>
 	<tr valign="top">
 		<td class="label">{fieldLabel name="emailSignature" key="manager.setup.emailSignature"}</td>

--- a/templates/rt/email.tpl
+++ b/templates/rt/email.tpl
@@ -146,6 +146,10 @@ function deleteAttachment(fileId) {
 	<td colspan="2">&nbsp;</td>
 </tr>
 <tr valign="top">
+	<td class="label">{translate key="email.from"}</td>
+	<td class="value">{$from|escape}</td>
+</tr>
+<tr valign="top">
 	<td width="20%" class="label">{fieldLabel name="subject" key="email.subject"}</td>
 	<td width="80%" class="value"><input type="text" id="subject" name="subject" value="{$subject|escape}" size="50" maxlength="120" class="textField" /></td>
 </tr>

--- a/templates/subscription/openAccessNotifyEmail.tpl
+++ b/templates/subscription/openAccessNotifyEmail.tpl
@@ -4,7 +4,6 @@
 Content-Type: text/plain; charset={$defaultCharset|escape}
 Content-Transfer-Encoding: quoted-printable
 
-{literal}{$templateHeader}{/literal}
 {$body}
 
 {$issue->getIssueIdentification()}
@@ -42,8 +41,6 @@ Content-Transfer-Encoding: quoted-printable
 		{/foreach}
 		</head>
 	<body>
-
-	<pre>{literal}{$templateHeader}{/literal}</pre>
 
 	<p>{$body|escape|nl2br}</p>
 


### PR DESCRIPTION
This pull reverts the SPF changes and combined with this commit already in lib-pkp/ojs-dev-2_4 should fix a lot of the mail discrepancies:

https://github.com/pkp/pkp-lib/commit/7af3bf24a2e24f8e2f4afcde4750d7b16d9b80f7

Note that it also adjusts the From: header on Step 5 of the Submission form, in order to prevent the email to the author from being from the author.  The SPF change originally set the reply-to to null which got around that. 

I may add to this PR as I find other places where the From: header may still be incorrect.  