### PR TITLE
pkp/pkp-lib#1910: use Crossref test API for status checks when appropriate

### DIFF
--- a/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
+++ b/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
@@ -258,10 +258,13 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 		$doi = urlencode($object->getStoredPubId('doi'));
 		$params = 'filter=doi:' . $doi ;
 
+		// Use a different endpoint for testing and
+		// production.
+		$endpoint = ($this->isTestMode($context) ? CROSSREF_API_URL_DEV : CROSSREF_API_URL);
 		curl_setopt(
 			$curlCh,
 			CURLOPT_URL,
-			CROSSREF_API_URL . (strpos(CROSSREF_API_URL,'?')===false?'?':'&') . $params
+			$endpoint . (strpos($endpoint,'?')===false?'?':'&') . $params
 		);
 		// try to fetch from the new API
 		$response = curl_exec($curlCh);


### PR DESCRIPTION
Well, my test submission still failed, but I think this fixes the status query, at least.