### PR TITLE
Allow artwork files for XML galleys

### DIFF
--- a/templates/controllers/grid/articleGalleys/form/articleGalleyForm.tpl
+++ b/templates/controllers/grid/articleGalleys/form/articleGalleyForm.tpl
@@ -39,7 +39,7 @@
 		{/fbvFormSection}
 	{/fbvFormArea}
 
-	{if $articleGalleyFile && $articleGalleyFile->getFileType()=='text/html'}
+	{if $articleGalleyFile && ($articleGalleyFile->getFileType()=='text/html' || $articleGalleyFile->getFileType()=='application/xml')}
 		{url|assign:dependentFilesGridUrl router=$smarty.const.ROUTE_COMPONENT component="grid.files.dependent.DependentFilesGridHandler" op="fetchGrid" submissionId=$submissionId fileId=$articleGalleyFile->getFileId() stageId=$smarty.const.WORKFLOW_STAGE_ID_PRODUCTION escape=false}
 		{load_url_in_div id="dependentFilesGridDiv" url=$dependentFilesGridUrl}
 	{/if}


### PR DESCRIPTION
HI @asmecher 

Based on you suggestion here http://forum.pkp.sfu.ca/t/artwork-files-for-xml-galleys/29587 I made a pr concerning the artwork files XML galleys. Allowing these is crucial for the implementation of XML workflows.

However, I started to think that should the `templates/controllers/grid/articleGalleys/form/articleGalleyForm.tpl` actually check for file type at all? I mean, why not allow artwork files for ANY galley? I realize that many usual galleys do not need or support separate artwork (like pdf), but still.

I am also preparing support for the XML artwork files both in my embedGalley plugin and the lensGalley plugin. However, I noticed that you have decided to stick with the old version of lens because it is missing support for mobile layouts. I have, however, used the latest lens release because it supports features likes footnotes. Making changes to the original lens.js files is very difficult. I am working with the lens and lens-starter repositories to create whole new lens.js files. In these versions I have also stripped most of the eLife filters that exist in the current lensGalley release. But more on those later.
