### PR TITLE
pkp/pkp-lib#383 fix JS event target form submit

### DIFF
--- a/js/controllers/form/DOIPubIdExportFormHandler.js
+++ b/js/controllers/form/DOIPubIdExportFormHandler.js
@@ -25,10 +25,34 @@
 			function($formElement, options) {
 		this.parent($formElement, options);
 
-		$('#exportSubmissionXmlForm a[id*="-button-"]').click(this.callbackWrapper(
-				this.submitAction_));
-		$('#exportIssueXmlForm a[id*="-button-"]').click(this.callbackWrapper(
-				this.submitAction_));
+		this.submissionsActions_ = [];
+		this.issuesActions_ = [];
+		this.actionRegExp_ = [];
+
+		var i;
+		if (options.submissionsActions) {
+			for (i = 0; i < options.submissionsActions.length; i++) {
+				/** @type {{_id:string}}*/
+				this.optionsSubmissionsAction = options.submissionsActions[i];
+				this.submissionsActions_.push(this.optionsSubmissionsAction._id);
+				$('#exportSubmissionXmlForm a[id^="' + this.optionsSubmissionsAction._id +
+					'-button-"]').click(this.callbackWrapper(this.submitAction_));
+			}
+			this.actionRegExp_.exportSubmissionXmlForm =
+					'(' + this.submissionsActions_.join('|') + ')';
+		}
+
+		if (options.issuesActions) {
+			for (i = 0; i < options.issuesActions.length; i++) {
+				/** @type {{_id:string}}*/
+				this.optionsIssuessAction = options.issuesActions[i];
+				this.issuesActions_.push(this.optionsIssuessAction._id);
+				$('#exportIssueXmlForm a[id^="' + this.optionsIssuessAction._id +
+					'-button-"]').click(this.callbackWrapper(this.submitAction_));
+			}
+			this.actionRegExp_.exportIssueXmlForm =
+					'(' + this.issuesActions_.join('|') + ')';
+		}
 
 	};
 	$.pkp.classes.Helper.inherits(
@@ -40,7 +64,7 @@
 	// Private methods.
 	//
 	/**
-	 * Callback triggered on clicking the "preview" button to open a preview window.
+	 * Callback triggered on clicking the link action buttons.
 	 *
 	 * @param {HTMLElement} submitButton The submit button.
 	 * @param {Event} event The event that triggered the
@@ -51,15 +75,17 @@
 	$.pkp.controllers.form.DOIPubIdExportFormHandler.
 			prototype.submitAction_ = function(submitButton, event) {
 
-		var idPattern = new RegExp('(.*)-button-'),
-				button = event.target,
+		var button = event.target,
+				$formElement = $(button).closest('form'),
+				idPattern = new RegExp(this.actionRegExp_[$formElement.attr('id')] +
+						'-button-'),
 				idPatternResult = idPattern.exec(button.id),
-				action = idPatternResult[1],
-				$formElement = $(button).closest('form');
+				action = idPatternResult[1];
 
 		$formElement.append('<input type="hidden" name="' + action + '" value="1">');
 		$formElement.submit();
 		return true;
 	};
+
 /** @param {jQuery} $ jQuery closure. */
 }(jQuery));

--- a/js/controllers/form/DOIPubIdExportFormHandler.js
+++ b/js/controllers/form/DOIPubIdExportFormHandler.js
@@ -51,14 +51,12 @@
 	$.pkp.controllers.form.DOIPubIdExportFormHandler.
 			prototype.submitAction_ = function(submitButton, event) {
 
-		var $formElement = this.getHtmlElement(),
-				idPattern = new RegExp('(.*)-button-'),
-				button = event.target.id,
-				idPatternResult = idPattern.exec(button),
+		var idPattern = new RegExp('(.*)-button-'),
+				button = event.target,
+				idPatternResult = idPattern.exec(button.id),
 				action = idPatternResult[1],
-				actionHiddenInput = $('<input>')
-					.attr('type', 'hidden')
-					.attr('name', action).val('1');
+				$formElement = $(button).closest('form');
+
 		$formElement.append('<input type="hidden" name="' + action + '" value="1">');
 		$formElement.submit();
 		return true;

--- a/plugins/importexport/crossref/templates/index.tpl
+++ b/plugins/importexport/crossref/templates/index.tpl
@@ -64,7 +64,11 @@
 				<script type="text/javascript">
 					$(function() {ldelim}
 						// Attach the form handler.
-						$('#exportSubmissionXmlForm').pkpHandler('$.pkp.controllers.form.DOIPubIdExportFormHandler');
+						$('#exportSubmissionXmlForm').pkpHandler('$.pkp.controllers.form.DOIPubIdExportFormHandler',
+							{ldelim}
+								submissionsActions: {$linkActions|@json_encode},
+							{rdelim}
+						);
 					{rdelim});
 				</script>
 				<form id="exportSubmissionXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
@@ -90,7 +94,11 @@
 				<script type="text/javascript">
 					$(function() {ldelim}
 						// Attach the form handler.
-						$('#exportIssueXmlForm').pkpHandler('$.pkp.controllers.form.DOIPubIdExportFormHandler');
+						$('#exportIssueXmlForm').pkpHandler('$.pkp.controllers.form.DOIPubIdExportFormHandler',
+							{ldelim}
+								issuesActions: {$linkActions|@json_encode},
+							{rdelim}
+						);
 					{rdelim});
 				</script>
 				<p>{translate key="plugins.importexport.crossref.issues.description"}</p>


### PR DESCRIPTION
the form to be submitted was not correctly determined: two forms (submissions and issues export form) have the same JS handler and both were submitted when clicking on an action link. now the form of the event target element is figured out/located and submitted.