### PR TITLE
add Arabic locale (ar_IQ) to OJS3

### DIFF
--- a/registry/locales.xml
+++ b/registry/locales.xml
@@ -16,6 +16,7 @@
 <!DOCTYPE locales SYSTEM "../lib/pkp/dtd/locales.dtd">
 
 <locales>
+	<locale key="ar_IQ" complete="true"  name="العربية" iso639-2b="ara" iso639-3="ara" stylesheet="lib/pkp/styles/rtl-arabic.css" />
 	<locale key="ca_ES" complete="false" name="Català" iso639-2b="cat" iso639-3="cat" />
 	<locale key="cs_CZ" complete="false" name="Čeština" iso639-2b="cze" iso639-3="ces" />
 	<locale key="da_DK" complete="false" name="Dansk" iso639-2b="dan" iso639-3="dan" />


### PR DESCRIPTION
I have merged all of @vormia's contributions, OJS 3 is now completely translated to Arabic. This adds ar_IQ to the languages list. See also pkp/pkp-lib#1889
