### PR TITLE
Install node dependencies in package build script

### DIFF
--- a/tools/buildpkg.sh
+++ b/tools/buildpkg.sh
@@ -98,6 +98,7 @@ lib/pkp/tools/travis						\
 lib/pkp/lib/swordappv2/.git					\
 lib/pkp/lib/swordappv2/.git					\
 lib/pkp/lib/swordappv2/test					\
+node_modules      \
 .babelrc          \
 .editorconfig     \
 .eslintignore     \
@@ -133,7 +134,11 @@ composer.phar install
 cd ../../..
 echo "Done"
 
-echo -n "Run webpack build process"
+echo -n "Installing node dependencies... "
+npm install
+echo "Done"
+
+echo -n "Running webpack build process... "
 npm run build
 echo "Done"
 


### PR DESCRIPTION
@asmecher This should fix the `buildpkg.sh`. Forgot to run `npm install` before building the JS. I've also excluded the `node_modules` directory from the package files.

When I compile, I get an error that `composer.phar` is not found. I usually just run `composer`. Any idea how I can get it so the `composer.phar` file itself can be run globally?