### PR TITLE
Fix the construction of the url in notification emails for editors.

### DIFF
--- a/classes/notification/NotificationManager.inc.php
+++ b/classes/notification/NotificationManager.inc.php
@@ -125,7 +125,7 @@ class NotificationManager extends PKPNotificationManager {
 
 		// Check if user is editor
 		$article =& $articleDao->getArticle($articleId);
-		if($article && Validation::isEditor($article->getJournalId())) {
+		if($article && $roleDao->userHasRole($article->getJournalId(), $userId, ROLE_ID_EDITOR)) {
 			$roles[] = ROLE_ID_EDITOR;
 		}
 


### PR DESCRIPTION
Instead of testing the role of the recipient of the email, it was testing the role of the current user.

This resulted in a bad URL in the emails received by editors : for example `https://.../index.php/JOURNAL/reviewer/submissionReview/123#peerReview` in a notification email for an uploaded review file.