### PR TITLE
Fix DOAJ export article URL's when using Acron

### DIFF
--- a/plugins/importexport/doaj/filter/DOAJJsonFilter.inc.php
+++ b/plugins/importexport/doaj/filter/DOAJJsonFilter.inc.php
@@ -120,7 +120,7 @@ class DOAJJsonFilter extends NativeImportExportFilter {
 			// FullText URL
 			$article['bibjson']['link'] = array();
 			$article['bibjson']['link'][] = array(
-				'url' => Request::url(null, 'article', 'view', $pubObject->getId()),
+				'url' => Request::url($context->getPath(), 'article', 'view', $pubObject->getId()),
 				'type' => 'fulltext',
 				'content_type' => 'html'
 			);


### PR DESCRIPTION
Hi @bozana 

While working with this https://github.com/pkp/pkp-lib/issues/2543, I noticed that the journal article url's depend on the journal that triggers the export. The pr fixes that, but does not solve the issue linked.