### PR TITLE
pkp/pkp-lib#2173 migrate review files

### DIFF
--- a/dbscripts/xml/upgrade/3.0.0_update.xml
+++ b/dbscripts/xml/upgrade/3.0.0_update.xml
@@ -185,6 +185,7 @@
 		<query driver="postgres7">UPDATE review_assignments SET review_round_id=rr.review_round_id FROM review_rounds rr WHERE rr.round = review_assignments.round AND rr.submission_id = review_assignments.submission_id</query>
 		<query>INSERT INTO review_round_files (submission_id, review_round_id, stage_id, file_id, revision) SELECT afm.article_id, rr.review_round_id, 3, afm.file_id, afm.revision FROM article_files_migration afm, articles_migration am, review_rounds rr WHERE am.review_file_id = afm.file_id AND rr.submission_id = afm.article_id AND rr.round = afm.round</query><!-- WORKFLOW_STAGE_ID_EXTERNAL_REVIEW -->
 		<query>INSERT INTO review_round_files (submission_id, review_round_id, stage_id, file_id, revision) SELECT afm.article_id, rr.review_round_id, 3, afm.file_id, afm.revision FROM article_files_migration afm, articles_migration am, review_rounds rr WHERE am.revised_file_id = afm.file_id AND rr.submission_id = afm.article_id AND rr.round = afm.round</query><!-- WORKFLOW_STAGE_ID_EXTERNAL_REVIEW -->
+		<query>INSERT INTO review_files (review_id, file_id) SELECT DISTINCT ra.review_id, afm.file_id FROM article_files_migration afm, articles_migration am, review_assignments ra WHERE ra.submission_id = am.article_id AND am.review_file_id = afm.file_id</query>
 	</sql>
 	<sql><!-- Update file stages -->
 		<query driver="mysql">UPDATE submission_files sf, articles_migration am SET sf.file_stage=2 WHERE am.submission_file_id=sf.file_id</query><!-- SUBMISSION_FILE_SUBMISSION -->


### PR DESCRIPTION
s. 1) here: https://github.com/pkp/pkp-lib/issues/2173 
This migrates correctly the review files. This cannot be considered for those already migrated to and using OJS 3.
For those, that already upgraded and are using OJS 3, here is the SQL statement, that should be run as a user that has rights on both DBs (current OJS 3 DB as well as old, backuped OJS 2 DB):
`INSERT INTO ojs3_db_name.review_files (review_id, file_id) SELECT DISTINCT ra.review_id, afm.file_id FROM ojs2_db_name.article_files afm, ojs_stable.articles am, ojs_stable.review_assignments ra WHERE ra.submission_id = am.article_id AND am.review_file_id = afm.file_id`