### PR TITLE
pkp/pkp-lib#1507: Use SSL for RECAPTCHA if protocol is HTTPS or if config requires SSL

### DIFF
--- a/classes/comment/form/CommentForm.inc.php
+++ b/classes/comment/form/CommentForm.inc.php
@@ -128,7 +128,7 @@ class CommentForm extends Form {
 			if ($this->reCaptchaEnabled) {
 				import('lib.pkp.lib.recaptcha.recaptchalib');
 				$publicKey = Config::getVar('captcha', 'recaptcha_public_key');
-				$useSSL = Config::getVar('security', 'force_ssl')?true:false;
+				$useSSL = Config::getVar('security', 'force_ssl')||Request::getProtocol()=='https'?true:false;
 				$reCaptchaHtml = recaptcha_get_html($publicKey, null, $useSSL);
 				$templateMgr->assign('reCaptchaHtml', $reCaptchaHtml);
 				$templateMgr->assign('captchaEnabled', $this->captchaEnabled);

--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -111,7 +111,7 @@ class RegistrationForm extends Form {
 			if ($this->reCaptchaEnabled) {
 				import('lib.pkp.lib.recaptcha.recaptchalib');
 				$publicKey = Config::getVar('captcha', 'recaptcha_public_key');
-				$useSSL = Config::getVar('security', 'force_ssl')?true:false;
+				$useSSL = Config::getVar('security', 'force_ssl')||Request::getProtocol()=='https'?true:false;
 				$reCaptchaHtml = recaptcha_get_html($publicKey, null, $useSSL);
 				$templateMgr->assign('reCaptchaHtml', $reCaptchaHtml);
 				$templateMgr->assign('captchaEnabled', $this->captchaEnabled);


### PR DESCRIPTION
Partially resolves https://github.com/pkp/pkp-lib/issues/1507 (see also shared library PR)

Allows backwards compatibility in the unlikely case of SSL being forced, but the request coming in over HTTP (a proxy perhaps?) but primarily ensures if the Request is HTTPS, then SSL should be used.