### PR TITLE
pkp/pkp-lib#2068: Change DOIExportPlugin assertion to !isempty() instead of passing "register" value directly.

### DIFF
--- a/plugins/importexport/datacite/classes/DOIExportPlugin.inc.php
+++ b/plugins/importexport/datacite/classes/DOIExportPlugin.inc.php
@@ -239,7 +239,7 @@ class DOIExportPlugin extends ImportExportPlugin {
 					);
 					break;
 				} else { // Register selected objects.
-					assert($request->getUserVar('register'));
+					assert($request->getUserVar('register') != false);
 					$result = $this->registerObjects($request, $exportSpec, $journal);
 
 					// Provide the user with some visual feedback that


### PR DESCRIPTION
Resolves pkp/pkp-lib#2068.