### PR TITLE
Remove unnecessary print_r from ArticleHander

### DIFF
--- a/pages/article/ArticleHandler.inc.php
+++ b/pages/article/ArticleHandler.inc.php
@@ -207,7 +207,6 @@ class ArticleHandler extends Handler {
 				$articleGalleys = $articleGalleyDao->getBySubmissionId($articleId);
 				while ($articleGalley = $articleGalleys->next()) {
 					$galleyFile = $articleGalley->getFile();
-print_r($galleyFile);
 					if ($galleyFile && $galleyFile->getFileId() == $submissionFile->getFileId()) {
 						header('HTTP/1.1 301 Moved Permanently');
 						$request->redirect(null, null, 'download', array($articleId, $articleGalley->getId(), $submissionFile->getFileId()));


### PR DESCRIPTION
@asmecher, there is an extra print_r command left probably from debugging which is causing headers already sent errors.
