### PR TITLE
pkp/pkp-lib#1564 Move status update outside of email send test

### DIFF
--- a/classes/submission/sectionEditor/SectionEditorAction.inc.php
+++ b/classes/submission/sectionEditor/SectionEditorAction.inc.php
@@ -2064,17 +2064,17 @@ class SectionEditorAction extends Action {
 
 		$copyeditor = $sectionEditorSubmission->getUserBySignoffType('SIGNOFF_COPYEDITING_INITIAL');
 
+		if ($decisionConst == SUBMISSION_EDITOR_DECISION_DECLINE) {
+			// If the most recent decision was a decline,
+			// archive the submission.
+			$sectionEditorSubmission->setStatus(STATUS_ARCHIVED);
+			$sectionEditorSubmission->stampStatusModified();
+			$sectionEditorSubmissionDao->updateSectionEditorSubmission($sectionEditorSubmission);
+		}
+
 		if ($send && !$email->hasErrors()) {
 			HookRegistry::call('SectionEditorAction::emailEditorDecisionComment', array(&$sectionEditorSubmission, &$send, &$request));
 			$email->send($request);
-
-			if ($decisionConst == SUBMISSION_EDITOR_DECISION_DECLINE) {
-				// If the most recent decision was a decline,
-				// sending this email archives the submission.
-				$sectionEditorSubmission->setStatus(STATUS_ARCHIVED);
-				$sectionEditorSubmission->stampStatusModified();
-				$sectionEditorSubmissionDao->updateSectionEditorSubmission($sectionEditorSubmission);
-			}
 
 			$articleComment = new ArticleComment();
 			$articleComment->setCommentType(COMMENT_TYPE_EDITOR_DECISION);


### PR DESCRIPTION
This pull request moves that status update outside of the $send test, so it happens every time.  Issue here:

https://github.com/pkp/pkp-lib/issues/1564