### PR TITLE
pkp/pkp-lib#1118, pkp/pkp-lib#3054: Catchup update on some String:: to PKPString:: test outliers

### DIFF
--- a/tests/functional/plugins/importexport/medra/FunctionalMedraExportTestCase.php
+++ b/tests/functional/plugins/importexport/medra/FunctionalMedraExportTestCase.php
@@ -404,13 +404,13 @@ class FunctionalMedraExportTest extends FunctionalDoiExportTest {
 	 */
 	protected function cleanXml($xml) {
 		// Fix URLs.
-		$xml = String::regexp_replace('#http://[^\s]+/index.php/(test|index)#', 'http://example.com/index.php/test', $xml);
+		$xml = PKPString::regexp_replace('#http://[^\s]+/index.php/(test|index)#', 'http://example.com/index.php/test', $xml);
 
 		// Fix sent date.
-		$xml = String::regexp_replace('/<SentDate>[0-9]{12}<\/SentDate>/', '<SentDate>201111082218</SentDate>', $xml);
+		$xml = PKPString::regexp_replace('/<SentDate>[0-9]{12}<\/SentDate>/', '<SentDate>201111082218</SentDate>', $xml);
 
 		// Fix version.
-		$xml = String::regexp_replace('/(<MessageNote>[^<]*)([0-9]\.){4}(<\/MessageNote>)/', '\1x.x.x.x.\3', $xml);
+		$xml = PKPString::regexp_replace('/(<MessageNote>[^<]*)([0-9]\.){4}(<\/MessageNote>)/', '\1x.x.x.x.\3', $xml);
 
 		return parent::cleanXml($xml);
 	}

--- a/tests/functional/plugins/pubIds/FunctionalDoiPubIdPluginTestCase.php
+++ b/tests/functional/plugins/pubIds/FunctionalDoiPubIdPluginTestCase.php
@@ -899,7 +899,7 @@ class FunctionalDOIPubIdPluginTest extends WebTestCase {
 				}
 				foreach (array('DC-meta', 'Google-meta') as $doiMetaAttribute) {
 					if (isset($this->pages[$objectType][$doiMetaAttribute])) {
-						$doiMetaElement = String::regexp_replace(
+						$doiMetaElement = PKPString::regexp_replace(
 							'/@[^@]+$/', '',
 							$this->pages[$objectType][$doiMetaAttribute]
 						);


### PR DESCRIPTION
Resolves pkp/pkp-lib#3054 for OJS 2.4.x.