### PR TITLE
pkp/pkp-lib#2496: Ensure newline between %P and %V in EndNote Citation format plugin

### DIFF
--- a/plugins/citationFormats/endNote/citation.tpl
+++ b/plugins/citationFormats/endNote/citation.tpl
@@ -32,7 +32,7 @@
 {if $article->getStoredPubId('doi')}%R {$article->getStoredPubId('doi')|escape}
 {/if}
 {if count($article->getPageArray()) > 0}%P {foreach from=$article->getPageArray() item=range name=pages}{$range[0]|escape}{if $range[1]}-{$range[1]|escape}{if !$smarty.foreach.pages.last},{/if}{/if}{/foreach}
-{/if}
+{* explicit newline required because Smarty foreach eats the one we expect *}{"\n"}{/if}
 {if $issue->getShowVolume()}%V {$issue->getVolume()|escape}
 {/if}
 {if $issue->getShowNumber()}%N {$issue->getNumber()|escape}


### PR DESCRIPTION
*Le sigh*, not happy with this one.