### PR TITLE
[crossref] Update pt-br and pt-pt translation

### DIFF
--- a/plugins/importexport/crossref/locale/pt_BR/locale.xml
+++ b/plugins/importexport/crossref/locale/pt_BR/locale.xml
@@ -10,20 +10,20 @@
   *
   * Localization strings for the pt_BR locale.
   -->
- 
+
 <locale name="pt_BR" full_name="Português (Brasil)">
-	<message key="plugins.importexport.crossref.description">Exporta metadados dos artigos no formato CrossRef XML.</message>
-	<message key="plugins.importexport.crossref.displayName">Exportação CrossRef em XML</message>
+	<message key="plugins.importexport.crossref.description">Exportar ou registrar metadados dos artigos no formato CrossRef XML.</message>
+	<message key="plugins.importexport.crossref.displayName">Plugin de Registros e Exportação CrossRef</message>
 	<message key="plugins.importexport.crossref.requirements">Requisitos</message>
-	<message key="plugins.importexport.crossref.requirements.satisfied">Todos os requisitos do plugin estão atendidos.</message>
+	<message key="plugins.importexport.crossref.requirements.satisfied">Todos os requisitos do plugin foram satisfeitos.</message>
 	<message key="plugins.importexport.crossref.error.pluginNotConfigured"><![CDATA[O plugin Crossref não está configurado! Configure este plugin na sua <a href="{$settingsUrl}">página de configurações</a>.]]></message>
 	<message key="plugins.importexport.crossref.error.DOIsNotAvailable"><![CDATA[Plugin de identificador público DOI não configurado! Habilite e configure este plugin na página de configurações do <a href="{$doiUrl}" target="_blank">Plugin DOI</a>.]]></message>
 	<message key="plugins.importexport.crossref.error.publisherNotConfigured"><![CDATA[O nome da editora não foi configurado! Você deve adicionar uma instituição editora no <a href="{$publisherUrl}" target="_blank">passo 1.5 das configurações da revista</a>.]]></message>
 	<message key="plugins.importexport.crossref.settings.depositorIntro">Os seguintes items são exigidos para um depósito bem sucedido na Crossref.</message>
 	<message key="plugins.importexport.crossref.settings.form.depositorName">Nome do depositante</message>
 	<message key="plugins.importexport.crossref.settings.form.depositorEmail">Email do depositante</message>
-	<message key="plugins.importexport.crossref.settings.form.depositorNameRequired">Por favor digite o nome do depositante.</message>
-	<message key="plugins.importexport.crossref.settings.form.depositorEmailRequired">Por favor digite o email do depositante.</message>
+	<message key="plugins.importexport.crossref.settings.form.depositorNameRequired">Por favor, digite o nome do depositante.</message>
+	<message key="plugins.importexport.crossref.settings.form.depositorEmailRequired">Por favor, digite o email do depositante.</message>
 	<message key="plugins.importexport.crossref.settings.form.automaticRegistration">Registrar DOIs automaticamente</message>
 	<message key="plugins.importexport.crossref.settings.form.automaticRegistration.description"><![CDATA[O OJS depositará os DOIs dos artigos automaticamente na Crossref conforme forem publicados. Por favor, note que isso pode levar um tempo após o processo de publicação. Você pode verificar todos DOIs não registrados na <a href="{$unregisteredURL}"> lista de artigos não registrados </a>.]]></message>
 
@@ -33,11 +33,46 @@
 
 	<message key="plugins.importexport.crossref.settings.form.description">Por favor, configure o plugin de exportação/registro CrossRef:</message>
 	<message key="plugins.importexport.crossref.settings.form.username">Nome de usuário</message>
-	<message key="plugins.importexport.crossref.settings.form.usernameRequired">Por favor, informe o nome de usuário que você revcebeu da CrossRef.</message>
+	<message key="plugins.importexport.crossref.settings.form.usernameRequired">Por favor, informe o nome de usuário que você recebeu da CrossRef.</message>
 
-	<message key="plugins.importexport.crossref.export.unregistered">Artigos não registrados</message>
+	<message key="plugins.importexport.crossref.export.unregistered">Exportar artigos não registrados</message>
 	<message key="plugins.importexport.crossref.export.selectUnregistered">Selecionar artigos não registrados</message>
