### PR TITLE
GOST Citation Format Plugin

### DIFF
--- a/plugins/citationFormats/gost/GOSTCitationPlugin.inc.php
+++ b/plugins/citationFormats/gost/GOSTCitationPlugin.inc.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * @file plugins/citationFormats/GOST/GOSTCitationPlugin.inc.php
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University
+ * Copyright (c) 2003-2017 John Willinsky
+ * With contributions from by Lepidus Tecnologia
+ *
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class GOSTCitationPlugin
+ * @ingroup plugins_citationFormats_GOST
+ *
+ * @brief GOST citation format plugin
+ */
+
+import('classes.plugins.CitationPlugin');
+
+class GOSTCitationPlugin extends CitationPlugin {
+	/**
+	 * @copydoc Plugin::register()
+	 */
+	function register($category, $path) {
+		$success = parent::register($category, $path);
+		$this->addLocaleData();
+		return $success;
+	}
+
+	/**
+	 * Get the name of this plugin. The name must be unique within
+	 * its category.
+	 * @return String name of plugin
+	 */
+	function getName() {
+		return 'GOSTCitationPlugin';
+	}
+
+	/**
+	 * @copydoc Plugin::getDisplayName()
+	 */
+	function getDisplayName() {
+		return __('plugins.citationFormats.GOST.displayName');
+	}
+
+	/**
+	 * @copydoc CitationPlugin::getCitationFormatName()
+	 */
+	function getCitationFormatName() {
+		return __('plugins.citationFormats.GOST.citationFormatName');
+	}
+
+	/**
+	 * @copydoc Plugin::getDescription()
+	 */
+	function getDescription() {
+		return __('plugins.citationFormats.GOST.description');
+	}
+
+	/**
+	 * Get the localized location for citations in this journal
+	 * @param $journal Journal
+	 * @return string
+	 */
+	function getLocalizedLocation($journal) {
+		$settings = $this->getSetting($journal->getId(), 'location');
+		if ($settings === null) {
+			return null;
+		}
+		$location = $settings[AppLocale::getLocale()];
+		if (empty($location)) {
+			$location = $settings[AppLocale::getPrimaryLocale()];
+		}
+		return $location;
+	}
+
+	/**
+	 * @copydoc Plugin::getManagementVerbLinkAction()
+	 */
+	function getManagementVerbLinkAction($request, $verb) {
+		list($verbName, $verbLocalized) = $verb;
+
+		switch ($verbName) {
+			case 'settings':
+				// Generate a link action for the "settings" action
+				$dispatcher = $request->getDispatcher();
+				import('lib.pkp.classes.linkAction.request.RedirectAction');
+				return new LinkAction(
+					$verbName,
+					new RedirectAction($dispatcher->url(
+						$request, ROUTE_PAGE,
+						null, 'management', 'settings', 'website',
+						array('uid' => uniqid()), // Force reload
+						'staticPages' // Anchor for tab
+					)),
+					$verbLocalized,
+					null
+				);
+			default:
+				return parent::getManagementVerbLinkAction($request, $verb);
+		}
+	}
+
+	/**
+	 * Display an HTML-formatted citation. We register PKPString::strtoupper modifier
+	 * in order to convert author names to uppercase.
+	 * @param $article Article
+	 * @param $issue Issue
+	 * @param $journal Journal
+	 */
+	function fetchCitation(&$article, &$issue, &$journal) {
+		$templateMgr = TemplateManager::getManager($this->getRequest());
+		$templateMgr->register_modifier('mb_upper', array('PKPString', 'strtoupper'));
+		$templateMgr->register_modifier('GOST_date_format', array($this, 'GOSTDateFormat'));
+		$templateMgr->register_modifier('GOST_date_format_with_day', array($this, 'GOSTDateFormatWithDay'));
+		return parent::fetchCitation($article, $issue, $journal);
+	}
+
+ 	/**
+	 * @copydoc Plugin::manage()
+	 */
+	function manage($verb, $args, &$message, &$messageParams, &$pluginModalContent = null) {
+		$request = $this->getRequest();
+		switch ($verb) {
+			case 'settings':
+				$templateMgr = TemplateManager::getManager($request);
+				$templateMgr->register_function('plugin_url', array($this, 'smartyPluginUrl'));
+				$journal = $request->getJournal();
+
+				$this->import('GOSTSettingsForm');
+				$form = new GOSTSettingsForm($this, $journal->getId());
+				if ($request->getUserVar('save')) {
+					$form->readInputData();
+					if ($form->validate()) {
+						$form->execute();
+						$request->redirect(null, 'manager', 'plugin');
+						return false;
+					} else {
+						$form->display();
+					}
+				} else {
+					if ($form->isLocaleResubmit()) {
+						$form->readInputData();
+					} else {
+						$form->initData();
+					}
+					$form->display();
+				}
+				return true;
+			default:
+				// Unknown management verb, delegate to parent
+				return parent::manage($verb, $args, $message);
+		}
+	}
+
+	/**
+	 * Extend the {url ...} smarty to support this plugin.
+	 * @param $params array
+	 * @param $smarty Smarty
+	 */
+	function smartyPluginUrl($params, &$smarty) {
+		$path = array($this->getCategory(), $this->getName());
+		if (is_array($params['path'])) {
+			$params['path'] = array_merge($path, $params['path']);
+		} elseif (!empty($params['path'])) {
+			$params['path'] = array_merge($path, array($params['path']));
+		} else {
+			$params['path'] = $path;
+		}
+
+		return $smarty->smartyUrl($params, $smarty);
+	}
+
+	/**
+	 * @function GOSTDateFormat Format date taking in consideration GOST month abbreviations
+	 * @param $string string
+	 * @return string
+	 */
+	function GOSTDateFormat($string) {
+		if (is_numeric($string)) {
+			// it is a numeric string, we handle it as timestamp
+			$timestamp = (int)$string;
+		} else {
+			$timestamp = strtotime($string);
+		}
+		$format = "%B %Y";
+		if (PKPString::strlen(strftime("%B", $timestamp)) > 4) {
+			$format = "%b. %Y";
+		}
+
+		return PKPString::strtolower(strftime($format, $timestamp));
+	}
+
+	/**
+	 * @function GOSTDateFormatWithDay Format date taking in consideration GOST month abbreviations
+	 * @param $string string
+	 * @return string
+	 */
+	function GOSTDateFormatWithDay($string) {
+		if (is_numeric($string)) {
+			// it is a numeric string, we handle it as timestamp
+			$timestamp = (int)$string;
+		} else {
+			$timestamp = strtotime($string);
+		}
+		$format = "%d %B %Y";
+		if (PKPString::strlen(strftime("%B", $timestamp)) > 4) {
+			$format = "%d %b. %Y";
+		}
+
+		return PKPString::strtolower(strftime($format, $timestamp));
+	}
+}
+
+?>

