### PR TITLE
Clean up temporary files after processing in the PLN plugin.

### DIFF
--- a/plugins/generic/pln/classes/DepositPackage.inc.php
+++ b/plugins/generic/pln/classes/DepositPackage.inc.php
@@ -328,8 +328,10 @@ class DepositPackage {
 		// create the bag
 		$bag->package($packageFile,'zip');
 		
-		// remove the temporary bag directory
+		// remove the temporary bag directory and temp files
 		$fileManager->rmtree($bagDir);
+		$fileManager->deleteFile($exportFile);
+		$fileManager->deleteFile($termsFile);
 		
 		return $packageFile;
 	}


### PR DESCRIPTION
tempnam() creates a temp file but doesn't automatically remove it, unlike tmpfile(). 

Fixes pkp/pkp-lib#1545