-	<message key="plugins.importexport.crossref.export.noUnregistered">Todos os artigos publicados já foram registrados (ou nenhum deles têm um DOI designado).</message>
+
+  <message key="plugins.importexport.crossref.manageDOIs">Gerenciar DOIs</message>
+	<message key="plugins.importexport.crossref.manageIssues">Gerenciar Edições</message>
+	<message key="plugins.importexport.crossref.manageArticleDOIs">Gerenciar DOIs de Artigos</message>
+	<message key="plugins.importexport.crossref.articles.notDeposited">Todos os artigos publicados já foram registrados (ou nenhum deles possui um DOI registrado).</message>
+	<message key="plugins.importexport.crossref.articles.failed">Não houveram depósitos falhos.</message>
+	<message key="plugins.importexport.crossref.articles.submitted">Não há DOIs submetidos.</message>
+	<message key="plugins.importexport.crossref.articles.completed">Não há depósitos completados.</message>
+	<message key="plugins.importexport.crossref.articles.found">Não há DOIs ativos</message>
+
+	<message key="plugins.importexport.crossref.downloadXML">Download XML</message>
+	<message key="plugins.importexport.crossref.checkStatus">Checar status</message>
+	<message key="plugins.importexport.crossref.checkStatusDescription">Clique aqui para atualizar o status do(s) objeto(s) selecionado(s).</message>
+	<message key="plugins.importexport.crossref.status.all">Todos</message>
+	<message key="plugins.importexport.crossref.status.non">Não depositado</message>
+	<message key="plugins.importexport.crossref.status.submitted">Submetido</message>
+	<message key="plugins.importexport.crossref.status.completed">Depositado</message>
+	<message key="plugins.importexport.crossref.status.failed">Falhos</message>
+	<message key="plugins.importexport.crossref.status.registered">Ativo</message>
+	<message key="plugins.importexport.crossref.status.markedRegistered">Marcado como registrado</message>
+	<message key="plugins.importexport.crossref.statusLegend"><![CDATA[
+		<p>Status de Depósito:</p>
+		<p>
+		- Não depositados: nenhuma tentativa de depósito foi efetuada para estes DOIs.<br />
+		- Submetidos: estes DOIs foram submetidos para depósito.<br />
+		- Depositados: os DOIs foram depositados na Crossref, mas pode, não estar ativos ainda.<br />
+		- Ativos: os DOIs foram depositados e estão funcionando normalmente.<br />
+		- Falhos: o depósito dos DOIs falhou.<br />
+		- Marcados como registrado: os DOIs foram marcados manualmente como registrados.
+		</p>
+		<p>Apenas o status da última verificação é mostrado.</p>
+		<p>Se um depósito falhou, tente resolver o problema e faça o depósito novamente.</p>]]></message>
+
+	<message key="plugins.importexport.crossref.notification.failed">Um doi falhou ao ser registrado. Por favor vá para "Plugin de Registros e Exportação CrossRef > Exportar artigos não registrados > Falhos".</message>
+	<message key="plugins.importexport.crossref.register.error.mdsError">Submissão não sucedida! O servidor de registro DOI retornou um erro: '{$param}'.</message>
+	<message key="plugins.importexport.crossref.register.success">Submissão bem sucedida!</message>
 
 	<message key="plugins.importexport.crossref.cliUsage"><![CDATA[Uso:
 {$scriptName} {$pluginName} export xmlFileName journal_path {issues|articles} objectId1 [objectId2] ...
@@ -45,4 +80,5 @@
 ]]></message>
 
 	<message key="plugins.importexport.crossref.senderTask.name">Dados CrossRef do remetente</message>
+  <message key="plugins.importexport.crossref.senderTask.warning.noDOIprefix">O prefixo DOI está faltando para o jornal localizado em: {$path}.</message>
 </locale>

--- a/plugins/importexport/crossref/locale/pt_BR/locale.xml
+++ b/plugins/importexport/crossref/locale/pt_BR/locale.xml
@@ -13,7 +13,7 @@
 
 <locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.importexport.crossref.description">Exportar ou registrar metadados dos artigos no formato CrossRef XML.</message>
-	<message key="plugins.importexport.crossref.displayName">Plugin de Registros e Exportação CrossRef</message>
+	<message key="plugins.importexport.crossref.displayName">Registro e Exportação XML CrossRef</message>
 	<message key="plugins.importexport.crossref.requirements">Requisitos</message>
 	<message key="plugins.importexport.crossref.requirements.satisfied">Todos os requisitos do plugin foram satisfeitos.</message>
 	<message key="plugins.importexport.crossref.error.pluginNotConfigured"><![CDATA[O plugin Crossref não está configurado! Configure este plugin na sua <a href="{$settingsUrl}">página de configurações</a>.]]></message>
@@ -70,7 +70,7 @@
 		<p>Apenas o status da última verificação é mostrado.</p>
 		<p>Se um depósito falhou, tente resolver o problema e faça o depósito novamente.</p>]]></message>
 
-	<message key="plugins.importexport.crossref.notification.failed">Um doi falhou ao ser registrado. Por favor vá para "Plugin de Registros e Exportação CrossRef > Exportar artigos não registrados > Falhos".</message>
+	<message key="plugins.importexport.crossref.notification.failed">Um doi falhou ao ser registrado. Por favor vá para "Registro e Exportação XML CrossRef > Exportar artigos não registrados > Falhos".</message>
 	<message key="plugins.importexport.crossref.register.error.mdsError">Submissão não sucedida! O servidor de registro DOI retornou um erro: '{$param}'.</message>
 	<message key="plugins.importexport.crossref.register.success">Submissão bem sucedida!</message>
 

--- a/plugins/importexport/crossref/locale/pt_PT/locale.xml
+++ b/plugins/importexport/crossref/locale/pt_PT/locale.xml
@@ -9,35 +9,76 @@
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
   * Localization strings for the pt_PT locale.
-  *
   -->
 
 <locale name="pt_PT" full_name="Português (Portugal)">
-	<message key="plugins.importexport.crossref.displayName">Plugin Exportação CrossRef XML</message>
-	<message key="plugins.importexport.crossref.description">Exporta metadados dos artigos no formato CrossRef XML.</message>
-	
-	<message key="plugins.importexport.crossref.cliUsage">Modo de Usar:
-{$scriptName} {$pluginName} [xmlFileName] [journal_path] artigos [articleId1] [articleId2] ...
-{$scriptName} {$pluginName} [xmlFileName] [journal_path] edição [issueId]</message>
-	<message key="plugins.importexport.crossref.settings.form.username">Utilizador</message>
+	<message key="plugins.importexport.crossref.description">Exportar ou registrar metadados dos artigos no formato CrossRef XML.</message>
+	<message key="plugins.importexport.crossref.displayName">Plugin de Registros e Exportação CrossRef</message>
 	<message key="plugins.importexport.crossref.requirements">Requisitos</message>
 	<message key="plugins.importexport.crossref.requirements.satisfied">Todos os requisitos do plugin foram satisfeitos.</message>
