### PR TITLE
pkp/pkp-lib#2074 remove double escape for Crossref URLs

### DIFF
--- a/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
@@ -218,13 +218,13 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 			$crawlerBasedCollectionNode->setAttribute('property', 'crawler-based');
 			$iParadigmsItemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
 			$iParadigmsItemNode->setAttribute('crawler', 'iParadigms');
-			$iParadigmsItemNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', htmlspecialchars($resourceURL, ENT_COMPAT, 'UTF-8')));
+			$iParadigmsItemNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $resourceURL));
 			$crawlerBasedCollectionNode->appendChild($iParadigmsItemNode);
 			$doiDataNode->appendChild($crawlerBasedCollectionNode);
 			// end iParadigms
 			// text-mining collection item
 			$textMiningItemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
-			$resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', htmlspecialchars($resourceURL, ENT_COMPAT, 'UTF-8'));
+			$resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', $resourceURL);
 			if (!$galley->getRemoteURL()) $resourceNode->setAttribute('mime_type', $galley->getFileType());
 			$textMiningItemNode->appendChild($resourceNode);
 			$textMiningCollectionNode->appendChild($textMiningItemNode);

--- a/plugins/importexport/crossref/filter/IssueCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/IssueCrossrefXmlFilter.inc.php
@@ -229,7 +229,7 @@ class IssueCrossrefXmlFilter extends NativeExportFilter {
 		$deployment = $this->getDeployment();
 		$doiDataNode = $doc->createElementNS($deployment->getNamespace(), 'doi_data');
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi', htmlspecialchars($doi, ENT_COMPAT, 'UTF-8')));
-		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', htmlspecialchars($url, ENT_COMPAT, 'UTF-8')));
+		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $url));
 		return $doiDataNode;
 	}
 


### PR DESCRIPTION
I forgot to remove htmlspecialchars for URLs after using the "escape" parameter for the request URL function, so that URLs are escaped double and thus incorrect :-(