### PR TITLE
pkp/pkp-lib#2461: Add section_ref as required attribute to articles; improve error recovery for native import when objects cannot be added to the database due to foreign key constraints

### DIFF
--- a/plugins/importexport/native/NativeImportExportDeployment.inc.php
+++ b/plugins/importexport/native/NativeImportExportDeployment.inc.php
@@ -91,8 +91,10 @@ class NativeImportExportDeployment extends PKPNativeImportExportDeployment {
 				if (!empty($processedIssuesIds)) {
 					$issueDao = DAORegistry::getDAO('IssueDAO');
 					foreach ($processedIssuesIds as $issueId => $errorMessages) {
-						$issue = $issueDao->getById($issueId);
-						$issueDao->deleteObject($issue);
+						if ($issueId) {
+							$issue = $issueDao->getById($issueId);
+							$issueDao->deleteObject($issue);
+						}
 					}
 				}
 				break;

--- a/plugins/importexport/native/NativeImportExportPlugin.inc.php
+++ b/plugins/importexport/native/NativeImportExportPlugin.inc.php
@@ -123,7 +123,6 @@ class NativeImportExportPlugin extends ImportExportPlugin {
 				$xmlString = file_get_contents($temporaryFilePath);
 				$document = new DOMDocument();
 				$document->loadXml($xmlString);
-				$requirementsErrors = null;
 				if (in_array($document->documentElement->tagName, array('article', 'articles'))) {
 					$filter = 'native-xml=>article';
 				}
@@ -345,6 +344,7 @@ class NativeImportExportPlugin extends ImportExportPlugin {
 				$deployment = new NativeImportExportDeployment($journal, $user);
 				$deployment->setImportPath(dirname($xmlFile));
 				$content = $this->importSubmissions($xmlString, $filter, $deployment);
+				$validationErrors = array_filter(libxml_get_errors(), create_function('$a', 'return $a->level == LIBXML_ERR_ERROR ||  $a->level == LIBXML_ERR_FATAL;'));
 
 				// Are there any issues import errors, display them
 				$processedIssuesIds = $deployment->getProcessedObjectsIds(ASSOC_TYPE_ISSUE);

--- a/plugins/importexport/native/filter/NativeXmlArticleFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlArticleFilter.inc.php
@@ -52,6 +52,26 @@ class NativeXmlArticleFilter extends NativeXmlSubmissionFilter {
 	}
 
 	/**
+	 * Handle an Article import.
+	 * The Article must have a valid section in order to be imported
+	 * @param $node DOMElement
+	 */
+	function handleElement($node) {
+		$deployment = $this->getDeployment();
+		$context = $deployment->getContext();
+		$sectionAbbrev = $node->getAttribute('section_ref');
+		if ($sectionAbbrev !== '') {
+			$sectionDao = DAORegistry::getDAO('SectionDAO');
+			$section = $sectionDao->getByAbbrev($sectionAbbrev, $context->getId());
+			if (!$section) {
+				$deployment->addError(ASSOC_TYPE_SUBMISSION, NULL, __('plugins.importexport.native.error.unknownSection', array('param' => $sectionAbbrev)));
+			} else {
+				parent::handleElement($node);
+			}
+		}
+	}
+
+	/**
 	 * @see Filter::process()
 	 * @param $document DOMDocument|string
 	 * @return array Array of imported documents

--- a/plugins/importexport/native/native.xsd
+++ b/plugins/importexport/native/native.xsd
@@ -26,7 +26,7 @@
 						<element ref="pkp:issue_identification" minOccurs="0" maxOccurs="1" />
 						<element maxOccurs="1" minOccurs="0" name="pages" type="string" />
 					</sequence>
-					<attribute name="section_ref" type="string" />
+					<attribute name="section_ref" type="string" use="required" />
 					<attribute name="seq" type="int" />
 					<attribute name="access_status" type="int" />
 					<attribute name="stage" use="required">


### PR DESCRIPTION
Resolves pkp/pkp-lib#2461 in combination with pkp/pkp-lib#2522.
