### PR TITLE
fix migration problem with multilingual review forms #1782

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -697,7 +697,7 @@ class Upgrade extends Installer {
 				$newOptions[$key] = $option['content'];
 			}
 			$row['setting_value'] = serialize($newOptions);
-			$reviewFormDao->Replace('review_form_element_settings', $row, array('review_form_id', 'locale', 'setting_name'));
+			$reviewFormDao->Replace('review_form_element_settings', $row, array('review_form_element_id', 'locale', 'setting_name'));
 			$result->MoveNext();
 		}
 		$result->Close();

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /cache/
+


### PR DESCRIPTION
Migrating from OJS2 to OJS3 causes multilingual review forms to break and show "Array" as values. 
Mentioned here: https://github.com/pkp/pkp-lib/issues/1782

Although the discussion there suggests that the original code should be working, I could not get it to work without this change.

This code worked both with a clean install of 2.4.8.1 and our production server with 45 journals.