-	<message key="plugins.importexport.crossref.error.pluginNotConfigured"><![CDATA[O plugin CrossRef não está configurado! Configure este plugin em <a href="{$settingsUrl}">na página de configuração geral da revista<a/>]]></message>
-	<message key="plugins.importexport.crossref.settings.form.automaticRegistration">Registar DOIs automaticamente</message>
-	<message key="plugins.importexport.crossref.error.DOIsNotAvailable"><![CDATA[O plugin DOI Public Identifier não configurado! Active e configure este plugin a partir de <a href="{$doiUrl}" target="_blank">DOI Plugin</a> Página de configuração.]]></message>
-	<message key="plugins.importexport.crossref.error.publisherNotConfigured"><![CDATA[Não foi configurado um editor da revista! Tem de adicionar um editor em <a href="{$publisherUrl}" target="_blank">Configuração da Revista, Passo 1.5</a>.]]></message>
-	<message key="plugins.importexport.crossref.settings.depositorIntro">Os seguintes requisitos não obrigatórios para um depósito com sucesso dos dados da CrossRef</message>
-	<message key="plugins.importexport.crossref.settings.form.depositorName">Nome do Depositante</message>
-	<message key="plugins.importexport.crossref.settings.form.depositorEmail">E-mail do Depositante</message>
-	<message key="plugins.importexport.crossref.settings.form.depositorNameRequired">Por favor, insira o nome do depositante.</message>
-	<message key="plugins.importexport.crossref.settings.form.depositorEmailRequired">Por favor, insira o e-mail do depositante.</message>
-	<message key="plugins.importexport.crossref.settings.form.automaticRegistration.description"><![CDATA[OJS depositará os DOIs dos artigos automaticamente na CrossRef tal como estes são publicados. Note que este processo poderá levar algum tempo após o processo de publicação. Poderá verificar todos os DOIs não registados em <a href="{$unregisteredURL}">lista de artigos não registados</a>.]]></message>
-	<message key="plugins.importexport.crossref.registrationIntro"><![CDATA[Este plugin pode ser configurado automaticamente para o Digital Object Identifiers (DOIs) junto da  CrossRef. É necessário estar na posse de nome de utilizador e senha (disponível em <a href="http://www.crossref.org" target="_blank">CrossRef</a>). Se ainda não tem nome de utilizador e senha poderá mesmo assim exportar para o formato XML da CrossRef, mas não poderá registar os DOIs na CrossRef a partir do OJS.]]></message>
-	<message key="plugins.importexport.crossref.settings.description"><![CDATA[Pode <a href="{$settingsUrl}">configurar o plugin de exportação/registo do CrossRef export/aqui</a>.]]></message>
-	<message key="plugins.importexport.crossref.settings.form.description">Por favor, configure o plugin de exportação/registo do CrossRef:</message>
-	<message key="plugins.importexport.crossref.settings.form.usernameRequired">Por favor, insira o nome de utilizador fornecido pela CrossRef</message>
-	<message key="plugins.importexport.crossref.export.unregistered">Artigos não Registados</message>
-	<message key="plugins.importexport.crossref.export.selectUnregistered">Seleccionar artigos não registados</message>
-	<message key="plugins.importexport.crossref.export.noUnregistered">Todos os artigos publicados foram registados (ou nenhum destes tem um DOI atribuído)</message>
-	<message key="plugins.importexport.crossref.senderTask.name">Tarefa de registo automático CrossRef</message>
+	<message key="plugins.importexport.crossref.error.pluginNotConfigured"><![CDATA[O plugin Crossref não está configurado! Configure este plugin na sua <a href="{$settingsUrl}">página de configurações</a>.]]></message>
+	<message key="plugins.importexport.crossref.error.DOIsNotAvailable"><![CDATA[Plugin de identificador público DOI não configurado! Habilite e configure este plugin na página de configurações do <a href="{$doiUrl}" target="_blank">Plugin DOI</a>.]]></message>
+	<message key="plugins.importexport.crossref.error.publisherNotConfigured"><![CDATA[O nome da editora não foi configurado! Você deve adicionar uma instituição editora no <a href="{$publisherUrl}" target="_blank">passo 1.5 das configurações da revista</a>.]]></message>
+	<message key="plugins.importexport.crossref.settings.depositorIntro">Os seguintes items são exigidos para um depósito bem sucedido na Crossref.</message>
+	<message key="plugins.importexport.crossref.settings.form.depositorName">Nome do depositante</message>
+	<message key="plugins.importexport.crossref.settings.form.depositorEmail">Email do depositante</message>
+	<message key="plugins.importexport.crossref.settings.form.depositorNameRequired">Por favor, digite o nome do depositante.</message>
+	<message key="plugins.importexport.crossref.settings.form.depositorEmailRequired">Por favor, digite o email do depositante.</message>
+	<message key="plugins.importexport.crossref.settings.form.automaticRegistration">Registrar DOIs automaticamente</message>
+	<message key="plugins.importexport.crossref.settings.form.automaticRegistration.description"><![CDATA[O OJS depositará os DOIs dos artigos automaticamente na Crossref conforme forem publicados. Por favor, note que isso pode levar um tempo após o processo de publicação. Você pode verificar todos DOIs não registrados na <a href="{$unregisteredURL}"> lista de artigos não registrados </a>.]]></message>
+
+	<message key="plugins.importexport.crossref.registrationIntro"><![CDATA[Este plugin pode ser configurado para registrar automaticamente Identificadores Digitais de Objeto (DOI) com a agência de registro CrossRef. Você precisará de um nome de usuário e senha (disponível a partir <a href="http://www.crossref.org" target="_blank"> CrossRef </a>). Se você não tiver o seu próprio nome de usuário e senha, você ainda pode exportar para o formato CrossRef XML, mas não poderá registrar os seus nomes DOI na CrossRef de dentro do OJS.]]></message>
+
+	<message key="plugins.importexport.crossref.settings.description"><![CDATA[Você pode <a href="{$settingsUrl}"> configurar o plug-in de exportação/registro CrossRef aqui</a>.]]></message>
+
+	<message key="plugins.importexport.crossref.settings.form.description">Por favor, configure o plugin de exportação/registro CrossRef:</message>
+	<message key="plugins.importexport.crossref.settings.form.username">Nome de usuário</message>
+	<message key="plugins.importexport.crossref.settings.form.usernameRequired">Por favor, informe o nome de usuário que você recebeu da CrossRef.</message>
+
+	<message key="plugins.importexport.crossref.export.unregistered">Exportar artigos não registrados</message>
+	<message key="plugins.importexport.crossref.export.selectUnregistered">Selecionar artigos não registrados</message>
+
+  <message key="plugins.importexport.crossref.manageDOIs">Gerenciar DOIs</message>
+	<message key="plugins.importexport.crossref.manageIssues">Gerenciar Edições</message>
+	<message key="plugins.importexport.crossref.manageArticleDOIs">Gerenciar DOIs de Artigos</message>
+	<message key="plugins.importexport.crossref.articles.notDeposited">Todos os artigos publicados já foram registrados (ou nenhum deles possui um DOI registrado).</message>
+	<message key="plugins.importexport.crossref.articles.failed">Não houveram depósitos falhos.</message>
+	<message key="plugins.importexport.crossref.articles.submitted">Não há DOIs submetidos.</message>
+	<message key="plugins.importexport.crossref.articles.completed">Não há depósitos completados.</message>
+	<message key="plugins.importexport.crossref.articles.found">Não há DOIs ativos</message>
+
+	<message key="plugins.importexport.crossref.downloadXML">Download XML</message>
+	<message key="plugins.importexport.crossref.checkStatus">Checar status</message>
+	<message key="plugins.importexport.crossref.checkStatusDescription">Clique aqui para atualizar o status do(s) objeto(s) selecionado(s).</message>
+	<message key="plugins.importexport.crossref.status.all">Todos</message>
+	<message key="plugins.importexport.crossref.status.non">Não depositado</message>
+	<message key="plugins.importexport.crossref.status.submitted">Submetido</message>
+	<message key="plugins.importexport.crossref.status.completed">Depositado</message>
+	<message key="plugins.importexport.crossref.status.failed">Falhos</message>
+	<message key="plugins.importexport.crossref.status.registered">Ativo</message>
+	<message key="plugins.importexport.crossref.status.markedRegistered">Marcado como registrado</message>
+	<message key="plugins.importexport.crossref.statusLegend"><![CDATA[
+		<p>Status de Depósito:</p>
+		<p>
+		- Não depositados: nenhuma tentativa de depósito foi efetuada para estes DOIs.<br />
+		- Submetidos: estes DOIs foram submetidos para depósito.<br />
+		- Depositados: os DOIs foram depositados na Crossref, mas pode, não estar ativos ainda.<br />
+		- Ativos: os DOIs foram depositados e estão funcionando normalmente.<br />
+		- Falhos: o depósito dos DOIs falhou.<br />
+		- Marcados como registrado: os DOIs foram marcados manualmente como registrados.
+		</p>
+		<p>Apenas o status da última verificação é mostrado.</p>
+		<p>Se um depósito falhou, tente resolver o problema e faça o depósito novamente.</p>]]></message>
+
+	<message key="plugins.importexport.crossref.notification.failed">Um doi falhou ao ser registrado. Por favor vá para "Plugin de Registros e Exportação CrossRef > Exportar artigos não registrados > Falhos".</message>
+	<message key="plugins.importexport.crossref.register.error.mdsError">Submissão não sucedida! O servidor de registro DOI retornou um erro: '{$param}'.</message>
+	<message key="plugins.importexport.crossref.register.success">Submissão bem sucedida!</message>
+
+	<message key="plugins.importexport.crossref.cliUsage"><![CDATA[Uso:
+{$scriptName} {$pluginName} export xmlFileName journal_path {issues|articles} objectId1 [objectId2] ...
+{$scriptName} {$pluginName} register journal_path {issues|articles} objectId1 [objectId2] ...
+]]></message>
+
+	<message key="plugins.importexport.crossref.senderTask.name">Dados CrossRef do remetente</message>
+  <message key="plugins.importexport.crossref.senderTask.warning.noDOIprefix">O prefixo DOI está faltando para o jornal localizado em: {$path}.</message>
 </locale>

