### PR TITLE
pkp/pkp-lib#2444: refactor constructor for GridCellProvider to take a $request parameter

### DIFF
--- a/classes/controllers/grid/issues/IssueGridHandler.inc.php
+++ b/classes/controllers/grid/issues/IssueGridHandler.inc.php
@@ -73,7 +73,7 @@ class IssueGridHandler extends GridHandler {
 
 		// Grid columns.
 		import('controllers.grid.issues.IssueGridCellProvider');
-		$issueGridCellProvider = new IssueGridCellProvider();
+		$issueGridCellProvider = new IssueGridCellProvider($request);
 
 		// Issue identification
 		$this->addColumn(

--- a/controllers/grid/articleGalleys/ArticleGalleyGridCellProvider.inc.php
+++ b/controllers/grid/articleGalleys/ArticleGalleyGridCellProvider.inc.php
@@ -22,10 +22,11 @@ class ArticleGalleyGridCellProvider extends DataObjectGridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 * @param $submission Submission
 	 */
-	function __construct($submission) {
-		parent::__construct();
+	function __construct($request, $submission) {
+		parent::__construct($request);
 		$this->_submission = $submission;
 	}
 
@@ -65,7 +66,7 @@ class ArticleGalleyGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		switch ($column->getId()) {
 			case 'label':
 				$element = $row->getData();
@@ -79,9 +80,9 @@ class ArticleGalleyGridCellProvider extends DataObjectGridCellProvider {
 					$element->getSubmissionId()
 				);
 				import('lib.pkp.controllers.api.file.linkAction.DownloadFileLinkAction');
-				return array(new DownloadFileLinkAction($request, $submissionFile, $request->getUserVar('stageId'), $element->getLabel()));
+				return array(new DownloadFileLinkAction($this->_request, $submissionFile, $this->_request->getUserVar('stageId'), $element->getLabel()));
 		}
-		return parent::getCellActions($request, $row, $column);
+		return parent::getCellActions($row, $column);
 	}
 }
 

--- a/controllers/grid/articleGalleys/ArticleGalleyGridHandler.inc.php
+++ b/controllers/grid/articleGalleys/ArticleGalleyGridHandler.inc.php
@@ -101,7 +101,7 @@ class ArticleGalleyGridHandler extends GridHandler {
 		);
 
 		import('controllers.grid.articleGalleys.ArticleGalleyGridCellProvider');
-		$cellProvider = new ArticleGalleyGridCellProvider($this->getSubmission());
+		$cellProvider = new ArticleGalleyGridCellProvider($request, $this->getSubmission());
 
 		// Columns
 		$this->addColumn(new GridColumn(

--- a/controllers/grid/issueGalleys/IssueGalleyGridCellProvider.inc.php
+++ b/controllers/grid/issueGalleys/IssueGalleyGridCellProvider.inc.php
@@ -18,11 +18,7 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 class IssueGalleyGridCellProvider extends GridCellProvider {
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$issueGalley = $row->getData();

--- a/controllers/grid/issueGalleys/IssueGalleyGridHandler.inc.php
+++ b/controllers/grid/issueGalleys/IssueGalleyGridHandler.inc.php
@@ -119,7 +119,7 @@ class IssueGalleyGridHandler extends GridHandler {
 
 		// Grid columns.
 		import('controllers.grid.issueGalleys.IssueGalleyGridCellProvider');
-		$issueGalleyGridCellProvider = new IssueGalleyGridCellProvider();
+		$issueGalleyGridCellProvider = new IssueGalleyGridCellProvider($request);
 
 		// Issue identification
 		$this->addColumn(

--- a/controllers/grid/issues/IssueGridCellProvider.inc.php
+++ b/controllers/grid/issues/IssueGridCellProvider.inc.php
@@ -22,8 +22,8 @@ class IssueGridCellProvider extends GridCellProvider {
 	/**
 	 * Constructor
 	 */
-	function __construct() {
-		parent::__construct();
+	function __construct($request) {
+		parent::__construct($request);
 		$this->dateFormatShort = Config::getVar('general', 'date_format_short');
 	}
 
@@ -31,19 +31,20 @@ class IssueGridCellProvider extends GridCellProvider {
 	 * Get cell actions associated with this row/column combination
 	 * @param $row GridRow
 	 * @param $column GridColumn
+	 * @param $position string
 	 * @return array an array of LinkAction instances
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		if ($column->getId() == 'identification') {
 			$issue = $row->getData();
 			assert(is_a($issue, 'Issue'));
-			$router = $request->getRouter();
+			$router = $this->_request->getRouter();
 			import('lib.pkp.classes.linkAction.request.AjaxModal');
 			return array(
 				new LinkAction(
 					'edit',
 					new AjaxModal(
-						$router->url($request, null, null, 'editIssue', null, array('issueId' => $issue->getId())),
+						$router->url($this->_request, null, null, 'editIssue', null, array('issueId' => $issue->getId())),
 						__('editor.issues.editIssue', array('issueIdentification' => $issue->getIssueIdentification())),
 						'modal_edit',
 						true
@@ -56,11 +57,7 @@ class IssueGridCellProvider extends GridCellProvider {
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$issue = $row->getData();

--- a/controllers/grid/pubIds/PubIdExportIssuesListGridCellProvider.inc.php
+++ b/controllers/grid/pubIds/PubIdExportIssuesListGridCellProvider.inc.php
@@ -21,13 +21,16 @@ class PubIdExportIssuesListGridCellProvider extends DataObjectGridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
+	 * @param $plugin PKPPlugin
+	 * @param $authorizedRoles mixed
 	 */
-	function __construct($plugin, $authorizedRoles = null) {
+	function __construct($request, $plugin, $authorizedRoles = null) {
 		$this->_plugin  = $plugin;
 		if ($authorizedRoles) {
 			$this->_authorizedRoles = $authorizedRoles;
 		}
-		parent::__construct();
+		parent::__construct($request);
 	}
 
 	//
@@ -38,7 +41,7 @@ class PubIdExportIssuesListGridCellProvider extends DataObjectGridCellProvider {
 	 *
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$publishedIssue = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedIssue, 'Issue') && !empty($columnId));
@@ -53,7 +56,7 @@ class PubIdExportIssuesListGridCellProvider extends DataObjectGridCellProvider {
 					new LinkAction(
 						'edit',
 						new AjaxModal(
-							$dispatcher->url($request, ROUTE_COMPONENT, null, 'grid.issues.BackIssueGridHandler', 'editIssue', null, array('issueId' => $publishedIssue->getId())),
+							$dispatcher->url($this->_request, ROUTE_COMPONENT, null, 'grid.issues.BackIssueGridHandler', 'editIssue', null, array('issueId' => $publishedIssue->getId())),
 							__('plugins.importexport.common.settings.DOIPluginSettings')
 						),
 						$publishedIssue->getIssueIdentification(),
@@ -79,7 +82,7 @@ class PubIdExportIssuesListGridCellProvider extends DataObjectGridCellProvider {
 					);
 				}
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	/**

--- a/controllers/grid/pubIds/PubIdExportIssuesListGridHandler.inc.php
+++ b/controllers/grid/pubIds/PubIdExportIssuesListGridHandler.inc.php
@@ -74,7 +74,7 @@ class PubIdExportIssuesListGridHandler extends GridHandler {
 		$authorizedRoles = $this->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
 
 		// Grid columns.
-		$cellProvider = new PubIdExportIssuesListGridCellProvider($this->_plugin, $authorizedRoles);
+		$cellProvider = new PubIdExportIssuesListGridCellProvider($request, $this->_plugin, $authorizedRoles);
 		$this->addColumn(
 			new GridColumn(
 				'identification',

--- a/controllers/grid/pubIds/PubIdExportRepresentationsListGridCellProvider.inc.php
+++ b/controllers/grid/pubIds/PubIdExportRepresentationsListGridCellProvider.inc.php
@@ -22,13 +22,16 @@ class PubIdExportRepresentationsListGridCellProvider extends DataObjectGridCellP
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
+	 * @param $plugin PKPPlugin
+	 * @param $authorizedRoles mixed
 	 */
-	function __construct($plugin, $authorizedRoles = null) {
+	function __construct($request, $plugin, $authorizedRoles = null) {
 		$this->_plugin  = $plugin;
 		if ($authorizedRoles) {
 			$this->_authorizedRoles = $authorizedRoles;
 		}
-		parent::__construct();
+		parent::__construct($request);
 	}
 
 	//
@@ -39,7 +42,7 @@ class PubIdExportRepresentationsListGridCellProvider extends DataObjectGridCellP
 	 *
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$publishedSubmissionGalley = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedSubmissionGalley, 'ArticleGalley') && !empty($columnId));
@@ -59,7 +62,7 @@ class PubIdExportRepresentationsListGridCellProvider extends DataObjectGridCellP
 					new LinkAction(
 						'itemWorkflow',
 						new RedirectAction(
-							SubmissionsListGridCellProvider::getUrlByUserRoles($request, $publishedSubmission)
+							SubmissionsListGridCellProvider::getUrlByUserRoles($this->_request, $publishedSubmission)
 						),
 						$title
 					)
@@ -77,7 +80,7 @@ class PubIdExportRepresentationsListGridCellProvider extends DataObjectGridCellP
 					new LinkAction(
 						'edit',
 						new AjaxModal(
-							$dispatcher->url($request, ROUTE_COMPONENT, null, 'grid.issues.BackIssueGridHandler', 'editIssue', null, array('issueId' => $issue->getId())),
+							$dispatcher->url($this->_request, ROUTE_COMPONENT, null, 'grid.issues.BackIssueGridHandler', 'editIssue', null, array('issueId' => $issue->getId())),
 							__('plugins.importexport.common.settings.DOIPluginSettings')
 						),
 						$issue->getIssueIdentification(),
@@ -102,14 +105,11 @@ class PubIdExportRepresentationsListGridCellProvider extends DataObjectGridCellP
 					);
 				}
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 *
-	 * @copydoc DataObjectGridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$publishedSubmissionGalley = $row->getData();

--- a/controllers/grid/pubIds/PubIdExportRepresentationsListGridHandler.inc.php
+++ b/controllers/grid/pubIds/PubIdExportRepresentationsListGridHandler.inc.php
@@ -76,7 +76,7 @@ class PubIdExportRepresentationsListGridHandler extends GridHandler {
 		$authorizedRoles = $this->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
 
 		// Grid columns.
-		$cellProvider = new PubIdExportRepresentationsListGridCellProvider($this->_plugin, $authorizedRoles);
+		$cellProvider = new PubIdExportRepresentationsListGridCellProvider($request, $this->_plugin, $authorizedRoles);
 		$this->addColumn(
 			new GridColumn(
 				'id',

--- a/controllers/grid/pubIds/PubIdExportSubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/pubIds/PubIdExportSubmissionsListGridCellProvider.inc.php
@@ -18,14 +18,7 @@ import('controllers.grid.submissions.ExportPublishedSubmissionsListGridCellProvi
 
 class PubIdExportSubmissionsListGridCellProvider extends ExportPublishedSubmissionsListGridCellProvider {
 	/**
-	 * Constructor
-	 */
-	function __construct($plugin, $authorizedRoles = null) {
-		parent::__construct($plugin, $authorizedRoles);
-	}
-
-	/**
-	 * @copydoc ExportPublishedSubmissionsListGridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$publishedSubmission = $row->getData();

--- a/controllers/grid/pubIds/PubIdExportSubmissionsListGridHandler.inc.php
+++ b/controllers/grid/pubIds/PubIdExportSubmissionsListGridHandler.inc.php
@@ -53,7 +53,9 @@ class PubIdExportSubmissionsListGridHandler extends ExportPublishedSubmissionsLi
 		// Fetch the authorized roles.
 		$authorizedRoles = $this->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
 		import('controllers.grid.pubIds.PubIdExportSubmissionsListGridCellProvider');
-		return new PubIdExportSubmissionsListGridCellProvider($this->_plugin, $authorizedRoles);
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
+		$request = PKPApplication::getRequest();
+		return new PubIdExportSubmissionsListGridCellProvider($request, $this->_plugin, $authorizedRoles);
 	}
 
 	/**

--- a/controllers/grid/submissions/ExportPublishedSubmissionsListGridCellProvider.inc.php
+++ b/controllers/grid/submissions/ExportPublishedSubmissionsListGridCellProvider.inc.php
@@ -21,13 +21,16 @@ class ExportPublishedSubmissionsListGridCellProvider extends DataObjectGridCellP
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
+	 * @param $plugin PKPPlugin
+	 * @param $authorizedRoles mixed
 	 */
-	function __construct($plugin, $authorizedRoles = null) {
+	function __construct($request, $plugin, $authorizedRoles = null) {
 		$this->_plugin  = $plugin;
 		if ($authorizedRoles) {
 			$this->_authorizedRoles = $authorizedRoles;
 		}
-		parent::__construct();
+		parent::__construct($request);
 	}
 
 	//
@@ -38,7 +41,7 @@ class ExportPublishedSubmissionsListGridCellProvider extends DataObjectGridCellP
 	 *
 	 * @copydoc GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
+	function getCellActions($row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {
 		$publishedSubmission = $row->getData();
 		$columnId = $column->getId();
 		assert(is_a($publishedSubmission, 'PublishedArticle') && !empty($columnId));
@@ -56,7 +59,7 @@ class ExportPublishedSubmissionsListGridCellProvider extends DataObjectGridCellP
 					new LinkAction(
 						'itemWorkflow',
 						new RedirectAction(
-							SubmissionsListGridCellProvider::getUrlByUserRoles($request, $publishedSubmission)
+							SubmissionsListGridCellProvider::getUrlByUserRoles($this->_request, $publishedSubmission)
 						),
 						$title
 					)
@@ -74,7 +77,7 @@ class ExportPublishedSubmissionsListGridCellProvider extends DataObjectGridCellP
 					new LinkAction(
 						'edit',
 						new AjaxModal(
-							$dispatcher->url($request, ROUTE_COMPONENT, null, 'grid.issues.BackIssueGridHandler', 'editIssue', null, array('issueId' => $issue->getId())),
+							$dispatcher->url($this->_request, ROUTE_COMPONENT, null, 'grid.issues.BackIssueGridHandler', 'editIssue', null, array('issueId' => $issue->getId())),
 							__('plugins.importexport.common.settings.DOIPluginSettings')
 						),
 						$issue->getIssueIdentification(),
@@ -99,14 +102,11 @@ class ExportPublishedSubmissionsListGridCellProvider extends DataObjectGridCellP
 					);
 				}
 		}
-		return parent::getCellActions($request, $row, $column, $position);
+		return parent::getCellActions($row, $column, $position);
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 *
-	 * @copydoc DataObjectGridCellProvider::getTemplateVarsFromRowColumn()
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$publishedSubmission = $row->getData();

--- a/controllers/grid/submissions/ExportPublishedSubmissionsListGridHandler.inc.php
+++ b/controllers/grid/submissions/ExportPublishedSubmissionsListGridHandler.inc.php
@@ -286,7 +286,9 @@ class ExportPublishedSubmissionsListGridHandler extends GridHandler {
 		// Fetch the authorized roles.
 		$authorizedRoles = $this->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
 		import('controllers.grid.submissions.ExportPublishedSubmissionsListGridCellProvider');
-		return new ExportPublishedSubmissionsListGridCellProvider($this->_plugin, $authorizedRoles);
+		// TODO: pkp/pkp-lib#2444 Where should the request come from?
+		$request = PKPApplication::getRequest();
+		return new ExportPublishedSubmissionsListGridCellProvider($request, $this->_plugin, $authorizedRoles);
 	}
 
 }

--- a/controllers/grid/toc/TocGridCellProvider.inc.php
+++ b/controllers/grid/toc/TocGridCellProvider.inc.php
@@ -18,17 +18,14 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 class TocGridCellProvider extends GridCellProvider {
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 */
-	function __construct($translate = false) {
-		parent::__construct();
+	function __construct($request) {
+		parent::__construct($request);
 	}
 
 	/**
-	 * Extracts variables for a given column from a data element
-	 * so that they may be assigned to template before rendering.
-	 * @param $row GridRow
-	 * @param $column GridColumn
-	 * @return array
+	 * @copydoc GridCellProvider::getTemplateVarsFromRowColumn()
 	 */
 	function getTemplateVarsFromRowColumn($row, $column) {
 		$element = $row->getData();

--- a/controllers/grid/toc/TocGridHandler.inc.php
+++ b/controllers/grid/toc/TocGridHandler.inc.php
@@ -61,7 +61,7 @@ class TocGridHandler extends CategoryGridHandler {
 		// Grid columns.
 		//
 		import('controllers.grid.toc.TocGridCellProvider');
-		$tocGridCellProvider = new TocGridCellProvider();
+		$tocGridCellProvider = new TocGridCellProvider($request);
 
 		// Article title
 		$this->addColumn(


### PR DESCRIPTION
Resolves pkp/pkp-lib#2444 for OJS; requires breaking change in shared library per https://github.com/pkp/pkp-lib/issues/2546 .

Leaves outstanding pulls to plugins and to OMP.