### PR TITLE
pkp/pkp-lib#1955 no XML validation option for the export plugins

### DIFF
--- a/classes/plugins/PubObjectsExportPlugin.inc.php
+++ b/classes/plugins/PubObjectsExportPlugin.inc.php
@@ -142,6 +142,7 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 				$selectedIssues = (array) $request->getUserVar('selectedIssues');
 				$selectedRepresentations = (array) $request->getUserVar('selectedRepresentations');
 				$tab = (string) $request->getUserVar('tab');
+				$noValidation = $request->getUserVar('validation') ? false : true;
 
 				if (empty($selectedSubmissions) && empty($selectedIssues) && empty($selectedRepresentations)) {
 					fatalError(__('plugins.importexport.common.error.noObjectsSelected'));
@@ -161,7 +162,7 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 				}
 
 				// Execute export action
-				$this->executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart);
+				$this->executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation);
 		}
 	}
 
@@ -172,14 +173,15 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 	 * @param $filter string Filter to use
 	 * @param $tab string Tab to return to
 	 * @param $objectsFileNamePart string Export file name part for this kind of objects
+	 * @param $noValidation boolean If set to true no XML validation will be done
 	 */
-	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart) {
+	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation = null) {
 		$context = $request->getContext();
 		$path = array('plugin', $this->getName());
 		if ($request->getUserVar(EXPORT_ACTION_EXPORT)) {
 			assert($filter != null);
 			// Get the XML
-			$exportXml = $this->exportXML($objects, $filter, $context);
+			$exportXml = $this->exportXML($objects, $filter, $context, $noValidation);
 			import('lib.pkp.classes.file.FileManager');
 			$fileManager = new FileManager();
 			$exportFileName = $this->getExportFileName($this->getExportPath(), $objectsFileNamePart, $context, '.xml');
@@ -189,7 +191,7 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 		} elseif ($request->getUserVar(EXPORT_ACTION_DEPOSIT)) {
 			assert($filter != null);
 			// Get the XML
-			$exportXml = $this->exportXML($objects, $filter, $context);
+			$exportXml = $this->exportXML($objects, $filter, $context, $noValidation);
 			// Write the XML to a file.
 			// export file name example: crossref-20160723-160036-articles-1.xml
 			import('lib.pkp.classes.file.FileManager');
@@ -334,8 +336,9 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 	 * @param $filter string
 	 * @param $context Context
 	 * @return string XML document.
+	 * @param $noValidation boolean If set to true no XML validation will be done
 	 */
-	function exportXML($objects, $filter, $context) {
+	function exportXML($objects, $filter, $context, $noValidation = null) {
 		$xml = '';
 		$filterDao = DAORegistry::getDAO('FilterDAO');
 		$exportFilters = $filterDao->getObjectsByGroup($filter);
@@ -343,6 +346,7 @@ abstract class PubObjectsExportPlugin extends ImportExportPlugin {
 		$exportFilter = array_shift($exportFilters);
 		$exportDeployment = $this->_instantiateExportDeployment($context);
 		$exportFilter->setDeployment($exportDeployment);
+		if ($noValidation) $exportFilter->setNoValidation($noValidation);
 		libxml_use_internal_errors(true);
 		$exportXml = $exportFilter->execute($objects, true);
 		$xml = $exportXml->saveXml();

--- a/locale/en_US/manager.xml
+++ b/locale/en_US/manager.xml
@@ -586,6 +586,7 @@
 	<message key="plugins.importexport.common.action.export">Export</message>
 	<message key="plugins.importexport.common.action.markRegistered">Mark registered</message>
 	<message key="plugins.importexport.common.action.register">Register</message>
+	<message key="plugins.importexport.common.validation">Validate XML before the export and registration.</message>
 	<!--  notifications and errors -->
 	<message key="plugins.importexport.common.error.noObjectsSelected">No objects selected.</message>
 	<message key="plugins.importexport.common.error.validation">Could not convert selected objects.</message>

--- a/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
+++ b/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
@@ -157,7 +157,7 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 	/**
 	 * @copydoc PubObjectsExportPlugin::executeExportAction()
 	 */
-	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart) {
+	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation = null) {
 		$context = $request->getContext();
 		$path = array('plugin', $this->getName());
 		if ($request->getUserVar(CROSSREF_EXPORT_ACTION_CHECKSTATUS)) {
@@ -165,7 +165,7 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 			// redirect back to the right tab
 			$request->redirect(null, null, null, $path, null, $tab);
 		} else {
-			parent::executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart);
+			parent::executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation);
 		}
 	}
 

--- a/plugins/importexport/crossref/templates/index.tpl
+++ b/plugins/importexport/crossref/templates/index.tpl
@@ -77,7 +77,11 @@
 				{fbvFormArea id="submissionsXmlForm"}
 					{url|assign:submissionsListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportSubmissionsListGridHandler" op="fetchGrid" plugin="crossref" category="importexport" escape=false}
 					{load_url_in_div id="submissionsListGridContainer" url=$submissionsListGridUrl}
+					{fbvFormSection list="true"}
+						{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+					{/fbvFormSection}
 					{if !empty($actionNames)}
+						{fbvFormSection}
 						<ul class="export_actions">
 							{foreach from=$actionNames key=action item=actionName}
 								<li class="export_action">
@@ -85,8 +89,9 @@
 								</li>
 							{/foreach}
 						</ul>
+						{/fbvFormSection}
 					{/if}
-			{/fbvFormArea}
+				{/fbvFormArea}
 			</form>
 			<p>{translate key="plugins.importexport.crossref.statusLegend"}</p>
 		</div>

--- a/plugins/importexport/datacite/DataciteExportPlugin.inc.php
+++ b/plugins/importexport/datacite/DataciteExportPlugin.inc.php
@@ -101,7 +101,7 @@ class DataciteExportPlugin extends DOIPubIdExportPlugin {
 	/**
 	 * @copydoc PubObjectsExportPlugin::executeExportAction()
 	 */
-	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart) {
+	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation = null) {
 		$context = $request->getContext();
 		$path = array('plugin', $this->getName());
 
@@ -115,7 +115,7 @@ class DataciteExportPlugin extends DOIPubIdExportPlugin {
 				$exportedFiles = array();
 				foreach ($objects as $object) {
 					// Get the XML
-					$exportXml = $this->exportXML($object, $filter, $context);
+					$exportXml = $this->exportXML($object, $filter, $context, $noValidation);
 					// Write the XML to a file.
 					// export file name example: datacite-20160723-160036-articles-1-1.xml
 					$objectFileNamePart = $objectsFileNamePart . '-' . $object->getId();
@@ -158,7 +158,7 @@ class DataciteExportPlugin extends DOIPubIdExportPlugin {
 			$resultErrors = array();
 			foreach ($objects as $object) {
 				// Get the XML
-				$exportXml = $this->exportXML($object, $filter, $context);
+				$exportXml = $this->exportXML($object, $filter, $context, $noValidation);
 				// Write the XML to a file.
 				// export file name example: datacite-20160723-160036-articles-1-1.xml
 				$objectFileNamePart = $objectsFileNamePart . '-' . $object->getId();

--- a/plugins/importexport/datacite/filter/DataciteXmlFilter.inc.php
+++ b/plugins/importexport/datacite/filter/DataciteXmlFilter.inc.php
@@ -120,6 +120,8 @@ class DataciteXmlFilter extends NativeExportFilter {
 			}
 		}
 
+		// Identify the object locale.
+		$objectLocalePrecedence = $this->getObjectLocalePrecedence($context, $article, $galley);
 		// The publisher is required.
 		// Use the journal title as DataCite recommends for now.
 		$publisher = $this->getPrimaryTranslation($context->getName(null), $objectLocalePrecedence);
@@ -134,8 +136,6 @@ class DataciteXmlFilter extends NativeExportFilter {
 		// Create the root node
 		$rootNode = $this->createRootNode($doc);
 		$doc->appendChild($rootNode);
-		// Identify the object locale.
-		$objectLocalePrecedence = $this->getObjectLocalePrecedence($context, $article, $galley);
 		// DOI (mandatory)
 		$doi = $pubObject->getStoredPubId('doi');
 		if ($plugin->isTestMode($context)) {

--- a/plugins/importexport/datacite/templates/index.tpl
+++ b/plugins/importexport/datacite/templates/index.tpl
@@ -72,7 +72,11 @@
 					{fbvFormArea id="submissionsXmlForm"}
 						{url|assign:submissionsListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportSubmissionsListGridHandler" op="fetchGrid" plugin="datacite" category="importexport" escape=false}
 						{load_url_in_div id="submissionsListGridContainer" url=$submissionsListGridUrl}
+						{fbvFormSection list="true"}
+							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+						{/fbvFormSection}
 						{if !empty($actionNames)}
+							{fbvFormSection}
 							<ul class="export_actions">
 								{foreach from=$actionNames key=action item=actionName}
 									<li class="export_action">
@@ -80,6 +84,7 @@
 									</li>
 								{/foreach}
 							</ul>
+							{/fbvFormSection}
 						{/if}
 					{/fbvFormArea}
 				</form>
@@ -98,7 +103,11 @@
 					{fbvFormArea id="issuesXmlForm"}
 						{url|assign:issuesListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportIssuesListGridHandler" op="fetchGrid" plugin="datacite" category="importexport" escape=false}
 						{load_url_in_div id="issuesListGridContainer" url=$issuesListGridUrl}
+						{fbvFormSection list="true"}
+							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+						{/fbvFormSection}
 						{if !empty($actionNames)}
+							{fbvFormSection}
 							<ul class="export_actions">
 								{foreach from=$actionNames key=action item=actionName}
 									<li class="export_action">
@@ -106,6 +115,7 @@
 									</li>
 								{/foreach}
 							</ul>
+							{/fbvFormSection}
 						{/if}
 					{/fbvFormArea}
 				</form>
@@ -124,7 +134,11 @@
 					{fbvFormArea id="representationsXmlForm"}
 						{url|assign:representationsListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportRepresentationsListGridHandler" op="fetchGrid" plugin="datacite" category="importexport" escape=false}
 						{load_url_in_div id="representationsListGridContainer" url=$representationsListGridUrl}
+						{fbvFormSection list="true"}
+							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+						{/fbvFormSection}
 						{if !empty($actionNames)}
+							{fbvFormSection}
 							<ul class="export_actions">
 								{foreach from=$actionNames key=action item=actionName}
 									<li class="export_action">
@@ -132,6 +146,7 @@
 									</li>
 								{/foreach}
 							</ul>
+							{/fbvFormSection}
 						{/if}
 					{/fbvFormArea}
 				</form>

--- a/plugins/importexport/doaj/DOAJExportPlugin.inc.php
+++ b/plugins/importexport/doaj/DOAJExportPlugin.inc.php
@@ -163,7 +163,7 @@ class DOAJExportPlugin extends PubObjectsExportPlugin {
 	/**
 	 * @copydoc PubObjectsExportPlugin::executeExportAction()
 	 */
-	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart) {
+	function executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation = null) {
 		$context = $request->getContext();
 		$path = array('plugin', $this->getName());
 		if ($request->getUserVar(EXPORT_ACTION_DEPOSIT)) {
@@ -197,7 +197,7 @@ class DOAJExportPlugin extends PubObjectsExportPlugin {
 			// redirect back to the right tab
 			$request->redirect(null, null, null, $path, null, $tab);
 		} else {
-			return parent::executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart);
+			return parent::executeExportAction($request, $objects, $filter, $tab, $objectsFileNamePart, $noValidation);
 		}
 	}
 

--- a/plugins/importexport/doaj/templates/index.tpl
+++ b/plugins/importexport/doaj/templates/index.tpl
@@ -58,7 +58,11 @@
 				{fbvFormArea id="submissionsXmlForm"}
 					{url|assign:submissionsListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.submissions.ExportPublishedSubmissionsListGridHandler" op="fetchGrid" plugin="doaj" category="importexport" escape=false}
 					{load_url_in_div id="submissionsListGridContainer" url=$submissionsListGridUrl}
+					{fbvFormSection list="true"}
+						{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+					{/fbvFormSection}
 					{if !empty($actionNames)}
+						{fbvFormSection}
 						<ul class="export_actions">
 							{foreach from=$actionNames key=action item=actionName}
 								<li class="export_action">								
@@ -66,6 +70,7 @@
 								</li>
 							{/foreach}
 						</ul>
+						{/fbvFormSection}
 					{/if}
 				{/fbvFormArea}
 			</form>

--- a/plugins/importexport/medra/filter/IssueMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/IssueMedraXmlFilter.inc.php
@@ -201,7 +201,7 @@ class IssueMedraXmlFilter extends O4DOIXmlFilter {
 		// Extent (for issues-as-manifestation only)
 		if (!$this->isWork($context, $plugin)) {
 			$issueGalleyDao = DAORegistry::getDAO('IssueGalleyDAO'); /* @var $issueGalleyDao IssueGalleyDAO */
-			$issueGalleys = $issueGalleyDao->getGalleysByIssue($issue->getId());
+			$issueGalleys = $issueGalleyDao->getByIssueId($issue->getId());
 			if (!empty($issueGalleys)) {
 				foreach($issueGalleys as $issueGalley) {
 					$journalIssueNode->appendChild($this->createExtentNode($doc, $issueGalley));

--- a/plugins/importexport/medra/templates/index.tpl
+++ b/plugins/importexport/medra/templates/index.tpl
@@ -72,7 +72,11 @@
 					{fbvFormArea id="submissionsXmlForm"}
 						{url|assign:submissionsListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportSubmissionsListGridHandler" op="fetchGrid" plugin="medra" category="importexport" escape=false}
 						{load_url_in_div id="submissionsListGridContainer" url=$submissionsListGridUrl}
+						{fbvFormSection list="true"}
+							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+						{/fbvFormSection}
 						{if !empty($actionNames)}
+							{fbvFormSection}
 							<ul class="export_actions">
 								{foreach from=$actionNames key=action item=actionName}
 									<li class="export_action">
@@ -80,6 +84,7 @@
 									</li>
 								{/foreach}
 							</ul>
+							{/fbvFormSection}
 						{/if}
 					{/fbvFormArea}
 				</form>
@@ -99,7 +104,11 @@
 					{fbvFormArea id="issuesXmlForm"}
 						{url|assign:issuesListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportIssuesListGridHandler" op="fetchGrid" plugin="medra" category="importexport" escape=false}
 						{load_url_in_div id="issuesListGridContainer" url=$issuesListGridUrl}
+						{fbvFormSection list="true"}
+							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+						{/fbvFormSection}
 						{if !empty($actionNames)}
+							{fbvFormSection}
 							<ul class="export_actions">
 								{foreach from=$actionNames key=action item=actionName}
 									<li class="export_action">
@@ -107,6 +116,7 @@
 									</li>
 								{/foreach}
 							</ul>
+							{/fbvFormSection}
 						{/if}
 					{/fbvFormArea}
 				</form>
@@ -126,7 +136,11 @@
 					{fbvFormArea id="representationsXmlForm"}
 						{url|assign:representationsListGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.pubIds.PubIdExportRepresentationsListGridHandler" op="fetchGrid" plugin="medra" category="importexport" escape=false}
 						{load_url_in_div id="representationsListGridContainer" url=$representationsListGridUrl}
+						{fbvFormSection list="true"}
+							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+						{/fbvFormSection}
 						{if !empty($actionNames)}
+							{fbvFormSection}
 							<ul class="export_actions">
 								{foreach from=$actionNames key=action item=actionName}
 									<li class="export_action">
@@ -134,6 +148,7 @@
 									</li>
 								{/foreach}
 							</ul>
+							{/fbvFormSection}
 						{/if}
 					{/fbvFormArea}
 				</form>


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/1955
this PR introduces the option not to validate XML when exporting... 
The native exports are not considered -- they have local schema and they are good to be validated in any case.
Also CLI exports are not considered for now, because it would mean change of the usage parameters and thus locales files.