### PR TITLE
revert archive send commit, adjust author submission status check

### DIFF
--- a/classes/submission/author/AuthorSubmission.inc.php
+++ b/classes/submission/author/AuthorSubmission.inc.php
@@ -170,7 +170,7 @@ class AuthorSubmission extends Article {
 
 		$latestDecision = $this->getMostRecentDecision();
 		if ($latestDecision) {
-			if ($latestDecision == SUBMISSION_EDITOR_DECISION_ACCEPT || $latestDecision == SUBMISSION_EDITOR_DECISION_DECLINE) {
+			if ($latestDecision == SUBMISSION_EDITOR_DECISION_ACCEPT) {
 				return STATUS_QUEUED_EDITING;
 			}
 		}

--- a/classes/submission/sectionEditor/SectionEditorAction.inc.php
+++ b/classes/submission/sectionEditor/SectionEditorAction.inc.php
@@ -2064,17 +2064,17 @@ class SectionEditorAction extends Action {
 
 		$copyeditor = $sectionEditorSubmission->getUserBySignoffType('SIGNOFF_COPYEDITING_INITIAL');
 
-		if ($decisionConst == SUBMISSION_EDITOR_DECISION_DECLINE) {
-			// If the most recent decision was a decline,
-			// archive the submission.
-			$sectionEditorSubmission->setStatus(STATUS_ARCHIVED);
-			$sectionEditorSubmission->stampStatusModified();
-			$sectionEditorSubmissionDao->updateSectionEditorSubmission($sectionEditorSubmission);
-		}
-
 		if ($send && !$email->hasErrors()) {
 			HookRegistry::call('SectionEditorAction::emailEditorDecisionComment', array(&$sectionEditorSubmission, &$send, &$request));
 			$email->send($request);
+
+			if ($decisionConst == SUBMISSION_EDITOR_DECISION_DECLINE) {
+				// If the most recent decision was a decline,
+				// archive the submission.
+				$sectionEditorSubmission->setStatus(STATUS_ARCHIVED);
+				$sectionEditorSubmission->stampStatusModified();
+				$sectionEditorSubmissionDao->updateSectionEditorSubmission($sectionEditorSubmission);
+			}
 
 			$articleComment = new ArticleComment();
 			$articleComment->setCommentType(COMMENT_TYPE_EDITOR_DECISION);


### PR DESCRIPTION
After discussion with Co Action, they'd prefer to not have the submission actually archived, but simply display a different submission status to the author.  This removes the previous fix to archive without sending, but also lets the _DECLINE decision fall through and return a _REVIEW status for the author instead.