### PR TITLE
Partial fix for pkp/pkp-lib#1924 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ temp
 .buildpath
 .settings
 .DS_Store
+# Local changes
+/.idea*
+*.bak
+*.live
+*.log
+GeoLiteCity.dat

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,3 @@ temp
 .buildpath
 .settings
 .DS_Store
-# Local changes
-/.idea*
-*.bak
-*.live
-*.log
-GeoLiteCity.dat

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -109,7 +109,7 @@ show_upgrade_warning = On
 
 ; Set the following parameter to off if you want to work with the uncompiled (non-minified) JavaScript
 ; source for debugging or if you are working off a development branch without compiled JavaScript.
-enable_minified = Off
+enable_minified = On
 
 ; Provide a unique site ID and OAI base URL to PKP for statistics and security
 ; alert purposes only.

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -109,7 +109,7 @@ show_upgrade_warning = On
 
 ; Set the following parameter to off if you want to work with the uncompiled (non-minified) JavaScript
 ; source for debugging or if you are working off a development branch without compiled JavaScript.
-enable_minified = On
+enable_minified = Off
 
 ; Provide a unique site ID and OAI base URL to PKP for statistics and security
 ; alert purposes only.


### PR DESCRIPTION
New function `glob_ci_pattern` that provides us with a case-insensitive globbing pattern so that the upgrade does not complain about not finding "123-456-7-??.PDF" when the file is in fact "123-456-7-??.pdf". Tested on Linux only, I am afraid that it might not work on Windows machines, depends on `glob()` implementation on Windows ([this post](http://php.net/manual/en/function.glob.php#108440) suggests that even Windows PHP supports character classes, but I have not way to test it).

I do not know if this is the best way to deal with the error, but it seems to: When I have a manuscript submitted with `.pdf` extension, our OJS 2.4.5 will save it as `<aid>-<fid>-<ver>-SM.pdf`, while a submission ending with `.PDF` will be saved as `<aid>-<fid>-<ver>-SM.PDF`. The database update will change the numbering of the files, and it seems to force the file extensions to lowercase. Nevertheless, the possibility of uppercase or mixed case file extension is ignored by the upgrade script which assumes that all extensions are lowercase.

Sorry for the number of reverts ...