### PR TITLE
pkp/pkp-lib#1905: Add check in acron to (re)validate scheduled task immediately before run

### DIFF
--- a/plugins/generic/acron/AcronPlugin.inc.php
+++ b/plugins/generic/acron/AcronPlugin.inc.php
@@ -244,7 +244,11 @@ class AcronPlugin extends GenericPlugin {
 
 			// By updating the last run time as soon as feasible, we can minimize
 			// the race window. See bug #8737.
-			$updateResult = $taskDao->updateLastRunTime($className, time());
+			$tasksToRun = $this->_getTasksToRun();
+			$updateResult = 0;
+			if (in_array($task, $tasksToRun, true)) {
+				$updateResult = $taskDao->updateLastRunTime($className, time());
+			}
 
 			switch ($updateResult) {
 				case false: // DB doesn't support the get affected rows used inside update method.

--- a/plugins/generic/acron/AcronPlugin.inc.php
+++ b/plugins/generic/acron/AcronPlugin.inc.php
@@ -250,17 +250,12 @@ class AcronPlugin extends GenericPlugin {
 				$updateResult = $taskDao->updateLastRunTime($className, time());
 			}
 
-			switch ($updateResult) {
-				case false: // DB doesn't support the get affected rows used inside update method.
-				case 1: // Introduced a new last run time.
-					// Load and execute the task.
-					import($className);
-					$task = new $baseClassName($taskArgs);
-					$task->execute();
-					break;
-				case 0: // Another simultaneously request came first.
-				default:
-					break;
+			if ($updateResult === false || $updateResult === 1) {
+				// DB doesn't support the get affected rows used inside update method, or one row was updated when we introduced a new last run time.
+				// Load and execute the task.
+				import($className);
+				$task = new $baseClassName($taskArgs);
+				$task->execute();
 			}
 		}
 	}


### PR DESCRIPTION
Comes closer to resolving pkp/pkp-lib#1905 by giving the semaphore only one method's worth of execution time to be out of sync.  It is still possible to have a duplicate run, but it needs to be outside of the same second (or on a database which doesn't support the "affected rows" query) and must have both processes executing somewhere between the new `$this->_getTasksToRun()` call and the `$taskDao->updateLastRunTime($className, time())` simultaneously.
