### PR TITLE
Add missing comma to `pages` in bibtex citation

### DIFF
--- a/plugins/citationFormats/bibtex/citation.tpl
+++ b/plugins/citationFormats/bibtex/citation.tpl
@@ -23,7 +23,7 @@
 {/literal}{assign var=onlineIssn value=$journal->getSetting('onlineIssn')}
 {assign var=issn value=$journal->getSetting('issn')}{if $issn}{literal}	issn = {{/literal}{$issn|bibtex_escape}{literal}},{/literal}
 {elseif $onlineIssn}{literal}	issn = {{/literal}{$onlineIssn|bibtex_escape}{literal}},{/literal}{/if}
-{if $article->getPages()}{if $article->getStartingPage()}	pages = {literal}{{/literal}{$article->getStartingPage()}{if $article->getEndingPage()}--{$article->getEndingPage()}{/if}{literal}}{/literal}{/if}{/if}
+{if $article->getPages()}{if $article->getStartingPage()}	pages = {literal}{{/literal}{$article->getStartingPage()}{if $article->getEndingPage()}--{$article->getEndingPage()}{/if}{literal}},{/literal}{/if}{/if}
 {if $article->getStoredPubId('doi')}	doi = {ldelim}{$article->getStoredPubId('doi')|escape}{rdelim},
 {/if}
 	url = {ldelim}{url|bibtex_escape page="article" op="view" path=$article->getBestArticleId()}{rdelim}


### PR DESCRIPTION
Added a comma delimiting pages from doi. JabRef and other managers reported import problems without this comma.