### PR TITLE
pkp/pkp-lib#2134 add article download hook in HTMLArticleGalleyPlugin

### DIFF
--- a/plugins/generic/htmlArticleGalley/HtmlArticleGalleyPlugin.inc.php
+++ b/plugins/generic/htmlArticleGalley/HtmlArticleGalleyPlugin.inc.php
@@ -99,9 +99,11 @@ class HtmlArticleGalleyPlugin extends GenericPlugin {
 		$request = Application::getRequest();
 
 		if ($galley && $galley->getFileType() == 'text/html' && $galley->getFileId() == $fileId) {
-			echo $this->_getHtmlContents($request, $galley);
-			$returner = true;
-			HookRegistry::call('HtmlArticleGalleyPlugin::articleDownloadFinished', array(&$returner));
+			if (!HookRegistry::call('HtmlArticleGalleyPlugin::articleDownload', array($article,  &$galley, &$fileId))) {
+				echo $this->_getHtmlContents($request, $galley);
+				$returner = true;
+				HookRegistry::call('HtmlArticleGalleyPlugin::articleDownloadFinished', array(&$returner));
+			}
 			return true;
 		}
 

--- a/plugins/generic/usageEvent/UsageEventPlugin.inc.php
+++ b/plugins/generic/usageEvent/UsageEventPlugin.inc.php
@@ -28,6 +28,7 @@ class UsageEventPlugin extends PKPUsageEventPlugin {
 		return array_merge(parent::getEventHooks(), array(
 			'ArticleHandler::download',
 			'IssueHandler::download',
+			'HtmlArticleGalleyPlugin::articleDownload',
 			'HtmlArticleGalleyPlugin::articleDownloadFinished'
 		));
 	}
@@ -112,6 +113,7 @@ class UsageEventPlugin extends PKPUsageEventPlugin {
 
 					// Article file.
 				case 'ArticleHandler::download':
+				case 'HtmlArticleGalleyPlugin::articleDownload':
 					$assocType = ASSOC_TYPE_SUBMISSION_FILE;
 					$article = $hookArgs[0];
 					$galley = $hookArgs[1];


### PR DESCRIPTION
HtmlArticleGalleyPlugin uses ArticleHandler::download hook and eventually blocks it for others, so it should create a new one, that can be then used by others. 