### PR TITLE
Restore automatic selection of the section when submitting an article

### DIFF
--- a/templates/submission/form/step1.tpl
+++ b/templates/submission/form/step1.tpl
@@ -11,7 +11,12 @@
 	 {translate key="author.submit.notAccepting"}
 {else}
 	{capture assign="additionalFormContent2"}
-		{include file="submission/form/section.tpl"}
+		{if $sectionOptions|@count == 2}
+			{* There is only one section; choose it invisibly *}
+			{fbvElement type="hidden" id="sectionId" value=$sectionOptions|@array_keys|@array_pop}
+		{else}
+			{include file="submission/form/section.tpl"}
+		{/if}
 	{/capture}
 
 	{include file="core:submission/form/step1.tpl"}


### PR DESCRIPTION
OJS 2.4 automatically selects the section of a submission if there is a single journal section defined. This pull request replicate this behaviour with OJS 3.