--- a/plugins/importexport/crossref/locale/pt_PT/locale.xml
+++ b/plugins/importexport/crossref/locale/pt_PT/locale.xml
@@ -2,16 +2,16 @@
 <!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
 
 <!--
-  * plugins/importexport/crossref/locale/pt_BR/locale.xml
+  * plugins/importexport/crossref/locale/pt_PT/locale.xml
   *
   * Copyright (c) 2013-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_BR locale.
+  * Localization strings for the pt_PT locale.
   -->
 
-<locale name="pt_BR" full_name="Português (Brasil)">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.importexport.crossref.description">Exportar ou registrar metadados dos artigos no formato CrossRef XML.</message>
 	<message key="plugins.importexport.crossref.displayName">Registro e Exportação XML CrossRef</message>
 	<message key="plugins.importexport.crossref.requirements">Requisitos</message>

--- a/plugins/importexport/crossref/locale/pt_PT/locale.xml
+++ b/plugins/importexport/crossref/locale/pt_PT/locale.xml
@@ -2,18 +2,18 @@
 <!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
 
 <!--
-  * plugins/importexport/crossref/locale/pt_PT/locale.xml
+  * plugins/importexport/crossref/locale/pt_BR/locale.xml
   *
   * Copyright (c) 2013-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT locale.
