### PR TITLE
Add head elements from HTML Galley file

### DIFF
--- a/plugins/generic/htmlArticleGalley/HtmlArticleGalleyPlugin.inc.php
+++ b/plugins/generic/htmlArticleGalley/HtmlArticleGalleyPlugin.inc.php
@@ -78,6 +78,7 @@ class HtmlArticleGalleyPlugin extends GenericPlugin {
 				'issue' => $issue,
 				'article' => $article,
 				'galley' => $galley,
+				'htmlGalleyContents' => $this->_getHTMLContents($request, $galley),
 			));
 			$templateMgr->display($this->getTemplatePath() . '/display.tpl');
 


### PR DESCRIPTION
This line will allow to add html head elements from html galley files that
are uploaded by user on production stage. Actually this line was present in
OJS 3.0.0.
Suppose I am doing pull request right :)