### PR TITLE
pkp/pkp-lib#2547: translate event log message in event details page

### DIFF
--- a/templates/sectionEditor/submissionEventLogEntry.tpl
+++ b/templates/sectionEditor/submissionEventLogEntry.tpl
@@ -54,7 +54,7 @@
 		<td class="value">
 			<strong>{translate key=$logEntry->getEventTitle()}</strong>
 			<br /><br />
-			{$logEntry->getMessage()|strip_unsafe_html|nl2br}
+			{$logEntry->getTranslatedMessage()|strip_unsafe_html|nl2br}
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
Resolves pkp/pkp-lib#2547; should be cherry-picked to stable 2.4.8.