+  * Localization strings for the pt_BR locale.
   -->
 
-<locale name="pt_PT" full_name="Português (Portugal)">
+<locale name="pt_BR" full_name="Português (Brasil)">
 	<message key="plugins.importexport.crossref.description">Exportar ou registrar metadados dos artigos no formato CrossRef XML.</message>
-	<message key="plugins.importexport.crossref.displayName">Plugin de Registros e Exportação CrossRef</message>
+	<message key="plugins.importexport.crossref.displayName">Registro e Exportação XML CrossRef</message>
 	<message key="plugins.importexport.crossref.requirements">Requisitos</message>
 	<message key="plugins.importexport.crossref.requirements.satisfied">Todos os requisitos do plugin foram satisfeitos.</message>
 	<message key="plugins.importexport.crossref.error.pluginNotConfigured"><![CDATA[O plugin Crossref não está configurado! Configure este plugin na sua <a href="{$settingsUrl}">página de configurações</a>.]]></message>
@@ -70,7 +70,7 @@
 		<p>Apenas o status da última verificação é mostrado.</p>
 		<p>Se um depósito falhou, tente resolver o problema e faça o depósito novamente.</p>]]></message>
 
-	<message key="plugins.importexport.crossref.notification.failed">Um doi falhou ao ser registrado. Por favor vá para "Plugin de Registros e Exportação CrossRef > Exportar artigos não registrados > Falhos".</message>
+	<message key="plugins.importexport.crossref.notification.failed">Um doi falhou ao ser registrado. Por favor vá para "Registro e Exportação XML CrossRef > Exportar artigos não registrados > Falhos".</message>
 	<message key="plugins.importexport.crossref.register.error.mdsError">Submissão não sucedida! O servidor de registro DOI retornou um erro: '{$param}'.</message>
 	<message key="plugins.importexport.crossref.register.success">Submissão bem sucedida!</message>
 

--- a/plugins/importexport/datacite/locale/pt_BR/common.xml
+++ b/plugins/importexport/datacite/locale/pt_BR/common.xml
@@ -8,18 +8,20 @@
   * Copyright (c) 2003-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings.
+  * Shared localization strings.
   -->
 
 <locale name="pt_BR" full_name="Português (Brasil)">
+
 	<message key="plugins.importexport.common.error.DOIsNotAvailable">Para usar este plugin, acesse a categoria de plugins "Identificadores públicos", habilite e configure o plugin DOI e especifique um prefixo DOI válido nele.</message>
 	<message key="plugins.importexport.common.error.pluginNotConfigured">O plugin não está totalmente configurado.</message>
 
 	<message key="plugins.importexport.common.settings">Configurações</message>
 
 	<message key="plugins.importexport.common.settings.form.password">Senha</message>
-	<message key="plugins.importexport.common.settings.form.passwordRequired">Informe uma senha</message>
-	
+	<message key="plugins.importexport.common.settings.form.passwordRequired">Atenção: a senha será salva em modo texto simples, não encriptada.</message>
+	<message key="plugins.importexport.common.settings.form.passwordRequired">Digite uma senha.</message>
+
 	<message key="plugins.importexport.common.register">Registrar</message>
 	<message key="plugins.importexport.common.registerDescription">Clique neste botão para registrar este objeto na agência de registro pela primeira vez. Isto funciona apenas se o objeto não foi registrado antes.</message>
 	<message key="plugins.importexport.common.registerDescription.multi">Clique neste botão para registrar ou atualizar os metadados do(s) objeto(s) selecionado(s) na agência de registro.</message>
@@ -28,37 +30,39 @@
 	<message key="plugins.importexport.common.register.warning">Registrar muitos objetos pode levar muito tempo. Seja paciente após clicar no botão "Registrar". Uma notificação será gerada ao concluir o registro.</message>
 	<message key="plugins.importexport.common.register.noCredentials"><![CDATA[O registro direto está atualmente desabilitado.<a href="{$settingsUrl}">Configure</a> um login e senha para poder registrar objetos diretamente na agência de registro.]]></message>
 
