### PR TITLE
pkp/pkp-lib#1585: Check if an article can be exported before attempting CrossRef update/registration.

### DIFF
--- a/plugins/importexport/crossref/CrossrefInfoSender.inc.php
+++ b/plugins/importexport/crossref/CrossrefInfoSender.inc.php
@@ -61,7 +61,8 @@ class CrossrefInfoSender extends ScheduledTask {
 			$unregisteredArticlesIds = array();
 			foreach ($unregisteredArticles as $articleData) {
 				$article = $articleData['article'];
-				if (is_a($article, 'PublishedArticle')) {
+				$errors = array();
+				if (is_a($article, 'PublishedArticle') && $plugin->canBeExported($article, $errors)) {
 					$unregisteredArticlesIds[$article->getId()] = $article;
 				}
 			}


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-lib/issues/1585
