### PR TITLE
pkp/pkp-lib#2570: Escape display of references rather than striping HTML-like tags.

### DIFF
--- a/templates/article/article.tpl
+++ b/templates/article/article.tpl
@@ -103,7 +103,7 @@
 		<br />
 		<div>
 			{iterate from=citationFactory item=citation}
-				<p>{$citation->getRawCitation()|strip_unsafe_html}</p>
+				<p>{$citation->getRawCitation()|escape}</p>
 			{/iterate}
 		</div>
 		<br />


### PR DESCRIPTION
Consider Harvard and ABNT citation styles as examples of why `strip_unsafe_html` should not be used.