### PR TITLE
Exclude paypal plugin vendor dir from XML linting

### DIFF
--- a/tools/xmllint-exclusions.txt
+++ b/tools/xmllint-exclusions.txt
@@ -18,5 +18,6 @@
 ./plugins/importexport/native/tests/functional
 ./plugins/importexport/users/sample.xml
 ./plugins/importexport/pubIds/tests/functional
+./plugins/paymethod/paypal/vendor
 ./lib/pkp/tests
 ./node_modules


### PR DESCRIPTION
Fixes issues with the tests running Guzzle tests and linting Guzzle XML files.