### PR TITLE
pkp/pkp-lib#2954 Possible error on line 113 of UserAction.inc.php

### DIFF
--- a/classes/user/UserAction.inc.php
+++ b/classes/user/UserAction.inc.php
@@ -110,7 +110,7 @@ class UserAction {
 		// Transfer completed payments.
 		$paymentDao = DAORegistry::getDAO('OJSCompletedPaymentDAO');
 		$paymentFactory = $paymentDao->getByUserId($oldUserId);
-		while ($payment = $paymentFactory->next()) {
+		while ($payment = next($paymentFactory)) {
 			$payment->setUserId($newUserId);
 			$paymentDao->updateObject($payment);
 		}


### PR DESCRIPTION
While attempting to merge two users, an error has occured because it tries to
invoke the "next()" method on an array. In this commit we suggest a possible fix
by invoking the next php array function, passing the array as argument.