--- a/plugins/citationFormats/gost/GOSTSettingsForm.inc.php
+++ b/plugins/citationFormats/gost/GOSTSettingsForm.inc.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @file GOSTSettingsForm.inc.php
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University
+ * Copyright (c) 2003-2017 John Willinsky
+ * Contributed by Lepidus Tecnologia
+ *
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class GOSTSettingsForm
+ * @ingroup plugins_citationFormats_GOST
+ *
+ * @brief Form for journal managers to modify GOST Citation plugin settings
+ */
+
+import('lib.pkp.classes.form.Form');
+
+class GOSTSettingsForm extends Form {
+
+	/** @var int */
+	var $journalId;
+
+	/** @var object */
+	var $plugin;
+
+	/**
+	 * Constructor
+	 * @param $plugin object
+	 * @param $journalId int
+	 */
+	function __construct(&$plugin, $journalId) {
+		$this->journalId = $journalId;
+		$this->plugin =& $plugin;
+
+		parent::__construct($plugin->getTemplatePath() . 'settingsForm.tpl');
+	}
+
+	/**
+	 * Initialize form data.
+	 */
+	function initData() {
+		$journalId = $this->journalId;
+		$plugin =& $this->plugin;
+
+		$this->_data = array(
+ 			'location' => $plugin->getSetting($journalId, 'location')
+		);
+	}
+
+	/**
+	 * Get the list of field names for which localized settings are used.
+	 * @return array
+	 */
+	function getLocaleFieldNames() {
+		return array('location');
+	}
+
+	/**
+	 * Assign form data to user-submitted data.
+	 */
+	function readInputData() {
+ 		$this->readUserVars(array('location'));
+	}
+
+	/**
+	 * Save settings.
+	 */
+	function execute() {
+		$plugin =& $this->plugin;
+
+		$value = $this->getData('location');
+		if (is_array($value)) {
+			$plugin->updateSetting($this->journalId, 'location', $value, 'object');
+		}
+	}
+}
+
+?>

