### PR TITLE
pkp/pkp-lib#2074: Update use of createElement and createElementNS escaping

### DIFF
--- a/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
@@ -92,7 +92,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 
 		// title
 		$titlesNode = $doc->createElementNS($deployment->getNamespace(), 'titles');
-		$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', $submission->getTitle($submission->getLocale())));
+		$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars($submission->getTitle($submission->getLocale()), ENT_COMPAT, 'UTF-8')));
 		$journalArticleNode->appendChild($titlesNode);
 
 		// contributors
@@ -107,8 +107,8 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 			} else {
 				$personNameNode->setAttribute('sequence', 'additional');
 			}
-			$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'given_name', ucfirst($author->getFirstName()).(($author->getMiddleName())?' '.ucfirst($author->getMiddleName()):'')));
-			$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'surname', ucfirst($author->getLastName())));
+			$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'given_name', htmlspecialchars(ucfirst($author->getFirstName()).(($author->getMiddleName())?' '.ucfirst($author->getMiddleName()):''), ENT_COMPAT, 'UTF-8')));
+			$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'surname', htmlspecialchars(ucfirst($author->getLastName()), ENT_COMPAT, 'UTF-8')));
 			if ($author->getData('orcid')) {
 				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ORCID', $author->getData('orcid')));
 			}
@@ -119,7 +119,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 		// abstract
 		if ($submission->getAbstract($submission->getLocale())) {
 			$abstractNode = $doc->createElementNS($deployment->getJATSNamespace(), 'jats:abstract');
-			$abstractNode->appendChild($node = $doc->createElementNS($deployment->getJATSNamespace(), 'jats:p', html_entity_decode(strip_tags($submission->getAbstract($submission->getLocale())), ENT_COMPAT, 'UTF-8')));
+			$abstractNode->appendChild($node = $doc->createElementNS($deployment->getJATSNamespace(), 'jats:p', htmlspecialchars(html_entity_decode(strip_tags($submission->getAbstract($submission->getLocale())), ENT_COMPAT, 'UTF-8'), ENT_COMPAT, 'UTF-8')));
 			$journalArticleNode->appendChild($abstractNode);
 		}
 
@@ -149,7 +149,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 		if ($submission->getLicenseUrl()) {
 			$licenseNode = $doc->createElementNS($deployment->getAINamespace(), 'ai:program');
 			$licenseNode->setAttribute('name', 'AccessIndicators');
-			$licenseNode->appendChild($node = $doc->createElementNS($deployment->getAINamespace(), 'ai:license_ref', $submission->getLicenseUrl()));
+			$licenseNode->appendChild($node = $doc->createElementNS($deployment->getAINamespace(), 'ai:license_ref', htmlspecialchars($submission->getLicenseUrl(), ENT_COMPAT, 'UTF-8')));
 			$journalArticleNode->appendChild($licenseNode);
 		}
 
@@ -218,13 +218,13 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 			$crawlerBasedCollectionNode->setAttribute('property', 'crawler-based');
 			$iParadigmsItemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
 			$iParadigmsItemNode->setAttribute('crawler', 'iParadigms');
-			$iParadigmsItemNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $resourceURL));
+			$iParadigmsItemNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', htmlspecialchars($resourceURL, ENT_COMPAT, 'UTF-8')));
 			$crawlerBasedCollectionNode->appendChild($iParadigmsItemNode);
 			$doiDataNode->appendChild($crawlerBasedCollectionNode);
 			// end iParadigms
 			// text-mining collection item
 			$textMiningItemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
-			$resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', $resourceURL);
+			$resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', htmlspecialchars($resourceURL, ENT_COMPAT, 'UTF-8'));
 			if (!$galley->getRemoteURL()) $resourceNode->setAttribute('mime_type', $galley->getFileType());
 			$textMiningItemNode->appendChild($resourceNode);
 			$textMiningCollectionNode->appendChild($textMiningItemNode);
@@ -255,7 +255,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 			$componentFileTitle = $componentFile->getName($componentGalley->getLocale());
 			if (!empty($componentFileTitle)) {
 				$titlesNode = $doc->createElementNS($deployment->getNamespace(), 'titles');
-				$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', $componentFileTitle));
+				$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars($componentFileTitle, ENT_COMPAT, 'UTF-8')));
 				$componentNode->appendChild($titlesNode);
 			}
 			// DOI data node

--- a/plugins/importexport/crossref/filter/IssueCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/IssueCrossrefXmlFilter.inc.php
@@ -99,7 +99,7 @@ class IssueCrossrefXmlFilter extends NativeExportFilter {
 		$context = $deployment->getContext();
 		$plugin = $deployment->getPlugin();
 		$headNode = $doc->createElementNS($deployment->getNamespace(), 'head');
-		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi_batch_id', $context->getSetting('initials', $context->getPrimaryLocale()) . '_' . time()));
+		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi_batch_id', htmlspecialchars($context->getSetting('initials', $context->getPrimaryLocale()) . '_' . time(), ENT_COMPAT, 'UTF-8')));
 		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'timestamp', time()));
 		$depositorNode = $doc->createElementNS($deployment->getNamespace(), 'depositor');
 		$depositorName = $plugin->getSetting($context->getId(), 'depositorName');
