### PR TITLE
pkp/pkp-lib:3049  Backport pkp_page and pkp_op body classes from 3.x to 2.x template header

### DIFF
--- a/templates/article/header.tpl
+++ b/templates/article/header.tpl
@@ -71,7 +71,7 @@
 
 	{$additionalHeadData}
 </head>
-<body id="pkp-{$pageTitle|replace:'.':'-'}">
+<body id="pkp-{$pageTitle|replace:'.':'-'}" class="pkp_page_{$requestedPage|escape|default:"index"} pkp_op_{$requestedOp|escape|default:"index"}">
 
 <div id="container">
 


### PR DESCRIPTION
Resolves pkp/pkp-lib:3049 for OJS 2.4 dev.  Note catchup of drift with shared library commits.