### PR TITLE
pkp/pkp-lib#1966 Update EndNote citation format

### DIFF
--- a/plugins/citationFormats/endNote/citation.tpl
+++ b/plugins/citationFormats/endNote/citation.tpl
@@ -24,9 +24,6 @@
 %D {$issue->getYear()|escape}
 {/if}
 %T {$article->getLocalizedTitle()|strip_tags}
-%B {$article->getDatePublished()|date_format:"%Y"}
-%9 {$article->getLocalizedSubject()|escape}
-%! {$article->getLocalizedTitle()|strip_tags}
 %K {$article->getLocalizedSubject()|escape}
 %X {$article->getLocalizedAbstract()|strip_tags|replace:"\n":" "|replace:"\r":" "}
 %U {$articleUrl}
@@ -34,15 +31,8 @@
 %0 Journal Article
 {if $article->getStoredPubId('doi')}%R {$article->getStoredPubId('doi')|escape}
 {/if}
-{if $article->getPages()}
-{if $article->getStartingPage()}%& {$article->getStartingPage()|escape}{/if}
-{if $article->getEndingPage()}
-{math equation="end - start + 1" end=$article->getEndingPage() start=$article->getStartingPage() assign=pages}
-%P {$pages}
-{else}
-%P 1
-{/if}
-{/if}
+{if $article->getStartingPage()}%P {$article->getStartingPage()|escape}{if $article->getEndingPage()}-{$article->getEndingPage()|escape}
+{/if}{/if}
 {if $issue->getShowVolume()}%V {$issue->getVolume()|escape}
 {/if}
 {if $issue->getShowNumber()}%N {$issue->getNumber()|escape}
@@ -52,8 +42,5 @@
 {/if}
 {if $article->getDatePublished()}
 %8 {$article->getDatePublished()|date_format:"%Y-%m-%d"}
-{/if}
-{if $issue->getDatePublished()}
-%7 {$issue->getDatePublished()|date_format:"%Y-%m-%d"}
 {/if}
 


### PR DESCRIPTION
Addresses the issue pkp/pkp-lib#1966 of correcting and cleaning up EndNote citation export. This has been tested on our journal (haujournal.org), and user confirmed it works for them on EndNote. However, someone else may want to confirm the exporting of page numbers works properly for other journal setups.