### PR TITLE
pkp/pkp-lib#1905 A more reliable semaphore for Acron Plugin 

### DIFF
--- a/plugins/generic/acron/AcronPlugin.inc.php
+++ b/plugins/generic/acron/AcronPlugin.inc.php
@@ -244,7 +244,11 @@ class AcronPlugin extends GenericPlugin {
 
 			// By updating the last run time as soon as feasible, we can minimize
 			// the race window. See bug #8737.
-			$updateResult = $taskDao->updateLastRunTime($className, time());
+			$tasksToRun = $this->_getTasksToRun();
+			$updateResult = 0;
+			if (in_array($task, $tasksToRun, true)) {
+				$updateResult = $taskDao->updateLastRunTime($className, time());
+			}
 
 			switch ($updateResult) {
 				case false: // DB doesn't support the get affected rows used inside update method.

--- a/plugins/generic/acron/AcronPlugin.inc.php
+++ b/plugins/generic/acron/AcronPlugin.inc.php
@@ -250,17 +250,12 @@ class AcronPlugin extends GenericPlugin {
 				$updateResult = $taskDao->updateLastRunTime($className, time());
 			}
 
-			switch ($updateResult) {
-				case false: // DB doesn't support the get affected rows used inside update method.
-				case 1: // Introduced a new last run time.
-					// Load and execute the task.
-					import($className);
-					$task = new $baseClassName($taskArgs);
-					$task->execute();
-					break;
-				case 0: // Another simultaneously request came first.
-				default:
-					break;
+			if ($updateResult === false || $updateResult === 1) {
+				// DB doesn't support the get affected rows used inside update method, or one row was updated when we introduced a new last run time.
+				// Load and execute the task.
+				import($className);
+				$task = new $baseClassName($taskArgs);
+				$task->execute();
 			}
 		}
 	}


### PR DESCRIPTION
s.  https://github.com/pkp/pkp-lib/issues/1905

This is a cherry-pick to ojs-stable-2_4_8