@@ -110,11 +110,11 @@ class IssueCrossrefXmlFilter extends NativeExportFilter {
 		if (empty($depositorEmail)) {
 			$depositorEmail = $context->getSetting('supportEmail');
 		}
-		$depositorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'depositor_name', $depositorName));
-		$depositorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'email_address', $depositorEmail));
+		$depositorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'depositor_name', htmlspecialchars($depositorName, ENT_COMPAT, 'UTF=8')));
+		$depositorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'email_address', htmlspecialchars($depositorEmail, ENT_COMPAT, 'UTF-8')));
 		$headNode->appendChild($depositorNode);
 		$publisherInstitution = $context->getSetting('publisherInstitution');
-		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'registrant', $publisherInstitution));
+		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'registrant', htmlspecialchars($publisherInstitution, ENT_COMPAT, 'UTF-8')));
 		return $headNode;
 	}
 
@@ -148,13 +148,13 @@ class IssueCrossrefXmlFilter extends NativeExportFilter {
 		if ($journalTitle == '') {
 			$journalTitle = $context->getSetting('abbreviation', $context->getPrimaryLocale());
 		}
-		$journalMetadataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'full_title', $journalTitle));
+		$journalMetadataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'full_title', htmlspecialchars($journalTitle, ENT_COMPAT, 'UTF-8')));
 		/* Abbreviated title - defaulting to initials if no abbreviation found */
 		$journalAbbrev = $context->getSetting('abbreviation', $context->getPrimaryLocale());
 		if ( $journalAbbrev == '' ) {
 			$journalAbbrev = $context->getSetting('acronym', $context->getPrimaryLocale());
 		}
-		$journalMetadataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'abbrev_title', $journalAbbrev));
+		$journalMetadataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'abbrev_title', htmlspecialchars($journalAbbrev, ENT_COMPAT, 'UTF-8')));
 		/* Both ISSNs are permitted for CrossRef, so sending whichever one (or both) */
 		if ($ISSN = $context->getSetting('onlineIssn') ) {
 			$journalMetadataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'issn', $ISSN));
@@ -185,11 +185,11 @@ class IssueCrossrefXmlFilter extends NativeExportFilter {
 		}
 		if ($issue->getVolume() && $issue->getShowVolume()){
 			$journalVolumeNode = $doc->createElementNS($deployment->getNamespace(), 'journal_volume');
-			$journalVolumeNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'volume', $issue->getVolume()));
+			$journalVolumeNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'volume', htmlspecialchars($issue->getVolume(), ENT_COMPAT, 'UTF-8')));
 			$journalIssueNode->appendChild($journalVolumeNode);
 		}
 		if ($issue->getNumber() && $issue->getShowNumber()) {
-			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'issue', $issue->getNumber()));
+			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'issue', htmlspecialchars($issue->getNumber(), ENT_COMPAT, 'UTF-8')));
 		}
 		if ($issue->getDatePublished() && $issue->getStoredPubId('doi')) {
 			$journalIssueNode->appendChild($this->createDOIDataNode($doc, $issue->getStoredPubId('doi'), Request::url($context->getPath(), 'issue', 'view', $issue->getBestIssueId($context))));
@@ -228,8 +228,8 @@ class IssueCrossrefXmlFilter extends NativeExportFilter {
 	function createDOIDataNode($doc, $doi, $url) {
 		$deployment = $this->getDeployment();
 		$doiDataNode = $doc->createElementNS($deployment->getNamespace(), 'doi_data');
-		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi', $doi));
-		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $url));
+		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
+		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', htmlspecialchars($url, ENT_COMPAT, 'UTF-8')));
 		return $doiDataNode;
 	}
 

--- a/plugins/importexport/datacite/filter/DataciteXmlFilter.inc.php
+++ b/plugins/importexport/datacite/filter/DataciteXmlFilter.inc.php
@@ -141,14 +141,14 @@ class DataciteXmlFilter extends NativeExportFilter {
 		if ($plugin->isTestMode($context)) {
 			$doi = PKPString::regexp_replace('#^[^/]+/#', DATACITE_API_TESTPREFIX . '/', $doi);
 		}
-		$rootNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'identifier', $doi));
+		$rootNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'identifier', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 		$node->setAttribute('identifierType', DATACITE_IDTYPE_DOI);
 		// Creators (mandatory)
 		$rootNode->appendChild($this->createCreatorsNode($doc, $issue, $article, $galley, $galleyFile, $publisher, $objectLocalePrecedence));
 		// Title (mandatory)
 		$rootNode->appendChild($this->createTitlesNode($doc, $issue, $article, $galley, $galleyFile, $objectLocalePrecedence));
 		// Publisher (mandatory)
-		$rootNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'publisher', $publisher));
+		$rootNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'publisher', htmlspecialchars($publisher, ENT_COMPAT, 'UTF-8')));
 		// Publication Year (mandatory)
 		$rootNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'publicationYear', date('Y', strtotime($publicationDate))));
 		// Subjects