+	<message key="plugins.importexport.common.markRegistered">Marcar registrados</message>
+	<message key="plugins.importexport.common.markRegisteredDescription">Clique neste botão para marcar os objetos registrados (se registrados previamente ou manualmente).</message>
+
 	<message key="plugins.importexport.common.update">Atualizar</message>
 	<message key="plugins.importexport.common.updateDescription">Clique neste botão para atualizar os metadados deste objeto na agência de registro. Isto funciona apenas se já registrou o objeto com sucesso antes.</message>
-		
+
 	<message key="plugins.importexport.common.export">Exportar dados</message>
+	<message key="plugins.importexport.common.export.unAvailable">Exportação de dados está atualmente desabilitada. Verifique os requisitos do plugin.</message>
 	<message key="plugins.importexport.common.export.unregistered">Exportar todas as edições, artigos e composições não registradas</message>
-	<message key="plugins.importexport.common.export.selectUnregistered">Escolher edições, artigos e composições não registradas</message>
+	<message key="plugins.importexport.common.export.selectUnregistered">Selecionar edições, artigos e composições não registradas</message>
 	<message key="plugins.importexport.common.export.noUnregistered">Todas as edições, artigos e composições já foram registradas (ou nenhum dos itens possui DOI).</message>
 	<message key="plugins.importexport.common.export.issues">Exportar edições específicas</message>
-	<message key="plugins.importexport.common.export.selectIssue">Escolher edições</message>
+	<message key="plugins.importexport.common.export.selectIssue">Selecionar edições</message>
 	<message key="plugins.importexport.common.export.noIssues">Nenhuma edição possui DOI atualmente.</message>
 	<message key="plugins.importexport.common.export.articles">Exportar artigos específicos</message>
-	<message key="plugins.importexport.common.export.selectArticle">Escolher artigos</message>
+	<message key="plugins.importexport.common.export.selectArticle">Selecionar artigos</message>
 	<message key="plugins.importexport.common.export.noArticles">Nenhum artigo possui DOI atualmente.</message>
 	<message key="plugins.importexport.common.export.galleys">Exportar composições específicas</message>
-	<message key="plugins.importexport.common.export.selectGalley">Escolher composições</message>
+	<message key="plugins.importexport.common.export.selectGalley">Selecionar composições</message>
 	<message key="plugins.importexport.common.export.noGalleys">Nenhuma composição possui DOI atualmente.</message>
 	<message key="plugins.importexport.common.exportDescription">Clique neste botão para exportar os dados em XML para o(s) objeto(s) selecionado(s) a um arquivo local sem registrá-lo em alguma agência de registro. Isto pode ser útil caso deseje que terceiros façam o registro do DOI ou se deseja inspecionar o formato XML antes de registrá-lo.</message>
 
 	<message key="plugins.importexport.common.export.error.issueNotFound">Nenhuma edição correspondente ao ID: {$param}.</message>
-	<message key="plugins.importexport.common.export.error.articleNotFound">Nenhum artigo correspondete ao ID: {$param}.</message>
+	<message key="plugins.importexport.common.export.error.articleNotFound">Nenhum artigo correspondente ao ID: {$param}.</message>
 	<message key="plugins.importexport.common.export.error.galleyNotFound">Nenhuma composição correspondente ao ID: {$param}.</message>
 	<message key="plugins.importexport.common.export.error.noDoiAssigned">O objeto de ID {$param} não possui DOI.</message>
-	<message key="plugins.importexport.common.export.error.unknownJournal">Nenhuma publicação corresponde ao caminho: {$param}.</message>
+	<message key="plugins.importexport.common.export.error.unknownJournal">Nenhuma revista encontrada no caminho especificado: {$param}.</message>
 	<message key="plugins.importexport.common.export.error.unknownObjectType">O tipo de objeto {$param} não pode ser exportado.</message>
 	<message key="plugins.importexport.common.export.error.outputFileNotWritable">Não foi possível gravar no arquivo de saída {$param}.</message>
 
 	<message key="plugins.importexport.common.notification.exportSuccessful">Objetos selecionados exportados com sucesso para '{$param}'</message>
 
 	<message key="plugins.importexport.common.cliError">ERRO:</message>
-	<message key="plugins.importexport.common.settings.form.password.description">As senhas serão salvas em texto não cifrado.</message>
-	<message key="plugins.importexport.common.markRegistered">Marco registrado</message>
-	<message key="plugins.importexport.common.markRegisteredDescription">Clique neste botão para marcar os objetos registrados (se registrados previamente ou manualmente).</message>
-	<message key="plugins.importexport.common.export.unAvailable">Exportação de dados está atualmente desabilitada. Verifique os requisitos do plugin.</message>
+
+	<message key="plugins.importexport.common.senderTask.warning.noDOIprefix">O prefixo DOI está faltando para o jornal localizado em {$path}.</message>
 </locale>

--- a/plugins/importexport/datacite/locale/pt_PT/common.xml
+++ b/plugins/importexport/datacite/locale/pt_PT/common.xml
@@ -2,55 +2,67 @@
 <!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
 
 <!--
-  * @file plugins/importexport/medra/locale/pt_PT/common.xml
+  * plugins/importexport/datacite/locale/pt_PT/common.xml
   *
   * Copyright (c) 2013-2016 Simon Fraser University Library
   * Copyright (c) 2003-2016 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Shared localization strings
+  * Shared localization strings.
   -->
 
 <locale name="pt_PT" full_name="Português (Portugal)">
