### PR TITLE
pkp/pkp-lib#1204 no mime_type for remote galleys in crossref export

### DIFF
--- a/plugins/importexport/crossref/classes/CrossRefExportDom.inc.php
+++ b/plugins/importexport/crossref/classes/CrossRefExportDom.inc.php
@@ -485,7 +485,10 @@ class CrossRefExportDom extends DOIExportDom {
 				XMLCustomWriter::appendChild($collectionNode, $itemNode);
 				$resourceNode = XMLCustomWriter::createElement($doc, 'resource');
 				XMLCustomWriter::appendChild($itemNode, $resourceNode);
-				XMLCustomWriter::setAttribute($resourceNode, 'mime_type', $galley->getFileType());
+				$remoteGalleyURL = $galley->getRemoteURL();
+				if (!$remoteGalleyURL) {
+					XMLCustomWriter::setAttribute($resourceNode, 'mime_type', $galley->getFileType());
+				}
 				$urlNode = XMLCustomWriter::createTextNode($doc, $request->url($journal->getPath(), 'article', 'viewFile', array($galley->getArticleId(), $galley->getBestGalleyId($journal))));
 				XMLCustomWriter::appendChild($resourceNode, $urlNode);
 			}


### PR DESCRIPTION
S. https://github.com/pkp/pkp-lib/issues/1204

This was missing for the stable branch :-( 