### PR TITLE
Use strip_unsafe_html instead of escape to not break Issue title if s…

### DIFF
--- a/templates/issue/archive.tpl
+++ b/templates/issue/archive.tpl
@@ -37,10 +37,10 @@
 	{if $issue->getFileName($coverLocale) && !$issue->getHideCoverPageArchives($coverLocale)}
 		<div class="issueCoverImage"><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}"><img src="{$coverPagePath|escape}{$issue->getFileName($coverLocale)|escape}"{if $issue->getCoverPageAltText($coverLocale) != ''} alt="{$issue->getCoverPageAltText($coverLocale)|escape}"{else} alt="{translate key="issue.coverPage.altText"}"{/if}/></a>
 		</div>
-		<h4><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}">{$issue->getIssueIdentification()|escape}</a></h4>
+		<h4><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}">{$issue->getIssueIdentification()|strip_unsafe_html}</a></h4>
 		<div class="issueCoverDescription">{$issue->getLocalizedCoverPageDescription()|strip_unsafe_html|nl2br}</div>
 	{else}
-		<h4><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}">{$issue->getIssueIdentification()|escape}</a></h4>
+		<h4><a href="{url op="view" path=$issue->getBestIssueId($currentJournal)}">{$issue->getIssueIdentification()|strip_unsafe_html}</a></h4>
 		<div class="issueDescription">{$issue->getLocalizedDescription()|strip_unsafe_html|nl2br}</div>
 	{/if}
 	</div>


### PR DESCRIPTION
…afe HTML is used

Just like @ /issue/view/ the archive should use `strip_unsafe_html` for filtering the issue title. We have some isue title with `<i>` and `escape` breaks it at the archive.

We use 2.4.8.0 currently.