--- a/plugins/citationFormats/gost/citation.tpl
+++ b/plugins/citationFormats/gost/citation.tpl
@@ -1,0 +1,39 @@
+{**
+ * plugins/citationFormats/GOST/citation.tpl
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University
+ * Copyright (c) 2003-2017 John Willinsky
+ * With contributions from by Lepidus Tecnologia
+ *
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Article reading tools -- Capture Citation for GOST
+ * 
+ *}
+
+{if $galley}
+	{url|assign:"articleUrl" page="article" op="view" path=$article->getBestArticleId()|to_array:$galley->getBestGalleyId()}
+{else}
+	{url|assign:"articleUrl" page="article" op="view" path=$article->getBestArticleId()}
+{/if}
+ 
+{assign var=authors value=$article->getAuthors()}
+{assign var=authorCount value=$authors|@count}
+{assign var=location value=$citationPlugin->getLocalizedLocation($journal)}
+{capture assign=iv}{translate key="issue.volume"}{/capture}
+{capture assign=pn}{translate key="common.pageNumber"}{/capture}
+{capture assign=sa}{translate key="submission.shortAuthor"}{/capture}
+{if $authorCount <= 3}
+	{foreach from=$authors item=author name=authors key=i}
+		{assign var=firstName value=$author->getFirstName()}
+		{assign var=middleName value=$author->getMiddleName()}
+		{$author->getLastName()|escape} {$firstName|escape|mb_substr:0:1}.{if $middleName} {$middleName|escape|mb_substr:0:1}.{/if}{if $i<$authorCount-1}, {/if}{/foreach}
+{else}
+	{assign var=firstName value=$authors[0]->getFirstName()}
+	{assign var=middleName value=$authors[0]->getMiddleName()}
+	{$authors[0]->getLastName()|escape} {$firstName|escape|mb_substr:0:1}.{if $middleName} {$middleName|escape|mb_substr:0:1}.{/if} {$sa|mb_substr:10:10}
+{/if}
+{$article->getLocalizedTitle()|strip_unsafe_html} // 
+<strong>{$journal->getLocalizedName()|escape}</strong>. {$article->getDatePublished()|date_format:'%Y'}{if $issue}{if $issue->getShowVolume()}. {$iv|mb_substr:0:1}. {$issue->getVolume()|escape}{/if}{if $issue->getShowNumber()}, № {$issue->getNumber()|escape}{/if}{/if}
+{if $article->getPages()}. {$pn|mb_substr:0:1}. {$article->getPages()|escape}{/if}.
+{if $article->getStoredPubId('doi')}doi:{$article->getStoredPubId('doi')}{else}{translate key="plugins.citationFormats.GOST.retrieved" retrievedDate=$smarty.now|date_format:"%d.%m.%Y" url=$articleUrl}{/if}

--- a/plugins/citationFormats/gost/index.php
+++ b/plugins/citationFormats/gost/index.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @defgroup plugins_citationFormats_GOST GOST Citation Format
+ */
+ 
+/**
+ * @file plugins/citationFormats/GOST/index.php
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University
+ * Copyright (c) 2003-2017 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @ingroup plugins_citationFormats_GOST
+ * @brief Wrapper for GOST citation plugin.
+ *
+ */
+
+require_once('GOSTCitationPlugin.inc.php');
+
+return new GOSTCitationPlugin();
+
+?>

