### PR TITLE
pkp/pkp-lib#1923: Refactor GridCellProvider::getTemplateVarsFromRowColumn() to include current $request object

### DIFF
--- a/controllers/grid/articleGalleys/ArticleGalleyGridCellProvider.inc.php
+++ b/controllers/grid/articleGalleys/ArticleGalleyGridCellProvider.inc.php
@@ -35,7 +35,7 @@ class ArticleGalleyGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($element, 'DataObject') && !empty($columnId));
@@ -48,7 +48,7 @@ class ArticleGalleyGridCellProvider extends DataObjectGridCellProvider {
 				break;
 			default: assert(false);
 		}
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 	/**

--- a/controllers/grid/issueGalleys/IssueGalleyGridCellProvider.inc.php
+++ b/controllers/grid/issueGalleys/IssueGalleyGridCellProvider.inc.php
@@ -24,13 +24,9 @@ class IssueGalleyGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$issueGalley = $row->getData();
 		$columnId = $column->getId();
 		assert (is_a($issueGalley, 'IssueGalley'));

--- a/controllers/grid/issues/IssueGridCellProvider.inc.php
+++ b/controllers/grid/issues/IssueGridCellProvider.inc.php
@@ -56,13 +56,9 @@ class IssueGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$issue = $row->getData();
 		$columnId = $column->getId();
 		assert (is_a($issue, 'Issue'));

--- a/controllers/grid/pubIds/PubIdExportIssuesListGridCellProvider.inc.php
+++ b/controllers/grid/pubIds/PubIdExportIssuesListGridCellProvider.inc.php
@@ -88,7 +88,7 @@ class PubIdExportIssuesListGridCellProvider extends DataObjectGridCellProvider {
 	 *
 	 * @copydoc DataObjectGridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$publishedIssue = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedIssue, 'Issue') && !empty($columnId));

--- a/controllers/grid/pubIds/PubIdExportRepresentationsListGridCellProvider.inc.php
+++ b/controllers/grid/pubIds/PubIdExportRepresentationsListGridCellProvider.inc.php
@@ -106,12 +106,9 @@ class PubIdExportRepresentationsListGridCellProvider extends DataObjectGridCellP
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 *
 	 * @copydoc DataObjectGridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$publishedSubmissionGalley = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedSubmissionGalley, 'ArticleGAlley') && !empty($columnId));

--- a/controllers/grid/pubIds/PubIdExportSubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/pubIds/PubIdExportSubmissionsListGridCellProvider.inc.php
@@ -25,9 +25,9 @@ class PubIdExportSubmissionsListGridCellProvider extends ExportPublishedSubmissi
 	}
 
 	/**
-	 * @copydoc ExportPublishedSubmissionsListGridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$publishedSubmission = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedSubmission, 'PublishedArticle') && !empty($columnId));
@@ -36,7 +36,7 @@ class PubIdExportSubmissionsListGridCellProvider extends ExportPublishedSubmissi
 			case 'pubId':
 				return array('label' => $publishedSubmission->getStoredPubId($this->_plugin->getPubIdType()));
 		}
-		return parent::getTemplateVarsFromRowColumn($row, $column);
+		return parent::getTemplateVarsFromRowColumn($request, $row, $column);
 	}
 
 }

--- a/controllers/grid/submissions/ExportPublishedSubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/submissions/ExportPublishedSubmissionsListGridCellProvider.inc.php
@@ -103,12 +103,9 @@ class ExportPublishedSubmissionsListGridCellProvider extends DataObjectGridCellP
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 *
-	 * @copydoc DataObjectGridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$publishedSubmission = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedSubmission, 'PublishedArticle') && !empty($columnId));

--- a/controllers/grid/toc/TocGridCellProvider.inc.php
+++ b/controllers/grid/toc/TocGridCellProvider.inc.php
@@ -24,13 +24,9 @@ class TocGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
-	function getTemplateVarsFromRowColumn($row, $column) {
+	function getTemplateVarsFromRowColumn($request, $row, $column) {
 		$element = $row->getData();
 		$columnId = $column->getId();
 		assert(!empty($columnId));


### PR DESCRIPTION
OJS refactoring for https://github.com/pkp/pkp-lib/pull/2283.  See description there.

See also pkp/pkp-lib#1923.