### PR TITLE
pkp/pkp-lib#2075: Cleanup first and last page parsing

### DIFF
--- a/classes/article/Article.inc.php
+++ b/classes/article/Article.inc.php
@@ -228,30 +228,6 @@ class Article extends Submission {
 	}
 
 	/**
-	 * Deprecated - this was used for loosely counting pages.  Either use ranges as entered, or write an actual page counting function.
-	 * Get starting page of an article.
-	 * @see Submission::getPageArray()
-	 * @return int
-	 */
-	function getStartingPage() {
-		if (Config::getVar('debug', 'deprecation_warnings')) trigger_error('Deprecated call to Article::getStartingPage().');
-		preg_match('/^[^\d]*(\d+)\D*(.*)$/', $this->getPages(), $pages);
-		return $pages[1];
-	}
-
-	/**
-	 * Deprecated - this was used for loosely counting pages.  Either use ranges as entered, or write an actual page counting function.
-	 * Get ending page of an article.
-	 * @see Submission::getPageArray()
-	 * @return int
-	 */
-	function getEndingPage() {
-		if (Config::getVar('debug', 'deprecation_warnings')) trigger_error('Deprecated call to Article::getEndingPage().');
-		preg_match('/^[^\d]*(\d+)\D*(.*)$/', $this->getPages(), $pages);
-		return $pages[2];
-	}
-
-	/**
 	 * Get the localized cover page server-side file name
 	 * @return string
 	 */

--- a/plugins/citationFormats/bibtex/citation.tpl
+++ b/plugins/citationFormats/bibtex/citation.tpl
@@ -23,7 +23,7 @@
 {/literal}{assign var=onlineIssn value=$journal->getSetting('onlineIssn')}
 {assign var=issn value=$journal->getSetting('issn')}{if $issn}{literal}	issn = {{/literal}{$issn|bibtex_escape}{literal}},{/literal}
 {elseif $onlineIssn}{literal}	issn = {{/literal}{$onlineIssn|bibtex_escape}{literal}},{/literal}{/if}
-{if $article->getPages()}{if $article->getStartingPage()}	pages = {literal}{{/literal}{$article->getStartingPage()}{if $article->getEndingPage()}--{$article->getEndingPage()}{/if}{literal}},{/literal}{/if}{/if}
+{if count($article->getPageArray()) > 0}	pages = {literal}{{/literal}{foreach from=$article->getPageArray() item=range name=pages}{$range[0]|escape}{if $range[1]}--{$range[1]|escape}{if !$smarty.foreach.pages.last},{/if}{/if}{/foreach}{literal}},{/literal}{/if}
 {if $article->getStoredPubId('doi')}	doi = {ldelim}{$article->getStoredPubId('doi')|escape}{rdelim},
 {/if}
 	url = {ldelim}{url|bibtex_escape page="article" op="view" path=$article->getBestArticleId()}{rdelim}

--- a/plugins/importexport/doaj/filter/DOAJXmlFilter.inc.php
+++ b/plugins/importexport/doaj/filter/DOAJXmlFilter.inc.php
@@ -101,15 +101,11 @@ class DOAJXmlFilter extends NativeExportFilter {
 			 * "page numbers" are; for example, some journals (eg. JMIR)
 			 * use the "e-location ID" as the "page numbers" in PubMed
 			 */
-			$pages = $pubObject->getPages();
-			if (preg_match("/([0-9]+)\s*-\s*([0-9]+)/i", $pages, $matches)) {
-				// simple pagination (eg. "pp. 3-8")
-				$recordNode->appendChild($node = $doc->createElement('startPage', htmlspecialchars($matches[1], ENT_COMPAT, 'UTF-8')));
-				$recordNode->appendChild($node = $doc->createElement('endPage', htmlspecialchars($matches[2], ENT_COMPAT, 'UTF-8')));
-			} elseif (preg_match("/(e[0-9]+)/i", $pages, $matches)) {
-				// elocation-id (eg. "e12")
-				$recordNode->appendChild($node = $doc->createElement('startPage', htmlspecialchars($matches[1], ENT_COMPAT, 'UTF-8')));
-				$recordNode->appendChild($node = $doc->createElement('endPage', htmlspecialchars($matches[1], ENT_COMPAT, 'UTF-8')));
+			$startPage = $pubObject->getStartingPage();
+			$endPage = $pubObject->getEndingPage();
+			if (isset($startPage) && $startPage !== "") {
+				$recordNode->appendChild($node = $doc->createElement('startPage', htmlspecialchars($startPage, ENT_COMPAT, 'UTF-8')));
+				$recordNode->appendChild($node = $doc->createElement('endPage', htmlspecialchars($endPage, ENT_COMPAT, 'UTF-8')));
 			}
 			// DOI
 			$doi = $pubObject->getStoredPubId('doi');

--- a/plugins/importexport/pubmed/PubMedExportDom.inc.php
+++ b/plugins/importexport/pubmed/PubMedExportDom.inc.php
@@ -97,18 +97,12 @@ class PubMedExportDom {
 		// there is some ambiguity for online journals as to what
 		// "page numbers" are; for example, some journals (eg. JMIR)
 		// use the "e-location ID" as the "page numbers" in PubMed
-		$pages = $article->getPages();
-		if (preg_match("/([0-9]+)\s*-\s*([0-9]+)/i", $pages, $matches)) {
-			// simple pagination (eg. "pp. 3- 		8")
-			XMLCustomWriter::createChildWithText($doc, $root, 'FirstPage', $matches[1]);
-			XMLCustomWriter::createChildWithText($doc, $root, 'LastPage', $matches[2]);
-		} elseif (preg_match("/(e[0-9]+)\s*-\s*(e[0-9]+)/i", $pages, $matches)) { // e9 - e14, treated as page ranges
-			XMLCustomWriter::createChildWithText($doc, $root, 'FirstPage', $matches[1]);
-			XMLCustomWriter::createChildWithText($doc, $root, 'LastPage', $matches[2]);
-		} elseif (preg_match("/(e[0-9]+)/i", $pages, $matches)) {
-			// single elocation-id (eg. "e12")
-			XMLCustomWriter::createChildWithText($doc, $root, 'FirstPage', $matches[1]);
-			XMLCustomWriter::createChildWithText($doc, $root, 'LastPage', $matches[1]);
+		$startPage = $pubObject->getStartingPage();
+		$endPage = $pubObject->getEndingPage();
+		if (isset($startPage) && $startPage !== "") {
+			// We have a page range or e-location id
+			XMLCustomWriter::createChildWithText($doc, $root, 'FirstPage', $startPage);
+			XMLCustomWriter::createChildWithText($doc, $root, 'LastPage', $endPage);
 		} else {
 			// we need to insert something, so use the best ID possible
 			XMLCustomWriter::createChildWithText($doc, $root, 'FirstPage', $article->getBestArticleId());


### PR DESCRIPTION
Remove faulty Article::getStartingPage() and Article::getEndingPage() in favor of implementations in Submission.  Allow bibtext citation to use page ranges.

Depends on pkp/pkp-lib#2207; Jointly resolves pkp/pkp-lib#2075.
