### PR TITLE
Prevent duplicate load of issue in Native Import with identical issue identification

### DIFF
--- a/plugins/importexport/native/NativeImportExportDeployment.inc.php
+++ b/plugins/importexport/native/NativeImportExportDeployment.inc.php
@@ -69,7 +69,6 @@ class NativeImportExportDeployment extends PKPNativeImportExportDeployment {
 	 */
 	function setIssue($issue) {
 		$this->_issue = $issue;
-		if ($issue) $this->addProcessedObjectId(ASSOC_TYPE_ISSUE, $issue->getId());
 	}
 
 	/**

--- a/plugins/importexport/native/NativeImportExportPlugin.inc.php
+++ b/plugins/importexport/native/NativeImportExportPlugin.inc.php
@@ -337,14 +337,15 @@ class NativeImportExportPlugin extends ImportExportPlugin {
 					return;
 				}
 
-				$filter = 'native-xml=>issue';
-				// is this articles import:
 				if (!file_exists($xmlFile)) {
 					echo __('plugins.importexport.common.cliError') . "\n";
 					echo __('plugins.importexport.common.export.error.inputFileNotReadable', array('param' => $xmlFile)) . "\n\n";
 					$this->usage($scriptName);
 					return;
 				}
+
+				$filter = 'native-xml=>issue';
+				// is this articles import:
 				$xmlString = file_get_contents($xmlFile);
 				$document = new DOMDocument();
 				$document->loadXml($xmlString);

--- a/plugins/importexport/native/filter/NativeXmlArticleFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlArticleFilter.inc.php
@@ -230,27 +230,23 @@ class NativeXmlArticleFilter extends NativeXmlSubmissionFilter {
 		$context = $deployment->getContext();
 		$submission = $deployment->getSubmission();
 		$vol = $num = $year = null;
-		$titles = $givenIssueIdentification = array();
+		$titles = array();
 		for ($n = $node->firstChild; $n !== null; $n=$n->nextSibling) {
 			if (is_a($n, 'DOMElement')) {
 				switch ($n->tagName) {
 					case 'volume':
 						$vol = $n->textContent;
-						$givenIssueIdentification[] = 'volue = ' .$vol .' ';
 						break;
 					case 'number':
 						$num = $n->textContent;
-						$givenIssueIdentification[] = 'number = ' .$num .' ';
 						break;
 					case 'year':
 						$year = $n->textContent;
-						$givenIssueIdentification[] = 'year = ' .$year .' ';
 						break;
 					case 'title':
 						list($locale, $value) = $this->parseLocalizedContent($n);
 						if (empty($locale)) $locale = $context->getPrimaryLocale();
 						$titles[$locale] = $value;
-						$givenIssueIdentification[] = 'title (' .$locale .') = ' .$value .' ';
 						break;
 					default:
 						$deployment->addWarning(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.common.error.unknownElement', array('param' => $n->tagName)));
@@ -261,7 +257,7 @@ class NativeXmlArticleFilter extends NativeXmlSubmissionFilter {
 		$issue = null;
 		$issuesByIdentification = $issueDao->getIssuesByIdentification($context->getId(), $vol, $num, $year, $titles);
 		if ($issuesByIdentification->getCount() != 1) {
-			$deployment->addError(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.native.import.error.issueIdentificationMatch', array('issueIdentification' => implode(',', $givenIssueIdentification))));
+			$deployment->addError(ASSOC_TYPE_SUBMISSION, $submission->getId(), __('plugins.importexport.native.import.error.issueIdentificationMatch', array('issueIdentification' => implode(',', $node->ownerDocument->saveXML($node)))));
 		} else {
 			$issue = $issuesByIdentification->next();
 		}

--- a/plugins/importexport/native/locale/en_US/locale.xml
+++ b/plugins/importexport/native/locale/en_US/locale.xml
@@ -51,6 +51,7 @@ The following formats are accepted:
 	<message key="plugins.importexport.native.import.error.sectionAbbrevMismatch">The section abbreviation "{$section1Abbrev}" and the section abbreviation "{$section2Abbrev}" of the "{$issueTitle}" issue matched the different existing journal sections.</message>
 	<message key="plugins.importexport.native.import.error.sectionAbbrevMatch">The section abbreviation "{$sectionAbbrev}" in the "{$issueTitle}" issue matched an existing journal section, but another abbreviation of this section doesn't match with another abbreviation of the existing journal section.</message>
 	<message key="plugins.importexport.native.import.error.issueIdentificationMatch">None or more than one issue matches the given issue identification "{$issueIdentification}".</message>
+	<message key="plugins.importexport.native.import.error.issueIdentificationDuplicate">Existing issue with id {$issueId} matches the given issue identification "{$issueIdentification}".  This issue will not be modified, but articles will be added.</message>
 	<message key="plugins.importexport.native.import.error.issueIdentificationMissing">The issue identification element is missing for the article "{$articleTitle}".</message>
 	<message key="plugins.importexport.native.import.error.publishedDateMissing">The article "{$articleTitle}" is contained within an issue, but has no published date.</message>
 </locale>


### PR DESCRIPTION
This pull resolves pkp/pkp-lib#2462 by checking if a matching issue_identification is found before creating a brand new issue.

Some problems with this:
* The entire import process is far too dependent on reporting errors based on imported object id; IMHO this should be based on the XML input (node lineage? line/char?).  Here I've just reported the raw XML.
* There is an unfortunate dependency throughout the import process on the magic of the `$deployment`'s shared variables for context, issue, submission, etc.  I'm unhappy with the `$addProcessedObject` parameter in `setIssue()` as a workaround for this.
* Reusing an existing issue based on issue_identification means that the issue will be updated, with no path to rollback possible in the event of error!