### PR TITLE
pkp/pkp-lib#2156: cleanup install/upgrade docs

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -209,6 +209,14 @@ Third-party Libraries
 	* See lib/pkp/lib/libraries.txt for a list of third-party libraries
 	  used by OJS.
 
+	* OJS supports the legacy GeoLiteCite database to approximate geolocation
+	  information for usage statistics. If you would like to use this optional
+	  functionality, you can download the database from MaxMind at:
+	  http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+	  You will need to decompress the file and place "GeoLiteCity.dat" into
+	  the "plugins/generic/usageStats" directory. A separate license agreement
+	  is required for this use of this database. For details, see:
+	  https://dev.maxmind.com/geoip/legacy/geolite/
 
 Contact/Support
 ---------------

--- a/docs/UPGRADE
+++ b/docs/UPGRADE
@@ -73,13 +73,13 @@ If you have not made local code modifications to the system, upgrade by
 downloading the complete package for the latest release of OJS:
 
     - Download and decompress the package from the OJS web site
-    - Make a copy of the config.inc.php provided in the new package
     - Move or copy the following files and directories from your current OJS
       installation:
         - config.inc.php
         - public/
         - Your uploaded files directory ("files_dir" in config.inc.php), if it
           resides within your OJS directory
+    - Synchronize new changes from config.TEMPLATE.inc.php to config.inc.php
     - Replace the current OJS directory with the new OJS directory, moving the
       old one to a safe location as a backup
     - Be sure to review the Configuration Changes section of the release notes


### PR DESCRIPTION
Update README to note the GeoLiteCity database option.  Update UPGRADE to clarify the Full Package install process.

Resolves pkp/pkp-lib#2156 for stable 2.4.8
