### PR TITLE
Fix error in RefWorks export (misplaced {if})

### DIFF
--- a/plugins/citationFormats/refWorks/citation.tpl
+++ b/plugins/citationFormats/refWorks/citation.tpl
@@ -14,42 +14,17 @@
 	{url|assign:"articleUrl" page="article" op="view" path=$article->getBestArticleId()}
 {/if}
 <form class="refworks_citation_form" action="http://www.refworks.com/express/expressimport.asp?vendor=Public%20Knowledge%20Project&filter=BibTeX&encoding=65001" method="post" target="RefWorksMain">
-	<textarea name="ImportData" rows=15 cols=70>
-	{literal}
-		@article{
-			{{/literal}{$journal->getLocalizedAcronym()|escape}{literal}}
-			{{/literal}{$articleId|escape}{literal}},
-			author = {{/literal}{assign var=authors value=$article->getAuthors()}{foreach from=$authors item=author name=authors key=i}{$author->getLastName()|escape}, {assign var=firstName value=$author->getFirstName()}{assign var=authorCount value=$authors|@count}{$firstName|escape|truncate:1:""}.{if $i<$authorCount-1}, {/if}{/foreach}{literal}},
-			title = {{/literal}{$article->getLocalizedTitle()|strip_unsafe_html}{literal}},
-			journal = {{/literal}{$journal->getLocalizedName()|escape}{literal}},{/literal}
-			{if $issue}
-				{if $issue->getShowVolume()}
-					{literal}
-						volume = {{/literal}{$issue->getVolume()|escape}{literal}},
-					{/literal}	
-				{/if}
-				{if $issue->getShowNumber()} {* Swap places of 'if' and 'literal' / Simon Mitternacht 2016-12-08 *}
-					{literal}
-						number = {{/literal}{$issue->getNumber()|escape}{literal}},
-					{/literal}
-				{/if}
-			{/if}
-			{literal}
-				year = {{/literal}{if $article->getDatePublished()}{$article->getDatePublished()|date_format:'%Y'}{elseif $issue->getDatePublished()}{$issue->getDatePublished()|date_format:'%Y'}{else}{$issue->getYear()|escape}{/if}{literal}},
-			{/literal}
-			{assign var=issn value=$journal->getSetting('issn')|escape}
-			{if $issn}
-				{literal}
-					issn = {{/literal}{$issn|escape}{literal}},
-				{/literal}
-			{/if}
-			{if $article->getStoredPubId('doi')}
-				doi = {ldelim}{$article->getStoredPubId('doi')|escape}{rdelim},
-			{/if}
-			{literal}
-				url = {{/literal}{$articleUrl}{literal}}
-		}
-	{/literal}
-	</textarea>
+	<textarea name="ImportData" rows=15 cols=70>{literal}@article{{{/literal}{$journal->getLocalizedAcronym()|escape}{literal}}{{/literal}{$articleId|escape}{literal}},
+	author = {{/literal}{assign var=authors value=$article->getAuthors()}{foreach from=$authors item=author name=authors key=i}{$author->getLastName()|escape}, {assign var=firstName value=$author->getFirstName()}{assign var=authorCount value=$authors|@count}{$firstName|escape|truncate:1:""}.{if $i<$authorCount-1}, {/if}{/foreach}{literal}},
+	title = {{/literal}{$article->getLocalizedTitle()|strip_unsafe_html}{literal}},
+	journal = {{/literal}{$journal->getLocalizedName()|escape}{literal}},
+{/literal}{if $issue}{if $issue->getShowVolume()}{literal}	volume = {{/literal}{$issue->getVolume()|escape}{literal}},{/literal}{/if}
+{if $issue->getShowNumber()}{literal}	number = {{/literal}{$issue->getNumber()|escape}{literal}},{/literal}{/if}{/if}{literal}
+	year = {{/literal}{if $article->getDatePublished()}{$article->getDatePublished()|date_format:'%Y'}{elseif $issue->getDatePublished()}{$issue->getDatePublished()|date_format:'%Y'}{else}{$issue->getYear()|escape}{/if}{literal}},
+{/literal}{assign var=issn value=$journal->getSetting('issn')|escape}{if $issn}{literal}	issn = {{/literal}{$issn|escape}{literal}},{/literal}{/if}
+{if $article->getStoredPubId('doi')}	doi = {ldelim}{$article->getStoredPubId('doi')|escape}{rdelim},
+{/if}
+{literal}	url = {{/literal}{$articleUrl}{literal}}
+}{/literal}</textarea>
 	<input type="submit" class="button defaultButton" name="Submit" value="{translate key="plugins.citationFormats.refWorks.export"}" />
 </form>

