### PR TITLE
 pkp-lib#440 grant access to user management to admins that are not journal managers

### DIFF
--- a/pages/management/SettingsHandler.inc.php
+++ b/pages/management/SettingsHandler.inc.php
@@ -23,6 +23,12 @@ class SettingsHandler extends ManagementHandler {
 	function __construct() {
 		parent::__construct();
 		$this->addRoleAssignment(
+			array(ROLE_ID_SITE_ADMIN),
+			array(
+				'access',
+			)
+		);
+		$this->addRoleAssignment(
 			ROLE_ID_MANAGER,
 			array(
 				'settings',

--- a/pages/management/index.php
+++ b/pages/management/index.php
@@ -22,6 +22,7 @@ switch ($op) {
 	//
 	case 'index':
 	case 'settings':
+	case 'access':
 		import('pages.management.SettingsHandler');
 		define('HANDLER_CLASS', 'SettingsHandler');
 		break;


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/440

In order not to allow the admin users without journal manager role the access to all settings functions, I extracted the function "access". If you think that access to other setting functions for these admin users wold also be OK, I can change it.