### PR TITLE
Escaping text in confirm on index/admin page

### DIFF
--- a/templates/admin/index.tpl
+++ b/templates/admin/index.tpl
@@ -33,10 +33,10 @@
 
 	<ul>
 		<li><a href="{url op="systemInfo"}">{translate key="admin.systemInformation"}</a></li>
-		<li><a href="{url op="expireSessions"}" onclick="return confirm({translate|json_encode key="admin.confirmExpireSessions"})">{translate key="admin.expireSessions"}</a></li>
+		<li><a href="{url op="expireSessions"}" onclick="return confirm({translate|json_encode|escape key="admin.confirmExpireSessions"})">{translate key="admin.expireSessions"}</a></li>
 		<li><a href="{url op="clearDataCache"}">{translate key="admin.clearDataCache"}</a></li>
-		<li><a href="{url op="clearTemplateCache"}" onclick="return confirm({translate|json_encode key="admin.confirmClearTemplateCache"})">{translate key="admin.clearTemplateCache"}</a></li>
-		<li><a href="{url op="clearScheduledTaskLogFiles"}" onclick="return confirm({translate|json_encode key="admin.scheduledTask.confirmClearLogs"})">{translate key="admin.scheduledTask.clearLogs"}</a></li>
+		<li><a href="{url op="clearTemplateCache"}" onclick="return confirm({translate|json_encode|escape key="admin.confirmClearTemplateCache"})">{translate key="admin.clearTemplateCache"}</a></li>
+		<li><a href="{url op="clearScheduledTaskLogFiles"}" onclick="return confirm({translate|json_encode|escape key="admin.scheduledTask.confirmClearLogs"})">{translate key="admin.scheduledTask.clearLogs"}</a></li>
 		{call_hook name="Templates::Admin::Index::AdminFunctions"}
 	</ul>
 


### PR DESCRIPTION
There is a broken HTML on admin/index page. The confirm text needs to be escaped because there are double quotes returned from json_encode.

![sceen](https://user-images.githubusercontent.com/115426/29005994-9a893b28-7ae7-11e7-983c-1d68638cb70e.png)