@@ -160,7 +160,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 		}
 		if (!empty($subject)) {
 			$subjectsNode = $doc->createElementNS($deployment->getNamespace(), 'subjects');
-			$subjectsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'subject', $subject));
+			$subjectsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'subject', htmlspecialchars($subject, ENT_COMPAT, 'UTF-8')));
 			$rootNode->appendChild($subjectsNode);
 		}
 		// Dates
@@ -183,7 +183,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 			$format = $galleyFile->getFileType();
 			if (!empty($format)) {
 				$formatsNode = $doc->createElementNS($deployment->getNamespace(), 'formats');
-				$formatsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'format', $format));
+				$formatsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'format', htmlspecialchars($format, ENT_COMPAT, 'UTF-8')));
 				$rootNode->appendChild($formatsNode);
 			}
 		}
@@ -191,7 +191,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 		$rightsURL = $article ? $article->getLicenseURL() : $context->getSetting('licenseURL');
 		if(!empty($rightsURL)) {
 			$rightsNode = $doc->createElementNS($deployment->getNamespace(), 'rightsList');
-			$rightsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'rights', strip_tags(Application::getCCLicenseBadge($rightsURL))));
+			$rightsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'rights', htmlspecialchars(strip_tags(Application::getCCLicenseBadge($rightsURL)), ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('rightsURI', $rightsURL);
 			$rootNode->appendChild($rightsNode);
 		}
@@ -258,7 +258,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 		$creatorsNode = $doc->createElementNS($deployment->getNamespace(), 'creators');
 		foreach ($creators as $creator) {
 			$creatorNode = $doc->createElementNS($deployment->getNamespace(), 'creator');
-			$creatorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'creatorName', $creator));
+			$creatorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'creatorName', htmlspecialchars($creator, ENT_COMPAT, 'UTF-8')));
 			$creatorsNode->appendChild($creatorNode);
 		}
 		return $creatorsNode;
@@ -297,15 +297,15 @@ class DataciteXmlFilter extends NativeExportFilter {
 		$titlesNode = $doc->createElementNS($deployment->getNamespace(), 'titles');
 		// Start with the primary object locale.
 		$primaryTitle = array_shift($titles);
-		$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', PKPString::html2text($primaryTitle)));
+		$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars(PKPString::html2text($primaryTitle), ENT_COMPAT, 'UTF-8')));
 		// Then let the translated titles follow.
 		foreach($titles as $locale => $title) {
-			$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', PKPString::html2text($title)));
+			$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars(PKPString::html2text($title), ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('titleType', DATACITE_TITLETYPE_TRANSLATED);
 		}
 		// And finally the alternative title.
 		if (!empty($alternativeTitle)) {
-			$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', PKPString::html2text($alternativeTitle)));
+			$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars(PKPString::html2text($alternativeTitle), ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('titleType', DATACITE_TITLETYPE_ALTERNATIVE);
 		}
 		return $titlesNode;
@@ -478,7 +478,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 				assert(isset($article));
 				$doi = $article->getStoredPubId('doi');
 				if (!empty($doi)) {
-					$relatedIdentifiersNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'relatedIdentifier', $doi));
+					$relatedIdentifiersNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'relatedIdentifier', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 					$node->setAttribute('relatedIdentifierType', DATACITE_IDTYPE_DOI);
 					$node->setAttribute('relationType', DATACITE_RELTYPE_ISPARTOF);
 				}
@@ -488,7 +488,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 				assert(isset($issue));
 				$doi = $issue->getStoredPubId('doi');
 				if (!empty($doi)) {
-					$relatedIdentifiersNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'relatedIdentifier', $doi));
+					$relatedIdentifiersNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'relatedIdentifier', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 					$node->setAttribute('relatedIdentifierType', DATACITE_IDTYPE_DOI);
 					$node->setAttribute('relationType', DATACITE_RELTYPE_ISPARTOF);
 				}
@@ -499,7 +499,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 				foreach ($galleysByArticle as $relatedGalley) {
 					$doi = $relatedGalley->getStoredPubId('doi');
 					if (!empty($doi)) {
-						$relatedIdentifiersNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'relatedIdentifier', $doi));
+						$relatedIdentifiersNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'relatedIdentifier', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 						$node->setAttribute('relatedIdentifierType', DATACITE_IDTYPE_DOI);
 						$node->setAttribute('relationType', DATACITE_RELTYPE_HASPART);
 					}
@@ -569,7 +569,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 		if (!empty($sizes)) {
 			$sizesNode = $doc->createElementNS($deployment->getNamespace(), 'sizes');
 			foreach($sizes as $size) {
-				$sizesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'size', $size));
+				$sizesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'size', htmlspecialchars($size, ENT_COMPAT, 'UTF-8')));
 			}
 		}
 		return $sizesNode;
@@ -616,7 +616,7 @@ class DataciteXmlFilter extends NativeExportFilter {
 		if (!empty($descriptions)) {
 			$descriptionsNode = $doc->createElementNS($deployment->getNamespace(), 'descriptions');
 			foreach($descriptions as $descType => $description) {
-				$descriptionsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'description', PKPString::html2text($description)));
+				$descriptionsNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'description', htmlspecialchars(PKPString::html2text($description), ENT_COMPAT, 'UTF-8')));
 				$node->setAttribute('descriptionType', $descType);
 			}
 		}

