### PR TITLE
pkp/pkp-lib#2173 (2) consider revision for reviewer files migration

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -1882,18 +1882,25 @@ class Upgrade extends Installer {
 
 			$submissionFileManager = new SubmissionFileManager($row['context_id'], $row['submission_id']);
 			// revision is always 1 because in OJS 2.4.x there was only one reviewer file
-			$revision = $submissionFileDao->getRevision($row['reviewer_file_id'], 1);
-			$wrongFilePath = $revision->getFilePath();
-			$revision->setFileStage(SUBMISSION_FILE_REVIEW_ATTACHMENT);
-			$newFilePath = $revision->getFilePath();
-			if (!file_exists($newFilePath)) {
-				if (!file_exists($path = dirname($newFilePath)) && !$submissionFileManager->mkdirtree($path)) {
-					error_log("Unable to make directory \"$path\"");
+			$revisions = $submissionFileDao->getAllRevisions($row['reviewer_file_id']);
+			if (!empty($revisions)) {
+				foreach ($revisions as $revision) {
+					$wrongFilePath = $revision->getFilePath();
+					$revision->setFileStage(SUBMISSION_FILE_REVIEW_ATTACHMENT);
+					$newFilePath = $revision->getFilePath();
+					if (!file_exists($newFilePath)) {
+						if (!file_exists($path = dirname($newFilePath)) && !$submissionFileManager->mkdirtree($path)) {
+							error_log("ERROR: Unable to make directory \"$path\"");
+						}
+						if (!rename($wrongFilePath, $newFilePath)) {
+							error_log("ERROR: Unable to move \"$wrongFilePath\" to \"$newFilePath\".");
+						}
+					}
 				}
-				if (!rename($wrongFilePath, $newFilePath)) {
-					error_log("Unable to move \"$wrongFilePath\" to \"$newFilePath\".");
-				}
+			} else {
+				error_log('ERROR: Reviewer files with ID ' . $row['reviewer_file_id'] . ' from review assignment ' .$row['review_id'] . ' could not be found in the database table submission_files');
 			}
+
 			$result->MoveNext();
 		}
 		$result->Close();

--- a/dbscripts/xml/upgrade/3.0.0_reviewer_files.xml
+++ b/dbscripts/xml/upgrade/3.0.0_reviewer_files.xml
@@ -13,11 +13,11 @@
 <data>
 	<sql>
 		<!-- #2173 the files should have file_stage = 5 (SUBMISSION_FILE_REVIEW_ATTACHMENT), assoc_type should be 517 (ASSOC_TYPE_REVIEW_ASSIGNMENT), assoc_id should be the appropriate review_id. -->
-		<query driver="mysql">UPDATE submission_files sf, review_assignments ra SET sf.file_stage = 5, sf.assoc_type = 517, sf.assoc_id = ra.review_id WHERE ra.reviewer_file_id IS NOT NULL AND sf.file_id = ra.reviewer_file_id AND sf.revision = 1</query>
-		<query driver="mysqli">UPDATE submission_files sf, review_assignments ra SET sf.file_stage = 5, sf.assoc_type = 517, sf.assoc_id = ra.review_id WHERE ra.reviewer_file_id IS NOT NULL AND sf.file_id = ra.reviewer_file_id AND sf.revision = 1</query>
-		<query driver="postgres7">UPDATE submission_files SET file_stage = 5, assoc_type = 517, assoc_id = ra.review_id FROM review_assignments ra WHERE ra.reviewer_file_id IS NOT NULL AND submission_files.file_id = ra.reviewer_file_id AND submission_files.revision = 1</query>
+		<query driver="mysql">UPDATE submission_files sf, review_assignments ra SET sf.file_stage = 5, sf.assoc_type = 517, sf.assoc_id = ra.review_id WHERE ra.reviewer_file_id IS NOT NULL AND sf.file_id = ra.reviewer_file_id</query>
+		<query driver="mysqli">UPDATE submission_files sf, review_assignments ra SET sf.file_stage = 5, sf.assoc_type = 517, sf.assoc_id = ra.review_id WHERE ra.reviewer_file_id IS NOT NULL AND sf.file_id = ra.reviewer_file_id</query>
+		<query driver="postgres7">UPDATE submission_files SET file_stage = 5, assoc_type = 517, assoc_id = ra.review_id FROM review_assignments ra WHERE ra.reviewer_file_id IS NOT NULL AND submission_files.file_id = ra.reviewer_file_id</query>
 		<!-- #2173 insert a raw in review_round_files, with stage_id = 3 (WORKFLOW_STAGE_ID_EXTERNAL_REVIEW) and revision = 1 (revision was always 1 in OJS 2.4.x) -->
-		<query>INSERT INTO review_round_files (submission_id, review_round_id, stage_id, file_id, revision) SELECT ra.submission_id, ra.review_round_id, 3, ra.reviewer_file_id, 1 FROM review_assignments ra WHERE ra.reviewer_file_id IS NOT NULL</query>
+		<query>INSERT INTO review_round_files (submission_id, review_round_id, stage_id, file_id, revision) SELECT ra.submission_id, ra.review_round_id, 3, ra.reviewer_file_id, sf.revision FROM review_assignments ra, submission_files sf WHERE ra.reviewer_file_id IS NOT NULL AND sf.file_id = ra.reviewer_file_id</query>
 		<!-- #2173 set reviewer_file_id = NULL in review_assignments -->
 		<query>UPDATE review_assignments SET reviewer_file_id = NULL WHERE reviewer_file_id IS NOT NULL</query>
 	</sql>


### PR DESCRIPTION
considers that reviewer files could have revisions and that it could happen that there is no such reviewer file with ID = reviewer_file_id in the submission_files table 