### PR TITLE
type: localization - Add missing strings to pt-pt translation.

### DIFF
--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -949,4 +949,34 @@ Pode-se opcionalmente informar o motivo pelo qual está sendo desactivado o regi
 	<message key="user.authorization.copyeditorAssignmentMissing">Acesso recusado! Não tem direitos de autor sobre este artigo.</message>
 	<message key="user.authorization.sectionAssignment">Está a tentar aceder a um artigo que não pertence à secção.</message>
 	<message key="user.authorization.invalidCopyditorSubmission">Submissão de cópia de editor inválida ou nenhuma de cópia de editor solicitada!</message>
+
+
+
+
+
+	<message key="dashboard.myQueue">Painel de Controlo</message>
+	<message key="editor.navigation.issues">Números</message>
+	<message key="editor.issues.futureIssues">Próximos</message>
+	<message key="editor.issues.backIssues">Anteriores</message>
+	<message key="navigation.settings">Definições</message>
+	<message key="navigation.access">Gestão de acessos</message>
+	<message key="navigation.tools">Ferramentas</message>
+	<message key="navigation.admin">Administrador</message>
+	<message key="navigation.viewFrontend">Previsualizar</message>
+	<message key="navigation.submissions">Submissões</message>
+	<message key="navigation.archives">Arquivo</message>
+	<message key="navigation.items.shownTotal">Total</message>
+	<message key="navigation.tools.importExport">Importar / exportar</message>
+	<message key="navigation.tools.statistics">Estatísticas</message>
+	<message key="submission.submit.newSubmissionSingle">Submeter</message>
+	<message key="submission.mySubmissions">As minhas submissões</message>
+	<message key="common.queue.long.myAssigned">As minhas tarefas</message>
+	<message key="grid.submission.itemTitle">Título</message>
+	<message key="workflow.stage">Estado</message>
+	<message key="workflow.review.externalReview">Revisão externa</message>
+	<message key="common.tasks">Tarefas ativas</message>
+	<message key="manager.website">Website</message>
+	<message key="manager.workflow">Fluxo de trabalho</message>
+	<message key="manager.distribution">Permissões</message>
+	<message key="manager.siteAccessOptions.siteAccessOptions">Opções de acesso</message>
 </locale>


### PR DESCRIPTION
Add several key / values to pt-pt locale.xml file, which didn't displayed correctly.	

modified:   locale/pt_PT/locale.xml