### PR TITLE
Change DOAJ API protocol to https

### DIFF
--- a/plugins/importexport/doaj/DOAJExportPlugin.inc.php
+++ b/plugins/importexport/doaj/DOAJExportPlugin.inc.php
@@ -15,12 +15,12 @@
 
 import('classes.plugins.PubObjectsExportPlugin');
 
-define('DOAJ_XSD_URL', 'http://www.doaj.org/schemas/doajArticles.xsd');
+define('DOAJ_XSD_URL', 'https://www.doaj.org/schemas/doajArticles.xsd');
 
 define('DOAJ_API_DEPOSIT_OK', 201);
 
-define('DOAJ_API_URL', 'http://doaj.org/api/v1/');
-define('DOAJ_API_URL_DEV', 'http://testdoaj.cottagelabs.com/api/v1/');
+define('DOAJ_API_URL', 'https://doaj.org/api/v1/');
+define('DOAJ_API_URL_DEV', 'https://testdoaj.cottagelabs.com/api/v1/');
 define('DOAJ_API_OPERATION', 'bulk/articles');
 
 class DOAJExportPlugin extends PubObjectsExportPlugin {


### PR DESCRIPTION
Hi @bozana 

If a journal is SSL the DOAJ API returns 301 error when trying to export articles. This can be fixed by chancing the API address to https.

However, I do not know whether you want to use `//doaj.org/api/v1/` instead? @asmecher? But if so, note that most of the export plugins define the API protocoll at the moment.
