### PR TITLE
Small corrections in en_US strings

### DIFF
--- a/locale/en_US/default.xml
+++ b/locale/en_US/default.xml
@@ -48,7 +48,7 @@ The editor and author should leave those changes with which they are satisfied. 
 After the text has been reviewed by editor and author, the copy editor will make a final pass over the text accepting the changes in preparation for the layout and galley stage.
 
 
-<strong>2. Harvard Educational Review </strong>
+<strong>2. Harvard Educational Review</strong>
 
 <strong>Instructions for Making Electronic Revisions to the Manuscript</strong>
 

--- a/locale/en_US/editor.xml
+++ b/locale/en_US/editor.xml
@@ -109,7 +109,6 @@
 	<message key="editor.issues.galleyLocaleRequired">An issue galley locale is required.</message>
 	<message key="editor.issues.galleyPublicIdentificationExists">Public issue galley identification already exists.</message>
 	<message key="editor.issues.backToIssueGalleys">Back to issue galleys</message>
-	<message key="editor.issues.viewingGalley">Viewing Issue Galley</message>
 	<message key="editor.issues.confirmDeleteGalley">Are you sure you want to delete this issue galley?</message>
 	<message key="editor.issues.identifiers">Identifiers</message>
 	<message key="editor.navigation.futureIssues">Future Issues</message>


### PR DESCRIPTION
Hi, just to suggest two corrections (whitespace and duplicate line) found during the work with the Swedish translation.