--- a/plugins/importexport/doaj/filter/DOAJXmlFilter.inc.php
+++ b/plugins/importexport/doaj/filter/DOAJXmlFilter.inc.php
@@ -76,10 +76,10 @@ class DOAJXmlFilter extends NativeExportFilter {
 			if (!empty($language)) $recordNode->appendChild($node = $doc->createElement('language', $language));
 			// Publisher name (i.e. institution name)
 			$publisher = $context->getSetting('publisherInstitution');
-			if (!empty($publisher)) $recordNode->appendChild($node = $doc->createElement('publisher', $publisher));
+			if (!empty($publisher)) $recordNode->appendChild($node = $doc->createElement('publisher', htmlspecialchars($publisher, ENT_COMPAT, 'UTF-8')));
 			// Journal's title (M)
 			$journalTitle =  $context->getName($context->getPrimaryLocale());
-			$recordNode->appendChild($node = $doc->createElement('journalTitle', $journalTitle));
+			$recordNode->appendChild($node = $doc->createElement('journalTitle', htmlspecialchars($journalTitle, ENT_COMPAT, 'UTF-8')));
 			// Identification Numbers
 			$issn = $context->getSetting('printIssn');
 			if (!empty($issn)) $recordNode->appendChild($node = $doc->createElement('issn', $issn));
@@ -93,9 +93,9 @@ class DOAJXmlFilter extends NativeExportFilter {
 				$recordNode->appendChild($node = $doc->createElement('publicationDate', $this->formatDate($issue->getDatePublished())));
 			}
 			$volume = $issue->getVolume();
-			if (!empty($volume) && $issue->getShowVolume()) $recordNode->appendChild($node = $doc->createElement('volume', $volume));
+			if (!empty($volume) && $issue->getShowVolume()) $recordNode->appendChild($node = $doc->createElement('volume', htmlspecialchars($volume, ENT_COMPAT, 'UTF-8')));
 			$issueNumber = $issue->getNumber();
-			if (!empty($issueNumber) && $issue->getShowNumber()) $recordNode->appendChild($node = $doc->createElement('issue', $issueNumber));
+			if (!empty($issueNumber) && $issue->getShowNumber()) $recordNode->appendChild($node = $doc->createElement('issue', htmlspecialchars($issueNumber, ENT_COMPAT, 'UTF-8')));
 			/** --- FirstPage / LastPage (from PubMed plugin)---
 			 * there is some ambiguity for online journals as to what
 			 * "page numbers" are; for example, some journals (eg. JMIR)
@@ -104,25 +104,25 @@ class DOAJXmlFilter extends NativeExportFilter {
 			$pages = $pubObject->getPages();
 			if (preg_match("/([0-9]+)\s*-\s*([0-9]+)/i", $pages, $matches)) {
 				// simple pagination (eg. "pp. 3-8")
-				$recordNode->appendChild($node = $doc->createElement('startPage', $matches[1]));
-				$recordNode->appendChild($node = $doc->createElement('endPage', $matches[2]));
+				$recordNode->appendChild($node = $doc->createElement('startPage', htmlspecialchars($matches[1], ENT_COMPAT, 'UTF-8')));
+				$recordNode->appendChild($node = $doc->createElement('endPage', htmlspecialchars($matches[2], ENT_COMPAT, 'UTF-8')));
 			} elseif (preg_match("/(e[0-9]+)/i", $pages, $matches)) {
 				// elocation-id (eg. "e12")
-				$recordNode->appendChild($node = $doc->createElement('startPage', $matches[1]));
-				$recordNode->appendChild($node = $doc->createElement('endPage', $matches[1]));
+				$recordNode->appendChild($node = $doc->createElement('startPage', htmlspecialchars($matches[1], ENT_COMPAT, 'UTF-8')));
+				$recordNode->appendChild($node = $doc->createElement('endPage', htmlspecialchars($matches[1], ENT_COMPAT, 'UTF-8')));
 			}
 			// DOI
 			$doi = $pubObject->getStoredPubId('doi');
-			if (!empty($doi)) $recordNode->appendChild($node = $doc->createElement('doi', $doi));
+			if (!empty($doi)) $recordNode->appendChild($node = $doc->createElement('doi', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 			// publisherRecordId
-			$recordNode->appendChild($node = $doc->createElement('publisherRecordId', $pubObject->getId()));
+			$recordNode->appendChild($node = $doc->createElement('publisherRecordId', htmlspecialchars($pubObject->getId(), ENT_COMPAT, 'UTF-8')));
 			// documentType
 			$type = $pubObject->getType($pubObject->getLocale());
-			if (!empty($type)) $recordNode->appendChild($node = $doc->createElement('documentType', $type));
+			if (!empty($type)) $recordNode->appendChild($node = $doc->createElement('documentType', htmlspecialchars($type, ENT_COMPAT, 'UTF-8')));
 			// Article title
 			foreach ((array) $pubObject->getTitle(null) as $locale => $title) {
 				if (!empty($title)) {
-					$recordNode->appendChild($node = $doc->createElement('title', $title));
+					$recordNode->appendChild($node = $doc->createElement('title', htmlspecialchars($title, ENT_COMPAT, 'UTF-8')));
 					$node->setAttribute('language', AppLocale::get3LetterIsoFromLocale($locale));
 				}
 			}
@@ -137,26 +137,26 @@ class DOAJXmlFilter extends NativeExportFilter {
 				$affilsNode = $doc->createElement('affiliationsList');
 				$recordNode->appendChild($affilsNode);
 				for ($i = 0; $i < count($affilList); $i++) {
-					$affilsNode->appendChild($node = $doc->createElement('affiliationName', $affilList[$i]));
+					$affilsNode->appendChild($node = $doc->createElement('affiliationName', htmlspecialchars($affilList[$i], ENT_COMPAT, 'UTF-8')));
 					$node->setAttribute('affiliationId', $i);
 				}
 			}
 			// Abstract
 			foreach ((array) $pubObject->getAbstract(null) as $locale => $abstract) {
 				if (!empty($abstract)) {
-					$recordNode->appendChild($node = $doc->createElement('abstract', PKPString::html2text($abstract)));
+					$recordNode->appendChild($node = $doc->createElement('abstract', htmlspecialchars(PKPString::html2text($abstract), ENT_COMPAT, 'UTF-8')));
 					$node->setAttribute('language', AppLocale::get3LetterIsoFromLocale($locale));
 				}
 			}
 			// FullText URL
-			$recordNode->appendChild($node = $doc->createElement('fullTextUrl', Request::url(null, 'article', 'view', $pubObject->getId())));
+			$recordNode->appendChild($node = $doc->createElement('fullTextUrl', htmlspecialchars(Request::url(null, 'article', 'view', $pubObject->getId()), ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('format', 'html');
 			// Keywords
 			$keywordsNode = $doc->createElement('keywords');
 			$recordNode->appendChild($keywordsNode);
 			$subjects = array_map('trim', explode(';', $pubObject->getSubject($pubObject->getLocale())));
 			foreach ($subjects as $keyword) {
-				if (!empty($keyword)) $keywordsNode->appendChild($node = $doc->createElement('keyword', $keyword));
+				if (!empty($keyword)) $keywordsNode->appendChild($node = $doc->createElement('keyword', htmlspecialchars($keyword, ENT_COMPAT, 'UTF-8')));
 			}
 		}
 		return $doc;
@@ -186,11 +186,11 @@ class DOAJXmlFilter extends NativeExportFilter {
 	function createAuthorNode($doc, $article, $author, $affilList) {
 		$deployment = $this->getDeployment();
 		$authorNode = $doc->createElement('author');
-		$authorNode->appendChild($node = $doc->createElement('name', $author->getFullName()));
+		$authorNode->appendChild($node = $doc->createElement('name', htmlspecialchars($author->getFullName(), ENT_COMPAT, 'UTF-8')));
 		$email = $author->getEmail();
 		if (!empty($email)) $authorNode->appendChild($node = $doc->createElement('email', $email));
 		if(in_array($author->getAffiliation($article->getLocale()), $affilList)  && !empty($affilList[0])) {
-			$authorNode->appendChild($node = $doc->createElement('affiliationId', current(array_keys($affilList, $author->getAffiliation($article->getLocale())))));
+			$authorNode->appendChild($node = $doc->createElement('affiliationId', htmlspecialchars(current(array_keys($affilList, $author->getAffiliation($article->getLocale()))), ENT_COMPAT, 'UTF-8')));
 		}
 		return $authorNode;
 	}

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -135,7 +135,7 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$notificationType = (empty($registeredDoi) ? O4DOI_NOTIFICATION_TYPE_NEW : O4DOI_NOTIFICATION_TYPE_UPDATE);
 		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'NotificationType', $notificationType));
 		// DOI (mandatory)
-		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOI', $doi));
+		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOI', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 		// DOI URL (mandatory)
 		$urlPath = $article->getBestArticleId();
 		if ($galley) $urlPath = array($article->getBestArticleId(), $galley->getBestGalleyId());
@@ -144,11 +144,11 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 			// Change server domain for testing.
 			$url = PKPString::regexp_replace('#://[^\s]+/index.php#', '://example.com/index.php', $url);
 		}
-		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOIWebsiteLink', $url));
+		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOIWebsiteLink', htmlspecialchars($url, ENT_COMPAT, 'UTF-8')));
 		// DOI strucural type
 		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOIStructuralType', $this->getDOIStructuralType()));
 		// Registrant (mandatory)
-		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'RegistrantName', $plugin->getSetting($context->getId(), 'registrantName')));
+		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'RegistrantName', htmlspecialchars($plugin->getSetting($context->getId(), 'registrantName'), ENT_COMPAT, 'UTF-8')));
 		// Registration authority (mandatory)
 		$articleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'RegistrationAuthority', 'mEDRA'));
 		// WorkIdentifier - proprietary ID
@@ -353,22 +353,22 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		// Person name (mandatory)
 		$personName = $author->getFullName();
 		assert(!empty($personName));
-		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PersonName', $personName));
+		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PersonName', htmlspecialchars($personName, ENT_COMPAT, 'UTF-8')));
 		// Inverted person name
 		$invertedPersonName = $author->getFullName(true);
 		assert(!empty($invertedPersonName));
-		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PersonNameInverted', $invertedPersonName));
+		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PersonNameInverted', htmlspecialchars($invertedPersonName, ENT_COMPAT, 'UTF-8')));
 		// Affiliation
 		$affiliation = $this->getPrimaryTranslation($author->getAffiliation(null), $objectLocalePrecedence);
 		if (!empty($affiliation)) {
 			$affiliationNode = $doc->createElementNS($deployment->getNamespace(), 'ProfessionalAffiliation');
-			$affiliationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'Affiliation', $affiliation));
+			$affiliationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'Affiliation', htmlspecialchars($affiliation, ENT_COMPAT, 'UTF-8')));
 			$contributorNode->appendChild($affiliationNode);
 		}
 		// Biographical note
 		$bioNote = $this->getPrimaryTranslation($author->getBiography(null), $objectLocalePrecedence);
 		if (!empty($bioNote)) {
-			$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'BiographicalNote', PKPString::html2text($bioNote)));
+			$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'BiographicalNote', htmlspecialchars(PKPString::html2text($bioNote), ENT_COMPAT, 'UTF-8')));
 		}
 		return $contributorNode;
 	}
@@ -388,12 +388,12 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectSchemeIdentifier', $subjectSchemeId));
 		if (is_null($subjectSchemeName)) {
 			// Subject Heading
-			$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectHeadingText', $subjectHeadingOrCode));
+			$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectHeadingText', htmlspecialchars($subjectHeadingOrCode, ENT_COMPAT, 'UTF-8')));
 		} else {
 			// Subject Scheme Name
-			$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectSchemeName', $subjectSchemeName));
+			$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectSchemeName', htmlspecialchars($subjectSchemeName, ENT_COMPAT, 'UTF-8')));
 			// Subject Code
-			$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectCode', $subjectHeadingOrCode));
+			$subjectNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SubjectCode', htmlspecialchars($subjectHeadingOrCode, ENT_COMPAT, 'UTF-8')));
 		}
 		return $subjectNode;
 	}

--- a/plugins/importexport/medra/filter/IssueMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/IssueMedraXmlFilter.inc.php
@@ -98,19 +98,19 @@ class IssueMedraXmlFilter extends O4DOIXmlFilter {
 		$notificationType = (empty($registeredDoi) ? O4DOI_NOTIFICATION_TYPE_NEW : O4DOI_NOTIFICATION_TYPE_UPDATE);
 		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'NotificationType', $notificationType));
 		// DOI (mandatory)
-		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOI', $doi));
+		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOI', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
 		// DOI URL (mandatory)
 		$url = $router->url($request, $context->getPath(), 'article', 'view', $pubObject->getBestIssueId());
 		if ($plugin->isTestMode($context)) {
 			// Change server domain for testing.
 			$url = PKPString::regexp_replace('#://[^\s]+/index.php#', '://example.com/index.php', $url);
 		}
-		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOIWebsiteLink', $url));
+		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOIWebsiteLink', htmlspecialchars($url, ENT_COMPAT, 'UTF-8')));
 		// DOI strucural type
 		$structuralType = $this->isWork($context, $plugin) ? 'Abstraction' : 'DigitalFixation';
 		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'DOIStructuralType', $structuralType));
 		// Registrant (mandatory)
-		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'RegistrantName', $plugin->getSetting($context->getId(), 'registrantName')));
+		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'RegistrantName', htmlspecialchars($plugin->getSetting($context->getId(), 'registrantName'), ENT_COMPAT, 'UTF-8')));
 		// Registration authority (mandatory)
 		$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'RegistrationAuthority', 'mEDRA'));
 		// Work/ProductIdentifier - proprietary ID

--- a/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
@@ -132,9 +132,9 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		$context = $deployment->getContext();
 		$plugin = $deployment->getPlugin();
 		$headNode = $doc->createElementNS($deployment->getNamespace(), 'Header');
-		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'FromCompany', $plugin->getSetting($context->getId(), 'fromCompany')));
-		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'FromPerson',  $plugin->getSetting($context->getId(), 'fromName')));
-		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'FromEmail',  $plugin->getSetting($context->getId(), 'fromEmail')));
+		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'FromCompany', htmlspecialchars($plugin->getSetting($context->getId(), 'fromCompany'), ENT_COMPAT, 'UTF-8')));
+		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'FromPerson',  htmlspecialchars($plugin->getSetting($context->getId(), 'fromName'), ENT_COMPAT, 'UTF-8')));
+		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'FromEmail',  htmlspecialchars($plugin->getSetting($context->getId(), 'fromEmail'), ENT_COMPAT, 'UTF-8')));
 		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ToCompany',  'mEDRA'));
 		$headNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SentDate',  date('YmdHi')));
 		// Message note
@@ -190,7 +190,7 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		// Publisher
 		$serialWorkNode->appendChild($this->createPublisherNode($doc, $journalLocalePrecedence));
 		// Country of Publication (mandatory)
-		$serialWorkNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'CountryOfPublication',  $plugin->getSetting($context->getId(), 'publicationCountry')));
+		$serialWorkNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'CountryOfPublication',  htmlspecialchars($plugin->getSetting($context->getId(), 'publicationCountry'), ENT_COMPAT, 'UTF-8')));
 		return $serialWorkNode;
 	}
 
@@ -214,7 +214,7 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		// Title type (mandatory)
 		$titleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'TitleType', $titleType));
 		// Title text (mandatory)
-		$titleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'TitleText', PKPString::html2text($localizedTitle)));
+		$titleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'TitleText', htmlspecialchars(PKPString::html2text($localizedTitle), ENT_COMPAT, 'UTF-8')));
 		return $titleNode;
 	}
 
@@ -238,7 +238,7 @@ class O4DOIXmlFilter extends NativeExportFilter {
 			$publisher = $this->getPrimaryTranslation($context->getName(null), $journalLocalePrecedence);
 		}
 		assert(!empty($publisher));
-		$publisherNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PublisherName', $publisher));
+		$publisherNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PublisherName', htmlspecialchars($publisher, ENT_COMPAT, 'UTF-8')));
 		return $publisherNode;
 	}
 
@@ -287,17 +287,17 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		// Volume
 		$volume = $issue->getVolume();
 		if (!empty($volume) && $issue->getShowVolume()) {
-			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'JournalVolumeNumber', $volume));
+			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'JournalVolumeNumber', htmlspecialchars($volume, ENT_COMPAT, 'UTF-8')));
 		}
 		// Number
 		$number = $issue->getNumber();
 		if (!empty($number) && $issue->getShowNumber()) {
-			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'JournalIssueNumber', $number));
+			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'JournalIssueNumber', htmlspecialchars($number, ENT_COMPAT, 'UTF-8')));
 		}
 		// Identification
 		$identification = $issue->getIssueIdentification();
 		if (!empty($identification)) {
-			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'JournalIssueDesignation', $identification));
+			$journalIssueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'JournalIssueDesignation', htmlspecialchars($identification, ENT_COMPAT, 'UTF-8')));
 		}
 		assert(!(empty($number) && empty($identification)));
 		// Nominal Year
@@ -393,7 +393,7 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		// Text
 		$language = AppLocale::get3LetterIsoFromLocale($locale);
 		assert(!empty($language));
-		$otherTextNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'Text', PKPString::html2text($description)));
+		$otherTextNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'Text', htmlspecialchars(PKPString::html2text($description), ENT_COMPAT, 'UTF-8')));
 		$node->setAttribute('textformat', O4DOI_TEXTFORMAT_ASCII);
 		$node->setAttribute('language', $language);
 		return $otherTextNode;

--- a/plugins/importexport/native/filter/ArticleNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/ArticleNativeXmlFilter.inc.php
@@ -82,7 +82,7 @@ class ArticleNativeXmlFilter extends SubmissionNativeXmlFilter {
 			$submissionNode->appendChild($nativeFilterHelper->createIssueIdentificationNode($this, $doc, $issue));
 		}
 		$pages = $submission->getPages();
-		if (!empty($pages)) $submissionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'pages', $pages));
+		if (!empty($pages)) $submissionNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'pages', htmlspecialchars($pages, ENT_COMPAT, 'UTF-8')));
 		return $submissionNode;
 	}
 

--- a/plugins/importexport/native/filter/ArtworkFileNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/ArtworkFileNativeXmlFilter.inc.php
@@ -49,19 +49,19 @@ class ArtworkFileNativeXmlFilter extends SubmissionFileNativeXmlFilter {
 		$deployment = $this->getDeployment();
 		$submissionFileNode = parent::createSubmissionFileNode($doc, $submissionFile);
 		if ($caption = $submissionFile->getCaption()) {
-			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'caption', $caption));
+			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'caption', htmlspecialchars($caption, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($credit = $submissionFile->getCredit()) {
-			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'credit', $credit));
+			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'credit', htmlspecialchars($credit, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($copyrightOwner = $submissionFile->getCopyrightOwner()) {
-			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'copyright_owner', $copyrightOwner));
+			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'copyright_owner', htmlspecialchars($copyrightOwner, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($copyrightOwnerContact = $submissionFile->getCopyrightOwnerContactDetails()) {
-			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'copyright_owner_contact', $copyrightOwnerContact));
+			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'copyright_owner_contact', htmlspecialchars($copyrightOwnerContact, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($permissionTerms = $submissionFile->getPermissionTerms()) {
-			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'permission_terms', $permissionTerms));
+			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'permission_terms', htmlspecialchars($permissionTerms, ENT_COMPAT, 'UTF-8')));
 		}
 
 		// FIXME: is permission file ID implemented?

--- a/plugins/importexport/native/filter/IssueGalleyNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/IssueGalleyNativeXmlFilter.inc.php
@@ -76,7 +76,7 @@ class IssueGalleyNativeXmlFilter extends NativeExportFilter {
 		$deployment = $this->getDeployment();
 		$issueGalleyNode = $doc->createElementNS($deployment->getNamespace(), 'issue_galley');
 		$issueGalleyNode->setAttribute('locale', $issueGalley->getLocale());
-		$issueGalleyNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'label', $issueGalley->getLabel()));
+		$issueGalleyNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'label', htmlspecialchars($issueGalley->getLabel(), ENT_COMPAT, 'UTF-8')));
 
 		$this->addFile($doc, $issueGalleyNode, $issueGalley);
 
@@ -96,11 +96,11 @@ class IssueGalleyNativeXmlFilter extends NativeExportFilter {
 		if ($issueFile) {
 			$deployment = $this->getDeployment();
 			$issueFileNode = $doc->createElementNS($deployment->getNamespace(), 'issue_file');
-			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'file_name', $issueFile->getServerFileName()));
-			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'file_type', $issueFile->getFileType()));
+			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'file_name', htmlspecialchars($issueFile->getServerFileName(), ENT_COMPAT, 'UTF-8')));
+			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'file_type', htmlspecialchars($issueFile->getFileType(), ENT_COMPAT, 'UTF-8')));
 			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'file_size', $issueFile->getFileSize()));
-			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'content_type', $issueFile->getContentType()));
-			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'original_file_name', $issueFile->getOriginalFileName()));
+			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'content_type', htmlspecialchars($issueFile->getContentType(), ENT_COMPAT, 'UTF-8')));
+			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'original_file_name', htmlspecialchars($issueFile->getOriginalFileName(), ENT_COMPAT, 'UTF-8')));
 			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'date_uploaded', strftime('%F', strtotime($issueFile->getDateUploaded()))));
 			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'date_modified', strftime('%F', strtotime($issueFile->getDateModified()))));
 

--- a/plugins/importexport/native/filter/IssueNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/IssueNativeXmlFilter.inc.php
@@ -118,7 +118,7 @@ class IssueNativeXmlFilter extends NativeExportFilter {
 
 		// Add public ID
 		if ($pubId = $issue->getStoredPubId('publisher-id')) {
-			$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', 'public');
 			$node->setAttribute('advice', 'update');
 		}
@@ -142,7 +142,7 @@ class IssueNativeXmlFilter extends NativeExportFilter {
 		$pubId = $issue->getStoredPubId($pubIdPlugin->getPubIdType());
 		if ($pubId) {
 			$deployment = $this->getDeployment();
-			$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', $pubId));
+			$issueNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'id', htmlspecialchars($pubId, ENT_COMPAT, 'UTF-8')));
 			$node->setAttribute('type', $pubIdPlugin->getPubIdType());
 			$node->setAttribute('advice', 'update');
 			return $node;
@@ -229,8 +229,8 @@ class IssueNativeXmlFilter extends NativeExportFilter {
 			foreach ($coverImages as $locale => $coverImage) {
 				$coverNode = $doc->createElementNS($deployment->getNamespace(), 'cover');
 				$coverNode->setAttribute('locale', $locale);
-				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image', $coverImage));
-				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image_alt_text', $issue->getCoverImageAltText($locale)));
+				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image', htmlspecialchars($coverImage, ENT_COMPAT, 'UTF-8')));
+				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image_alt_text', htmlspecialchars($issue->getCoverImageAltText($locale), ENT_COMPAT, 'UTF-8')));
 
 				import('classes.file.PublicFileManager');
 				$publicFileManager = new PublicFileManager();

--- a/plugins/importexport/native/filter/NativeFilterHelper.inc.php
+++ b/plugins/importexport/native/filter/NativeFilterHelper.inc.php
@@ -31,15 +31,15 @@ class NativeFilterHelper {
 		$issueIdentificationNode = $doc->createElementNS($deployment->getNamespace(), 'issue_identification');
 		if ($issue->getShowVolume()) {
 			assert(!empty($vol));
-			$issueIdentificationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'volume', $vol));
+			$issueIdentificationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'volume', htmlspecialchars($vol, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($issue->getShowNumber()) {
 			assert(!empty($num));
-			$issueIdentificationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'number', $num));
+			$issueIdentificationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'number', htmlspecialchars($num, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($issue->getShowYear()) {
 			assert(!empty($year));
-			$issueIdentificationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'year', $year));
+			$issueIdentificationNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'year', htmlspecialchars($year, ENT_COMPAT, 'UTF-8')));
 		}
 		if ($issue->getShowTitle()) {
 			assert(!empty($title));

--- a/plugins/importexport/native/filter/SupplementaryFileNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/SupplementaryFileNativeXmlFilter.inc.php
@@ -58,7 +58,7 @@ class SupplementaryFileNativeXmlFilter extends SubmissionFileNativeXmlFilter {
 		}
 		$this->createLocalizedNodes($doc, $submissionFileNode, 'source', $submissionFile->getSource(null));
 		if ($language = $submissionFile->getLanguage()) {
-			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'language', $language));
+			$submissionFileNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'language', htmlspecialchars($language, ENT_COMPAT, 'UTF-8')));
 		}
 		return $submissionFileNode;
 	}


### PR DESCRIPTION
Specifically, for XML contexts with user-sourced data to escape the data.

Our XML output is UTF-8 regardless of the selected locale, correct?

This is essentially a find-and-replace change and requires vetting.  I have not tested the changes against a live dataset.