### PR TITLE
Add migration script for comments to editor

### DIFF
--- a/dbscripts/xml/ojs_schema.xml
+++ b/dbscripts/xml/ojs_schema.xml
@@ -447,7 +447,6 @@
 		<field name="language" type="C2" size="10">
 			<DEFAULT VALUE="en"/>
 		</field>
-		<field name="comments_to_ed" type="X"/>
 		<field name="citations" type="X"/>
 		<field name="date_submitted" type="T"/>
 		<field name="last_modified" type="T"/>

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -90,6 +90,7 @@
 		<code function="installEmailTemplate" key="SUBMISSION_ACK_NOT_USER" locales="en_US,ca_ES,el_GR,es_ES,fr_CA,pt_BR" />
 		<data file="dbscripts/xml/upgrade/3.0.0_scheduledTasks.xml" />
 		<code function="localizeCustomBlockSettings" />
+		<code function="convertCommentsToEditor" />
 		<code function="convertEditorDecisionNotes" />
 		<code function="convertQueries" />
 		<code function="migrateFiles" />

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -38,9 +38,13 @@
 		<data file="dbscripts/xml/upgrade/2.4.0_postUsageStatsMigration2.xml" condition="return $installer->tableExists('issue_galleys_stats_migration');" />
 		<data file="dbscripts/xml/upgrade/2.4.0_postCounterMigration.xml" condition="return $installer->tableExists('counter_monthly_log');" />
 		<data file="dbscripts/xml/upgrade/2.4.0_postTimedViewsMigration.xml" condition="return $installer->tableExists('timed_views_log');" />
+		<code function="convertCommentsToEditor" />
 	</upgrade>
 
-
+	<upgrade minversion="3.0.0.0" maxversion="3.0.1.9">
+		<code function="convertCommentsToEditor" />
+	</upgrade>
+	
 	<!-- PKP schema components -->
 	<schema file="lib/pkp/xml/schema/common.xml" />
 	<schema file="lib/pkp/xml/schema/log.xml" />
@@ -90,7 +94,6 @@
 		<code function="installEmailTemplate" key="SUBMISSION_ACK_NOT_USER" locales="en_US,ca_ES,el_GR,es_ES,fr_CA,pt_BR" />
 		<data file="dbscripts/xml/upgrade/3.0.0_scheduledTasks.xml" />
 		<code function="localizeCustomBlockSettings" />
-		<code function="convertCommentsToEditor" />
 		<code function="convertEditorDecisionNotes" />
 		<code function="convertQueries" />
 		<code function="migrateFiles" />


### PR DESCRIPTION
Initial commit for migrating comments to editor field to queries.

Still to consider: removing comments to editor field from the submissions table



Tagging @bozana 

See:
https://github.com/pkp/pkp-lib/issues/1873
https://github.com/pkp/pkp-lib/pull/2200
