### PR TITLE
Make new issue notifications optional

### DIFF
--- a/classes/controllers/grid/issues/IssueGridHandler.inc.php
+++ b/classes/controllers/grid/issues/IssueGridHandler.inc.php
@@ -499,8 +499,8 @@ class IssueGridHandler extends GridHandler {
 
 		if ($articleSearchIndex) $articleSearchIndex->articleChangesFinished();
 
-		// Send a notification to associated users if journal is publishing content online with OJS
-		if ($journal->getSetting('publishingMode') != PUBLISHING_MODE_NONE) {
+		// Send a notification to associated users if selected and journal is publishing content online with OJS
+		if ($request->getUserVar('sendIssueNotification') && $journal->getSetting('publishingMode') != PUBLISHING_MODE_NONE) {
 			import('classes.notification.NotificationManager');
 			$notificationManager = new NotificationManager();
 			$notificationUsers = array();

--- a/templates/controllers/grid/pubIds/form/assignPublicIdentifiersForm.tpl
+++ b/templates/controllers/grid/pubIds/form/assignPublicIdentifiersForm.tpl
@@ -23,7 +23,7 @@
 		<input type="hidden" name="confirmed" value=true />
 		{assign var=hideCancel value=false}
 		{fbvFormSection for="sendIssueNotification" list="true"}
-			{fbvElement type="checkbox" name="sendIssueNotification" id="sendIssueNotification" checked=true label="notification.type.issuePublished" inline=true}
+			{fbvElement type="checkbox" name="sendIssueNotification" id="sendIssueNotification" checked=true label="notification.sendNotificationConfirmation" inline=true}
 		{/fbvFormSection}		
 {elseif $pubObject instanceof Article}
 	<form class="pkp_form" id="assignPublicIdentifierForm" method="post" action="{url router=$smarty.const.ROUTE_COMPONENT component="tab.issueEntry.IssueEntryTabHandler" op="assignPubIds" escape=false}">

--- a/templates/controllers/grid/pubIds/form/assignPublicIdentifiersForm.tpl
+++ b/templates/controllers/grid/pubIds/form/assignPublicIdentifiersForm.tpl
@@ -22,6 +22,7 @@
 		<input type="hidden" name="issueId" value="{$pubObject->getId()|escape}" />
 		<input type="hidden" name="confirmed" value=true />
 		{assign var=hideCancel value=false}
+		<input type="checkbox" name="sendIssueNotification" id="sendIssueNotification" checked="checked" /> {translate key="notification.type.issuePublished"}		
 {elseif $pubObject instanceof Article}
 	<form class="pkp_form" id="assignPublicIdentifierForm" method="post" action="{url router=$smarty.const.ROUTE_COMPONENT component="tab.issueEntry.IssueEntryTabHandler" op="assignPubIds" escape=false}">
 		<input type="hidden" name="submissionId" value="{$pubObject->getId()|escape}" />

--- a/templates/controllers/grid/pubIds/form/assignPublicIdentifiersForm.tpl
+++ b/templates/controllers/grid/pubIds/form/assignPublicIdentifiersForm.tpl
@@ -22,7 +22,9 @@
 		<input type="hidden" name="issueId" value="{$pubObject->getId()|escape}" />
 		<input type="hidden" name="confirmed" value=true />
 		{assign var=hideCancel value=false}
-		<input type="checkbox" name="sendIssueNotification" id="sendIssueNotification" checked="checked" /> {translate key="notification.type.issuePublished"}		
+		{fbvFormSection for="sendIssueNotification" list="true"}
+			{fbvElement type="checkbox" name="sendIssueNotification" id="sendIssueNotification" checked=true label="notification.type.issuePublished" inline=true}
+		{/fbvFormSection}		
 {elseif $pubObject instanceof Article}
 	<form class="pkp_form" id="assignPublicIdentifierForm" method="post" action="{url router=$smarty.const.ROUTE_COMPONENT component="tab.issueEntry.IssueEntryTabHandler" op="assignPubIds" escape=false}">
 		<input type="hidden" name="submissionId" value="{$pubObject->getId()|escape}" />


### PR DESCRIPTION
Fix second issue in https://github.com/pkp/pkp-lib/issues/2561

Using the assignPublicIdentifiersForm.tpl is maybe a bit hacky, but it is used there even if no pubid's are being assigned.