--- a/plugins/citationFormats/gost/locale/en_US/locale.xml
+++ b/plugins/citationFormats/gost/locale/en_US/locale.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * plugins/citationFormats/GOST/locale/en_US/locale.xml
+  *
+  * Copyright (c) 2014-2017 Simon Fraser University
+  * Copyright (c) 2003-2017 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  * Localization information: https://pkp.sfu.ca/wiki/index.php?title=Translating_OxS
+  * Localization strings.
+  -->
+ 
+<locale name="en_US" full_name="U.S. English">
+	<message key="plugins.citationFormats.GOST.displayName">GOST citation format plugin</message>
+	<message key="plugins.citationFormats.GOST.citationFormatName">GOST</message>
+	<message key="plugins.citationFormats.GOST.description">This plugin implements the GOST citation format.</message>
+	
+	<message key="plugins.citationFormats.GOST.manager.settings">Settings</message>
+	<message key="plugins.citationFormats.GOST.manager.GOSTCitationSettings">GOST citation format plugin settings</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.description">Settings used to create citations according to GOST.</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.location">Location</message>
+	
+	<message key="plugins.citationFormats.GOST.retrieved"><![CDATA[URL: <a href="{$url}" target="_new">{$url}</a> (date accessed: {$retrievedDate})]]></message>
+</locale>

--- a/plugins/citationFormats/gost/locale/fr_CA/locale.xml
+++ b/plugins/citationFormats/gost/locale/fr_CA/locale.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * plugins/citationFormats/GOST/locale/fr_CA/locale.xml
+  *
+  * Copyright (c) 2014-2017 Simon Fraser University
+  * Copyright (c) 2003-2017 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  * Localization information: https://pkp.sfu.ca/wiki/index.php?title=OJS:_French_(fr_CA)
+  * Localization strings.
+  -->
+ 
+<locale name = "fr_CA" full_name = "Français (Canada)">
+	<message key="plugins.citationFormats.GOST.displayName">Plugiciel de format de référence bibliographique GOST</message>
+	<message key="plugins.citationFormats.GOST.citationFormatName">GOST</message>
+	<message key="plugins.citationFormats.GOST.description">Ce plugiciel implante le format de référence bibliographique GOST.</message>
+	<message key="plugins.citationFormats.GOST.retrieved"><![CDATA[URL: <a href="{$url}" target="_new">{$url}</a> (date de consultation: {$retrievedDate})]]></message>
+	<message key="plugins.citationFormats.GOST.manager.settings">Paramètres</message>
+	<message key="plugins.citationFormats.GOST.manager.GOSTCitationSettings">Paramétrage du plugiciel pour le format de citation GOST</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.description">Paramètres utilisés pour créer des citations sous format GOST</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.location">Localisation</message>
+</locale>

--- a/plugins/citationFormats/gost/locale/ru_RU/locale.xml
+++ b/plugins/citationFormats/gost/locale/ru_RU/locale.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * plugins/citationFormats/GOST/locale/ru_RU/locale.xml
+  *
+  * Copyright (c) 2014-2017 Simon Fraser University
+  * Copyright (c) 2003-2017 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  * Localization information: https://pkp.sfu.ca/wiki/index.php?title=OJS:_Russian_(ru_RU)
+  * Localization strings.
+  -->
+ 
+<locale name="ru_RU" full_name="Русский">
+	<message key="plugins.citationFormats.GOST.displayName">Модуль формата библиографических ссылок ГОСТ 7.0.5-2008</message>
+	<message key="plugins.citationFormats.GOST.citationFormatName">ГОСТ</message>
+	<message key="plugins.citationFormats.GOST.description">Реализует формат библиографических ссылок по ГОСТ 7.0.5-2008.</message>
+	
+	<message key="plugins.citationFormats.GOST.manager.settings">Настройки</message>
+	<message key="plugins.citationFormats.GOST.manager.GOSTCitationSettings">Настройки модуля формата библиографических ссылок ГОСТ</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.description">Настройки, используемые для создания библиографических ссылок в соответствии с ГОСТ.</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.location">Расположение</message>
+	
+	<message key="plugins.citationFormats.GOST.retrieved"><![CDATA[URL: <a href="{$url}" target="_new">{$url}</a> (дата обращения: {$retrievedDate})]]></message>
+</locale>

