### PR TITLE
pkp/pkp-lib#1873 comments_to_ed migration if no author is assigned

### DIFF
--- a/dbscripts/xml/upgrade/3.0.0_preupdate_commentsToEditor.xml
+++ b/dbscripts/xml/upgrade/3.0.0_preupdate_commentsToEditor.xml
@@ -15,7 +15,7 @@
 <data>
 	<sql>
 		<query>
-			CREATE TABLE submissions_tmp AS (SELECT submission_id, comments_to_ed, date_submitted FROM submissions)
+			CREATE TABLE submissions_tmp AS (SELECT submission_id, context_id, comments_to_ed, date_submitted FROM submissions)
 		</query>
 	</sql>
 </data>


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/1873
This PR considers the situation when no author is assigned to a submission with a comment for the editors -- which is possible in OJS 3.x -- in that situation the first JM found will be used.