### PR TITLE
Fix oai_marc template for schema compliance in dev-2_4

### DIFF
--- a/plugins/oaiMetadataFormats/marc/record.tpl
+++ b/plugins/oaiMetadataFormats/marc/record.tpl
@@ -14,25 +14,25 @@
 		<fixfield id="008">"{$article->getDatePublished()|strtotime|date_format:"%y%m%d %Y"}                        eng  "</fixfield>
 	{/if}
 	{if $journal->getSetting('onlineIssn')}
-		<varfield tag="022" ind1="#" ind2="#">
+		<varfield id="022" i1="#" i2="#">
 			<subfield label="$a">{$journal->getSetting('onlineIssn')|escape}</subfield>
 		</varfield>
 	{/if}
 	{if $journal->getSetting('printIssn')}
-		<varfield tag="022" ind1="#" ind2="#">
+		<varfield id="022" i1="#" i2="#">
 			<subfield label="$a">{$journal->getSetting('printIssn')|escape}</subfield>
 		</varfield>
 	{/if}
-	<varfield tag="042" ind1=" " ind2=" ">
+	<varfield id="042" i1=" " i2=" ">
 		<subfield label="a">dc</subfield>
 	</varfield>
-	<varfield tag="245" ind1="0" ind2="0">
+	<varfield id="245" i1="0" i2="0">
 		<subfield label="a">{$article->getTitle($journal->getPrimaryLocale())|escape}</subfield>
 	</varfield>
 
 	{assign var=authors value=$article->getAuthors()}
 	{foreach from=$authors item=author}
-		<varfield tag="{if $authors|@count==1}100{else}720{/if}" ind1="1" ind2=" ">
+		<varfield id="{if $authors|@count==1}100{else}720{/if}" i1="1" i2=" ">
 			<subfield label="a">{$author->getFullName(true)|escape}</subfield>
 			{assign var=affiliation value=$author->getAffiliation($journal->getPrimaryLocale())}
 			{if $affiliation}<subfield label="u">{$affiliation|escape}</subfield>{/if}
@@ -40,10 +40,10 @@
 			{if $author->getData('orcid')}<subfield label="0">{$author->getData('orcid')|escape}</subfield>{/if}
 		</varfield>
 	{/foreach}
-	{if $subject}<varfield tag="653" ind1=" " ind2=" ">
+	{if $subject}<varfield id="653" i1=" " i2=" ">
 		<subfield label="a">{$subject|escape}</subfield>
 	</varfield>{/if}
-	{if $abstract}<varfield tag="520" ind1=" " ind2=" ">
+	{if $abstract}<varfield id="520" i1=" " i2=" ">
 		<subfield label="a">{$abstract|escape}</subfield>
 	</varfield>{/if}
 
@@ -51,58 +51,58 @@
 	{if $journal->getSetting('publisherInstitution')}
 		{assign var=publisher value=$journal->getSetting('publisherInstitution')}
 	{/if}
-	<varfield tag="260" ind1=" " ind2=" ">
+	<varfield id="260" i1=" " i2=" ">
 		<subfield label="b">{$publisher|escape}</subfield>
 	</varfield>
-	<dataField tag="260" ind1=" " ind2=" ">
+	<dataField id="260" i1=" " i2=" ">
 		<subfield label="c">{$issue->getDatePublished()}</subfield>
 	</dataField>
 
 	{assign var=identifyType value=$section->getIdentifyType($journal->getPrimaryLocale())}
-	{if $identifyType}<varfield tag="655" ind1=" " ind2="7">
+	{if $identifyType}<varfield id="655" i1=" " i2="7">
 		<subfield label="a">{$identifyType|escape}</subfield>
 	</varfield>{/if}
 
 	{foreach from=$article->getGalleys() item=galley}
-		<varfield tag="856" ind1=" " ind2=" ">
+		<varfield id="856" i1=" " i2=" ">
 			<subfield label="q">{$galley->getFileType()|escape}</subfield>
 		</varfield>
 	{/foreach}
-	<varfield tag="856" ind1="4" ind2="0">
+	<varfield id="856" i1="4" i2="0">
 		<subfield label="u">{url journal=$journal->getPath() page="article" op="view" path=$article->getBestArticleId()|escape}</subfield>
 	</varfield>
 
-	<varfield tag="786" ind1="0" ind2=" ">
+	<varfield id="786" i1="0" i2=" ">
 		<subfield label="n">{$journal->getTitle($journal->getPrimaryLocale())|escape}; {$issue->getIssueIdentification()|escape}</subfield>
 	</varfield>
 
-	<varfield tag="546" ind1=" " ind2=" ">
+	<varfield id="546" i1=" " i2=" ">
 		<subfield label="a">{$language}</subfield>
 	</varfield>
 
 	{foreach from=$article->getSuppFiles() item=suppFile}
-		<varfield tag="787" ind1="0" ind2=" ">
+		<varfield id="787" i1="0" i2=" ">
 			<subfield label="n">{url journal=$journal->getPath() page="article" op="download" path=$article->getId()|to_array:$suppFile->getFileId()|escape}</subfield>
 		</varfield>
 	{/foreach}
 
 	{if $article->getCoverageGeo($journal->getPrimaryLocale())}
-		<varfield tag="500" ind1=" " ind2=" ">
+		<varfield id="500" i1=" " i2=" ">
 			<subfield label="a">{$article->getCoverageGeo($journal->getPrimaryLocale())|escape}</subfield>
 		</varfield>
 	{/if}
 	{if $article->getCoverageChron($journal->getPrimaryLocale())}
-		<varfield tag="500" ind1=" " ind2=" ">
+		<varfield id="500" i1=" " i2=" ">
 			<subfield label="a">{$article->getCoverageChron($journal->getPrimaryLocale())|escape}</subfield>
 		</varfield>
 	{/if}
 	{if $article->getCoverageSample($journal->getPrimaryLocale())}
-		<varfield tag="500" ind1=" " ind2=" ">
+		<varfield id="500" i1=" " i2=" ">
 			<subfield label="a">{$article->getCoverageSample($journal->getPrimaryLocale())|escape}</subfield>
 		</varfield>
 	{/if}
 
-	<varfield tag="540" ind1=" " ind2=" ">
+	<varfield id="540" i1=" " i2=" ">
 		<subfield label="a">{translate key="submission.copyrightStatement" copyrightYear=$article->getCopyrightYear() copyrightHolder=$article->getCopyrightHolder($journal->getPrimaryLocale())|escape}</subfield>
 	</varfield>
 </oai_marc>

--- a/plugins/oaiMetadataFormats/marc/record.tpl
+++ b/plugins/oaiMetadataFormats/marc/record.tpl
@@ -54,9 +54,9 @@
 	<varfield id="260" i1=" " i2=" ">
 		<subfield label="b">{$publisher|escape}</subfield>
 	</varfield>
-	<dataField id="260" i1=" " i2=" ">
+	<varfield id="260" i1=" " i2=" ">
 		<subfield label="c">{$issue->getDatePublished()}</subfield>
-	</dataField>
+	</varfield>
 
 	{assign var=identifyType value=$section->getIdentifyType($journal->getPrimaryLocale())}
 	{if $identifyType}<varfield id="655" i1=" " i2="7">


### PR DESCRIPTION
Replace instances of marcxml tags/attributes with oai_marc tags/attributes.  (ojs-dev-2_4)

See: pkp/pkp-lib#3062