--- a/plugins/citationFormats/gost/locale/uk_UA/locale.xml
+++ b/plugins/citationFormats/gost/locale/uk_UA/locale.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * plugins/citationFormats/GOST/locale/uk_UA/locale.xml
+  *
+  * Copyright (c) 2014-2017 Simon Fraser University
+  * Copyright (c) 2003-2017 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Localization strings for the uk_UA (Українська) locale.
+  *
+  * Translated by Denys Solovianenko, 2011
+  * V. I. Vernadsky National Library of Ukraine
+  -->
+ 
+<locale name="uk_UA" full_name="Українська">
+       <message key="plugins.citationFormats.GOST.displayName">Модуль формату цитат GOST</message>
+       <message key="plugins.citationFormats.GOST.citationFormatName">GOST</message>
+       <message key="plugins.citationFormats.GOST.description">Цей модуль дозволяє використання формату цитат GOST.</message>
+       <message key="plugins.citationFormats.GOST.retrieved"><![CDATA[URL: <a href="{$url}" target="_new">{$url}</a> (дата доступу: {$retrievedDate})]]></message>
+	<message key="plugins.citationFormats.GOST.manager.settings">Налаштування</message>
+	<message key="plugins.citationFormats.GOST.manager.GOSTCitationSettings">Налаштування модуля формату цитат GOST</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.description">Налаштування, потрібні для створення цитат формату GOST.</message>
+	<message key="plugins.citationFormats.GOST.manager.settings.location">Розташування</message>
+</locale>

--- a/plugins/citationFormats/gost/settingsForm.tpl
+++ b/plugins/citationFormats/gost/settingsForm.tpl
@@ -1,0 +1,66 @@
+{**
+ * settingsForm.tpl
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University
+ * Copyright (c) 2003-2017 John Willinsky
+ * Contributed by Lepidus Tecnologia
+ *
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * GOST Citation plugin settings
+ *
+ *}
+{strip}
+{assign var="pageTitle" value="plugins.citationFormats.GOST.manager.GOSTCitationSettings"}
+{include file="common/header.tpl"}
+{/strip}
+<div id="GOSTCitationSettings">
+<div id="description">{translate key="plugins.citationFormats.GOST.manager.settings.description"}</div>
+
+<div class="separator"></div>
+
+<br />
+
+<script>
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#setupForm').pkpHandler('$.pkp.controllers.form.FormHandler');
+	{rdelim});
+</script>
+<form class="pkp_form" name="setupForm" id="setupForm" method="post" action="{plugin_url path="settings"}">
+{csrf}
+{include file="common/formErrors.tpl"}
+
+{if count($formLocales) > 1}
+<div id="locales">
+<table class="data">
+	<tr>
+		<td class="label">{fieldLabel name="formLocale" key="form.formLanguage"}</td>
+		<td class="value">
+			{plugin_url|assign:"setupFormUrl" path="settings" escape=false}
+			{form_language_chooser form="setupForm" url=$setupFormUrl}
+			<span class="instruct">{translate key="form.formLanguage.description"}</span>
+		</td>
+	</tr>
+</table>
+</div>
+{/if}
+<br/>
+
+<table class="data">
+	<tr>
+		<td class="label">{fieldLabel name="location" key="plugins.citationFormats.GOST.manager.settings.location"}</td>
+		<td class="value"><input type="text" name="location[{$formLocale|escape}]" id="location" value="{$location[$formLocale]|escape}" size="40" maxlength="120" class="textField" /></td>
+	</tr>
+</table>
+
+<br/>
+
+<input type="submit" name="save" class="button defaultButton" value="{translate key="common.save"}"/><input type="button" class="button" value="{translate key="common.cancel"}" onclick="history.go(-1)"/>
+</form>
+
+<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
+</div>
+
+
+{include file="common/footer.tpl"}

--- a/plugins/citationFormats/gost/version.xml
+++ b/plugins/citationFormats/gost/version.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE version SYSTEM "../../../lib/pkp/dtd/pluginVersion.dtd">
+
+<!--
+  * plugins/citationFormats/GOST/version.xml
+  *
+  * Copyright (c) 2014-2017 Simon Fraser University
+  * Copyright (c) 2003-2017 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Plugin version information.
+  -->
+<version>
+	<application>GOST</application>
+	<type>plugins.citationFormats</type>
+	<release>1.1.0.0</release>
+	<date>2009-07-13</date>
+</version>


### PR DESCRIPTION
This plugin implements the GOST (ГОСТ 7.0.5-2008) citation format, which is widely used in many countries, like Russia, Ukraine, Belarus and others.