### PR TITLE
pkp/pkp-lib#2663: Prevent IssueDAO::resequenceCustomIssueOrders() from creating a new arbitrary ordering where none existed

### DIFF
--- a/classes/issue/IssueDAO.inc.php
+++ b/classes/issue/IssueDAO.inc.php
@@ -368,9 +368,7 @@ class IssueDAO extends DAO implements PKPPubIdPluginDAO {
 
 		$this->updateLocaleFields($issue);
 
-		if ($this->customIssueOrderingExists($issue->getJournalId())) {
-			$this->resequenceCustomIssueOrders($issue->getJournalId());
-		}
+		$this->resequenceCustomIssueOrders($issue->getJournalId());
 
 		return $issue->getId();
 	}
@@ -446,9 +444,7 @@ class IssueDAO extends DAO implements PKPPubIdPluginDAO {
 
 		$this->updateLocaleFields($issue);
 
-		if ($this->customIssueOrderingExists($issue->getJournalId())) {
-			$this->resequenceCustomIssueOrders($issue->getJournalId());
-		}
+		$this->resequenceCustomIssueOrders($issue->getJournalId());
 
 		$this->flushCache();
 	}
@@ -671,6 +667,10 @@ class IssueDAO extends DAO implements PKPPubIdPluginDAO {
 	 * @param $journalId int
 	 */
 	function resequenceCustomIssueOrders($journalId) {
+		// If no custom issue ordering already exists, there is nothing to do
+		if (!$this->customIssueOrderingExists($journalId)) {
+			return;
+		}
 		$result = $this->retrieve(
 			'SELECT i.issue_id FROM issues i LEFT JOIN custom_issue_orders o ON (o.issue_id = i.issue_id) WHERE i.journal_id = ? ORDER BY o.seq',
 			(int) $journalId


### PR DESCRIPTION
Resolves pkp/pkp-lib#2663.

An alternate strategy could be to continue to wrap every call to `IssueDAO::resequenceCustomIssueOrders()` with a check, but that seems unnecessary.

Also considered was adding `i.date_published DESC` to the `$this->retrieve()` of 670 so that even if called it would at least order them correctly, but this also seems unnecessary.
