### PR TITLE
pkp/pkp-lib#1543 log automatic datacite doi registration result if fa…

### DIFF
--- a/plugins/importexport/datacite/DataciteInfoSender.inc.php
+++ b/plugins/importexport/datacite/DataciteInfoSender.inc.php
@@ -108,9 +108,19 @@ class DataciteInfoSender extends ScheduledTask {
 				$exportSpec[DOI_EXPORT_SUPPFILES] = $unregisteredSuppFileIds;
 				$register = true;
 			}
-
 			if ($register) {
-				$plugin->registerObjects($request, $exportSpec, $journal);
+				$result = $plugin->registerObjects($request, $exportSpec, $journal);
+				if ($result !== true) {
+					if (is_array($result)) {
+						foreach($result as $error) {
+							assert(is_array($error) && count($error) >= 1);
+							$this->addExecutionLogEntry(
+								__($error[0], array('param' => (isset($error[1]) ? $error[1] : null))),
+								SCHEDULED_TASK_MESSAGE_TYPE_WARNING
+							);
+						}
+					}
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
…iled

This is a small improvement: if the registration failed, the result will be logged in the scheduled task log file, for the users to see.