### PR TITLE
pkp/pkp-lib#2516: Flag an error in Native Import if article has no date_published, but is a member of an issue

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlArticleFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlArticleFilter.inc.php
@@ -72,7 +72,7 @@ class NativeXmlArticleFilter extends NativeXmlSubmissionFilter {
 	}
 
 	/**
-	 * Populate the submission object from the node
+	 * Populate the submission object from the node, checking first for a valid section and published_date/issue relationship
 	 * @param $submission Submission
 	 * @param $node DOMElement
 	 * @return Submission
@@ -88,6 +88,14 @@ class NativeXmlArticleFilter extends NativeXmlSubmissionFilter {
 			} else {
 				$submission->setSectionId($section->getId());
 			}
+		}
+		// check if article is related to an issue, but has no published date
+		$datePublished = $node->getAttribute('date_published');
+		$issue = $deployment->getIssue();
+		$issue_identification = $node->getElementsByTagName('issue_identification');
+		if (!$datePublished && ($issue || $issue_identification->length)) {
+			$titleNodes = $node->getElementsByTagName('title');
+			$deployment->addError(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.native.import.error.publishedDateMissing', array('articleTitle' => $titleNodes->item(0)->textContent)));
 		}
 
 		return parent::populateObject($submission, $node);

--- a/plugins/importexport/native/locale/en_US/locale.xml
+++ b/plugins/importexport/native/locale/en_US/locale.xml
@@ -52,4 +52,5 @@ The following formats are accepted:
 	<message key="plugins.importexport.native.import.error.sectionAbbrevMatch">The section abbreviation "{$sectionAbbrev}" in the "{$issueTitle}" issue matched an existing journal section, but another abbreviation of this section doesn't match with another abbreviation of the existing journal section.</message>
 	<message key="plugins.importexport.native.import.error.issueIdentificationMatch">None or more than one issue matches the given issue identification "{$issueIdentification}".</message>
 	<message key="plugins.importexport.native.import.error.issueIdentificationMissing">The issue identification element is missing for the article "{$articleTitle}".</message>
+	<message key="plugins.importexport.native.import.error.publishedDateMissing">The article "{$articleTitle}" is contained within an issue, but has no published date.</message>
 </locale>


### PR DESCRIPTION
Resolves a part of pkp/pkp-lib#2516.

Raises an error if the import has a `<issue>` element which contains `<article>` elements which do not have a `date_published` attribute.  Articles cannot be added to an issue without a published date.