--- a/plugins/citationFormats/refWorks/citation.tpl
+++ b/plugins/citationFormats/refWorks/citation.tpl
@@ -14,17 +14,42 @@
 	{url|assign:"articleUrl" page="article" op="view" path=$article->getBestArticleId()}
 {/if}
 <form class="refworks_citation_form" action="http://www.refworks.com/express/expressimport.asp?vendor=Public%20Knowledge%20Project&filter=BibTeX&encoding=65001" method="post" target="RefWorksMain">
-	<textarea name="ImportData" rows=15 cols=70>{literal}@article{{{/literal}{$journal->getLocalizedAcronym()|escape}{literal}}{{/literal}{$articleId|escape}{literal}},
-	author = {{/literal}{assign var=authors value=$article->getAuthors()}{foreach from=$authors item=author name=authors key=i}{$author->getLastName()|escape}, {assign var=firstName value=$author->getFirstName()}{assign var=authorCount value=$authors|@count}{$firstName|escape|truncate:1:""}.{if $i<$authorCount-1}, {/if}{/foreach}{literal}},
-	title = {{/literal}{$article->getLocalizedTitle()|strip_unsafe_html}{literal}},
-	journal = {{/literal}{$journal->getLocalizedName()|escape}{literal}},
-{/literal}{if $issue}{if $issue->getShowVolume()}{literal}	volume = {{/literal}{$issue->getVolume()|escape}{literal}},{/literal}{/if}{literal}
-{if $issue->getShowNumber()}	number = {{/literal}{$issue->getNumber()|escape}{literal}},{/literal}{/if}{/if}{literal}
-	year = {{/literal}{if $article->getDatePublished()}{$article->getDatePublished()|date_format:'%Y'}{elseif $issue->getDatePublished()}{$issue->getDatePublished()|date_format:'%Y'}{else}{$issue->getYear()|escape}{/if}{literal}},
-{/literal}{assign var=issn value=$journal->getSetting('issn')|escape}{if $issn}{literal}	issn = {{/literal}{$issn|escape}{literal}},{/literal}{/if}
-{if $article->getStoredPubId('doi')}	doi = {ldelim}{$article->getStoredPubId('doi')|escape}{rdelim},
-{/if}
-{literal}	url = {{/literal}{$articleUrl}{literal}}
-}{/literal}</textarea>
+	<textarea name="ImportData" rows=15 cols=70>
+	{literal}
+		@article{
+			{{/literal}{$journal->getLocalizedAcronym()|escape}{literal}}
+			{{/literal}{$articleId|escape}{literal}},
+			author = {{/literal}{assign var=authors value=$article->getAuthors()}{foreach from=$authors item=author name=authors key=i}{$author->getLastName()|escape}, {assign var=firstName value=$author->getFirstName()}{assign var=authorCount value=$authors|@count}{$firstName|escape|truncate:1:""}.{if $i<$authorCount-1}, {/if}{/foreach}{literal}},
+			title = {{/literal}{$article->getLocalizedTitle()|strip_unsafe_html}{literal}},
+			journal = {{/literal}{$journal->getLocalizedName()|escape}{literal}},{/literal}
+			{if $issue}
+				{if $issue->getShowVolume()}
+					{literal}
+						volume = {{/literal}{$issue->getVolume()|escape}{literal}},
+					{/literal}	
+				{/if}
+				{if $issue->getShowNumber()} {* Swap places of 'if' and 'literal' / Simon Mitternacht 2016-12-08 *}
+					{literal}
+						number = {{/literal}{$issue->getNumber()|escape}{literal}},
+					{/literal}
+				{/if}
+			{/if}
+			{literal}
+				year = {{/literal}{if $article->getDatePublished()}{$article->getDatePublished()|date_format:'%Y'}{elseif $issue->getDatePublished()}{$issue->getDatePublished()|date_format:'%Y'}{else}{$issue->getYear()|escape}{/if}{literal}},
+			{/literal}
+			{assign var=issn value=$journal->getSetting('issn')|escape}
+			{if $issn}
+				{literal}
+					issn = {{/literal}{$issn|escape}{literal}},
+				{/literal}
+			{/if}
+			{if $article->getStoredPubId('doi')}
+				doi = {ldelim}{$article->getStoredPubId('doi')|escape}{rdelim},
+			{/if}
+			{literal}
+				url = {{/literal}{$articleUrl}{literal}}
+		}
+	{/literal}
+	</textarea>
 	<input type="submit" class="button defaultButton" name="Submit" value="{translate key="plugins.citationFormats.refWorks.export"}" />
 </form>


### PR DESCRIPTION
My log was clogging up with smarty errors from the RefWorks citation plugin. Only real change was on line 31, the rest was just indentation to be able to locate the error.