### PR TITLE
Replace page counting with ranges

### DIFF
--- a/classes/article/Article.inc.php
+++ b/classes/article/Article.inc.php
@@ -228,19 +228,25 @@ class Article extends Submission {
 	}
 
 	/**
+	 * Deprecated - this was used for loosely counting pages.  Either use ranges as entered, or write an actual page counting function.
 	 * Get starting page of an article.
+	 * @see Submission::getPageArray()
 	 * @return int
 	 */
 	function getStartingPage() {
+		if (Config::getVar('debug', 'deprecation_warnings')) trigger_error('Deprecated call to Article::getStartingPage().');
 		preg_match('/^[^\d]*(\d+)\D*(.*)$/', $this->getPages(), $pages);
 		return $pages[1];
 	}
 
 	/**
+	 * Deprecated - this was used for loosely counting pages.  Either use ranges as entered, or write an actual page counting function.
 	 * Get ending page of an article.
+	 * @see Submission::getPageArray()
 	 * @return int
 	 */
 	function getEndingPage() {
+		if (Config::getVar('debug', 'deprecation_warnings')) trigger_error('Deprecated call to Article::getEndingPage().');
 		preg_match('/^[^\d]*(\d+)\D*(.*)$/', $this->getPages(), $pages);
 		return $pages[2];
 	}

--- a/plugins/citationFormats/endNote/citation.tpl
+++ b/plugins/citationFormats/endNote/citation.tpl
@@ -31,8 +31,8 @@
 %0 Journal Article
 {if $article->getStoredPubId('doi')}%R {$article->getStoredPubId('doi')|escape}
 {/if}
-{if $article->getStartingPage()}%P {$article->getStartingPage()|escape}{if $article->getEndingPage()}-{$article->getEndingPage()|escape}
-{/if}{/if}
+{if count($article->getPageArray()) > 0}%P {foreach from=$article->getPageArray() item=range name=pages}{$range[0]|escape}{if $range[1]}-{$range[1]|escape}{if !$smarty.foreach.pages.last},{/if}{/if}{/foreach}
+{/if}
 {if $issue->getShowVolume()}%V {$issue->getVolume()|escape}
 {/if}
 {if $issue->getShowNumber()}%N {$issue->getNumber()|escape}

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -195,23 +195,20 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$seq = $article->getSequence();
 		assert(!empty($seq));
 		$contentItemNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SequenceNumber', $seq));
-		// Number of pages
-		$pages = $article->getPages();
-		if (is_numeric($pages)) {
-			$pages = (int) $pages;
-		} else {
-			// If the field is not numeric then try to parse it (eg. "pp. 3-8").
-			if (preg_match("/([0-9]+)\s*-\s*([0-9]+)/i", $pages, $matches)) {
-				if (is_numeric($matches[1]) && is_numeric($matches[2])) {
-					$firstPage = (int) $matches[1];
-					$lastPage = (int) $matches[2];
-					$pages = $lastPage - $firstPage + 1;
-				}
-			}
-		}
-		if (is_integer($pages)) {
+		// Describe page runs
+		$pages = $article->getPageArray();
+		if ($pages) {
 			$textItemNode = $doc->createElementNS($deployment->getNamespace(), 'TextItem');
-			$textItemNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'NumberOfPages', $pages));
+			foreach ($pages as $range) {
+				$pageRunNode = $doc->createElementNS($deployment->getNamespace(), 'PageRun');
+				$node = $doc->createElementNS($deployment->getNamespace(), 'FirstPageNumber', htmlspecialchars($range[0]));
+				$pageRunNode->appendChild($node);
+				if (isset($range[1])) {
+					$node = $doc->createElementNS($deployment->getNamespace(), 'LastPageNumber', htmlspecialchars($range[1]));
+					$pageRunNode->appendChild($node);
+				}
+				$textItemNode->appendChild($pageRunNode);
+			}
 			$contentItemNode->appendChild($textItemNode);
 		}
 		// Extent (for article-as-manifestation only)


### PR DESCRIPTION
Resolves pkp/pkp-lib#2076.

Deprecates `Article::getStartPage()` and `Article::getEndPage()` which were introduced for loose page counting.

Depends on https://github.com/pkp/pkp-lib/issues/2196