-	<message key="plugins.importexport.common.settings.form.password.description">Tenha em atenção que a senha será guardada como texto, não encriptada.</message>
-	<message key="plugins.importexport.common.markRegistered">Marcar como registado</message>
-	<message key="plugins.importexport.common.markRegisteredDescription">Clicar neste botão para marcar os objectos registados (e.g. se registado antes ou manualmente).</message>
-	<message key="plugins.importexport.common.export.unAvailable">A exportação de dados indisponível. Por favor, verifique os requisitos do plugin.</message>
-	<message key="plugins.importexport.common.error.DOIsNotAvailable">Para utilizar este plugin, por favor, consultar a categoria de plugins "Identificador Público", activar e configurar o plug-in DOI e especificar um prefixo DOI válido.</message>
+
+	<message key="plugins.importexport.common.error.DOIsNotAvailable">Para usar este plugin, acesse a categoria de plugins "Identificadores públicos", habilite e configure o plugin DOI e especifique um prefixo DOI válido nele.</message>
 	<message key="plugins.importexport.common.error.pluginNotConfigured">O plugin não está totalmente configurado.</message>
+
 	<message key="plugins.importexport.common.settings">Configurações</message>
+
 	<message key="plugins.importexport.common.settings.form.password">Senha</message>
-	<message key="plugins.importexport.common.settings.form.passwordRequired">Por favor, insira uma senha.</message>
-	<message key="plugins.importexport.common.register">Registar-se</message>
-	<message key="plugins.importexport.common.registerDescription">Clique neste botão para registar pela primeira vez este objecto na agência de registo. Funciona apenas quando o objecto não foi registado antes!</message>
-	<message key="plugins.importexport.common.registerDescription.multi">Clique neste botão para registar ou actualizar os metadados do objeto (s) seleccionado junto da agência de registo.</message>
-	<message key="plugins.importexport.common.register.error.mdsError">O registo não foi bem-sucedido! O servidor de registo DOI retornou um erro: '{$param}'.</message>
-	<message key="plugins.importexport.common.register.success">Registo com sucesso!</message>
-	<message key="plugins.importexport.common.register.warning">Registar muitos objectos pode demorar. Por favor, seja paciente após clicar no botão "Registar-se". Será notificado quando o registo for concluído.</message>
-	<message key="plugins.importexport.common.register.noCredentials"><![CDATA[O registo directo está actualmente desactivado. <a Href="{$settingsUrl}"> configurar </a> um nome de utilizador e senha para ser possível registar objectos directamente através do serviço de registo.]]></message>
-	<message key="plugins.importexport.common.update">Actualizar</message>
-	<message key="plugins.importexport.common.updateDescription">Clicar neste botão para actualizar os metadados do objecto junto da agência de registo. Funciona apenas se efectuou anteriormente o registo do objecto com sucesso!</message>
-	<message key="plugins.importexport.common.export">Exportar Dados</message>
-	<message key="plugins.importexport.common.export.unregistered">Exportar todos os números, artigos e provas não registados</message>
-	<message key="plugins.importexport.common.export.selectUnregistered">Seleccionar todos os números, artigos e provas não registados</message>
-	<message key="plugins.importexport.common.export.noUnregistered">Todos os números publicados, artigos e provas já foram registados (ou nenhum deles tem um DOI atribuído).</message>
-	<message key="plugins.importexport.common.export.issues">Exportar Números</message>
-	<message key="plugins.importexport.common.export.selectIssue">Seleccionar Números</message>
-	<message key="plugins.importexport.common.export.noIssues">Nenhum número com DOIs atribuído actualmente.</message>
-	<message key="plugins.importexport.common.export.articles">Exportar artigos</message>
-	<message key="plugins.importexport.common.export.selectArticle">Seleccionar Artigos</message>
-	<message key="plugins.importexport.common.export.noArticles">Nenhum artigo com DOIs atribuído actualmente.</message>
-	<message key="plugins.importexport.common.export.galleys">Exportar provas</message>
-	<message key="plugins.importexport.common.export.selectGalley">Seleccionar Provas</message>
-	<message key="plugins.importexport.common.export.noGalleys">Nenhuma prova com DOIs atribuído actualmente.</message>
-	<message key="plugins.importexport.common.exportDescription">Clicar neste botão para exportar dados XML para o objecto (s) seleccionado num ficheiro local, sem registar junto da agência de registo. Poderá ser útil se pretende que um terceiro o substitua no registo de DOIs ou se pretende inspecionar o formato XML antes de registá-lo.</message>
-	<message key="plugins.importexport.common.export.error.issueNotFound">Nenhum número correspondeu ao ID do número específico: {$param}.</message>
-	<message key="plugins.importexport.common.export.error.articleNotFound">Nenhum artigo correspondeu ao ID do artigo específico: {$param}.</message>
-	<message key="plugins.importexport.common.export.error.galleyNotFound">Nenhuma prova correspondeu ao ID da prova específica: {$param}.</message>
-	<message key="plugins.importexport.common.export.error.noDoiAssigned">O objecto com ID {$param} não tem um DOI atribuído.</message>
-	<message key="plugins.importexport.common.export.error.unknownJournal">Nenhuma revista correspondeu ao caminho da revista especificada: {$param}.</message>
-	<message key="plugins.importexport.common.export.error.unknownObjectType">O tipo de objecto {$param} não pode ser exportado.</message>
-	<message key="plugins.importexport.common.export.error.outputFileNotWritable">O ficheiro de saída {$param} não é gravável.</message>
-	<message key="plugins.importexport.common.notification.exportSuccessful">Exportação com sucesso dos objectos seleccionados para '{$param}'</message>
+	<message key="plugins.importexport.common.settings.form.passwordRequired">Atenção: a senha será salva em modo texto simples, não encriptada.</message>
+	<message key="plugins.importexport.common.settings.form.passwordRequired">Digite uma senha.</message>
+
+	<message key="plugins.importexport.common.register">Registrar</message>
+	<message key="plugins.importexport.common.registerDescription">Clique neste botão para registrar este objeto na agência de registro pela primeira vez. Isto funciona apenas se o objeto não foi registrado antes.</message>
+	<message key="plugins.importexport.common.registerDescription.multi">Clique neste botão para registrar ou atualizar os metadados do(s) objeto(s) selecionado(s) na agência de registro.</message>
+	<message key="plugins.importexport.common.register.error.mdsError">Falha no registro! O servidor de registro DOI retornou um erro: '{$param}'.</message>
+	<message key="plugins.importexport.common.register.success">Registro realizado com sucesso!</message>
+	<message key="plugins.importexport.common.register.warning">Registrar muitos objetos pode levar muito tempo. Seja paciente após clicar no botão "Registrar". Uma notificação será gerada ao concluir o registro.</message>
+	<message key="plugins.importexport.common.register.noCredentials"><![CDATA[O registro direto está atualmente desabilitado.<a href="{$settingsUrl}">Configure</a> um login e senha para poder registrar objetos diretamente na agência de registro.]]></message>
+
+	<message key="plugins.importexport.common.markRegistered">Marcar registrados</message>
+	<message key="plugins.importexport.common.markRegisteredDescription">Clique neste botão para marcar os objetos registrados (se registrados previamente ou manualmente).</message>
+
+	<message key="plugins.importexport.common.update">Atualizar</message>
+	<message key="plugins.importexport.common.updateDescription">Clique neste botão para atualizar os metadados deste objeto na agência de registro. Isto funciona apenas se já registrou o objeto com sucesso antes.</message>
+
+	<message key="plugins.importexport.common.export">Exportar dados</message>
+	<message key="plugins.importexport.common.export.unAvailable">Exportação de dados está atualmente desabilitada. Verifique os requisitos do plugin.</message>
+	<message key="plugins.importexport.common.export.unregistered">Exportar todas as edições, artigos e composições não registradas</message>
+	<message key="plugins.importexport.common.export.selectUnregistered">Selecionar edições, artigos e composições não registradas</message>
+	<message key="plugins.importexport.common.export.noUnregistered">Todas as edições, artigos e composições já foram registradas (ou nenhum dos itens possui DOI).</message>
+	<message key="plugins.importexport.common.export.issues">Exportar edições específicas</message>
+	<message key="plugins.importexport.common.export.selectIssue">Selecionar edições</message>
+	<message key="plugins.importexport.common.export.noIssues">Nenhuma edição possui DOI atualmente.</message>
+	<message key="plugins.importexport.common.export.articles">Exportar artigos específicos</message>
+	<message key="plugins.importexport.common.export.selectArticle">Selecionar artigos</message>
+	<message key="plugins.importexport.common.export.noArticles">Nenhum artigo possui DOI atualmente.</message>
+	<message key="plugins.importexport.common.export.galleys">Exportar composições específicas</message>
+	<message key="plugins.importexport.common.export.selectGalley">Selecionar composições</message>
+	<message key="plugins.importexport.common.export.noGalleys">Nenhuma composição possui DOI atualmente.</message>
+	<message key="plugins.importexport.common.exportDescription">Clique neste botão para exportar os dados em XML para o(s) objeto(s) selecionado(s) a um arquivo local sem registrá-lo em alguma agência de registro. Isto pode ser útil caso deseje que terceiros façam o registro do DOI ou se deseja inspecionar o formato XML antes de registrá-lo.</message>
+
+	<message key="plugins.importexport.common.export.error.issueNotFound">Nenhuma edição correspondente ao ID: {$param}.</message>
+	<message key="plugins.importexport.common.export.error.articleNotFound">Nenhum artigo correspondente ao ID: {$param}.</message>
+	<message key="plugins.importexport.common.export.error.galleyNotFound">Nenhuma composição correspondente ao ID: {$param}.</message>
+	<message key="plugins.importexport.common.export.error.noDoiAssigned">O objeto de ID {$param} não possui DOI.</message>
+	<message key="plugins.importexport.common.export.error.unknownJournal">Nenhuma revista encontrada no caminho especificado: {$param}.</message>
+	<message key="plugins.importexport.common.export.error.unknownObjectType">O tipo de objeto {$param} não pode ser exportado.</message>
+	<message key="plugins.importexport.common.export.error.outputFileNotWritable">Não foi possível gravar no arquivo de saída {$param}.</message>
+
+	<message key="plugins.importexport.common.notification.exportSuccessful">Objetos selecionados exportados com sucesso para '{$param}'</message>
+
 	<message key="plugins.importexport.common.cliError">ERRO:</message>
+
+	<message key="plugins.importexport.common.senderTask.warning.noDOIprefix">O prefixo DOI está faltando para o jornal localizado em {$path}.</message>
 </locale>


### PR DESCRIPTION
OJS 2.4.8-1 introduced some big changes on the crossref plugin strings and it looks like no translation were made at all, OJS should warns about this because it is seriously breaking the usability of 2.4.8-1 to every journal editor that doesn't uses en_US.

I made a patch that updates the translation for pt_BR and pt_PT.

@mtub Can you have a look at this?

Thanks!