### PR TITLE
MathJax plugin

### DIFF
--- a/plugins/generic/mathjax/MathJaxPlugin.inc.php
+++ b/plugins/generic/mathjax/MathJaxPlugin.inc.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @file plugins/generic/mathjax/MathJaxPlugin.inc.php
+ *
+ * Copyright (c) 2017 Vasyl Ostrovskyi
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class MathJaxPlugin
+ * @ingroup plugins_generic_mathjax
+ *
+ * @brief Plugin to allow MathJax scripts to be added to OCS
+ */
+
+// $Id$
+
+
+import('lib.pkp.classes.plugins.GenericPlugin');
+
+class MathJaxPlugin extends GenericPlugin {
+	/**
+	 * Register the plugin, if enabled; note that this plugin
+	 * @param $category string
+	 * @param $path string
+	 * @return boolean
+	 */
+	function register($category, $path) {
+		if (parent::register($category, $path)) {
+			if ($this->getEnabled()) {
+				HookRegistry::register('TemplateManager::display', array(&$this, 'insertMJ'));
+			}
+			return true;
+		}
+		return false;
+	}
+
+
+//	function zatyk($hookName,$args){
+//		return false;
+//	}
+
+	/**
+	 * Hook callback function for TemplateManager::display
+	 * @param $hookName string
+	 * @param $args array
+	 * @return boolean
+	 */
+	function insertMJ($hookName, $args) {
+		$templateManager =& $args[0];
+		$MathJaxScript="</script>\n";
+		$MathJaxScript .= "<script type=\"text/x-mathjax-config\">\n MathJax.Hub.Config({\n   tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]},\n   processEscapes: true\n }); \n</script>\n";
+		$MathJaxScript .= '<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">' ."\n";
+		$templateManager->addJavaScript('mathjax', $MathJaxScript, 
+			array(
+				'inline' => true,
+				'contexts' => array('frontend', 'backend')
+			)
+		);
+		return false;
+	}
+
+	/**
+	 * Get the name of the settings file to be installed on new context
+	 * creation.
+	 * @return string
+	 */
+//	function getContextSpecificPluginSettingsFile() {
+//		return $this->getPluginPath() . '/settings.xml';
+//	}
+
+	/**
+	 * Get the display name of this plugin
+	 * @return string
+	 */
+	function getDisplayName() {
+		return __('plugins.generic.mathjax.name');
+	}
+
+	/**
+	 * Get the description of this plugin
+	 * @return string
+	 */
+	function getDescription() {
+		return __('plugins.generic.mathjax.description');
+	}
+}
+?>

--- a/plugins/generic/mathjax/README
+++ b/plugins/generic/mathjax/README
@@ -1,0 +1,12 @@
+================================
+=== OCS mathjax Plugin
+=== Author: Vasyl Ostrovskyi (vo @ imath.kiev.ua)
+================================
+
+About
+-----
+This plugin loads the mathjax javascript LaTeX parser into all OCS pages.
+
+License
+-------
+This plugin is licensed under the GNU General Public License v2. See the file COPYING for the complete terms of this license.

--- a/plugins/generic/mathjax/index.php
+++ b/plugins/generic/mathjax/index.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @defgroup plugins_generic_mathjax
+ */
+ 
+/**
+ * @file plugins/generic/mathjax/index.php
+ *
+ * Copyright (c) 2017 Vasyl Ostrovskyi
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @ingroup plugins_generic_mathjax
+ * @brief Wrapper for mathjax plugin.
+ *
+ */
+
+// $Id$
+
+
+require_once('MathJaxPlugin.inc.php');
+
+return new MathJaxPlugin();
+
+?> 

--- a/plugins/generic/mathjax/locale/en_US/locale.xml
+++ b/plugins/generic/mathjax/locale/en_US/locale.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * locale.xml
+  *
+  * Copyright (c) 2017 Vasyl Ostrovskyi
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Localization strings for the en_US (U.S. English) locale.
+  *
+  * $Id$
+  -->
+ 
+<locale name="en_US" full_name="U.S. English">
+	<message key="plugins.generic.mathjax.name">MathJax Plugin</message>
+	<message key="plugins.generic.mathjax.description"><![CDATA[This plugin enables javascript LaTeX math rendering of OJS content using the <a href="http://www.mathjax.org" target="_new">MathJax</a> parser.]]></message>
+	<message key="plugins.generic.mathjax.disabled">The MathJax Plugin has been disabled.</message>
+	<message key="plugins.generic.mathjax.enabled">The MathJax Plugin has been enabled.</message>
+</locale>

--- a/plugins/generic/mathjax/locale/uk_UA/locale.xml
+++ b/plugins/generic/mathjax/locale/uk_UA/locale.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
+
+<!--
+  * locale.xml
+  *
+  * Copyright (c) 2017 Vasyl Ostrovskyi
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Localization strings for the en_US (U.S. English) locale.
+  *
+  * $Id$
+  -->
+ 
+<locale name="en_US" full_name="U.S. English">
+	<message key="plugins.generic.mathjax.name">Плагін MathJax</message>
+	<message key="plugins.generic.mathjax.description"><![CDATA[Цей плагін вмикає інтерпретацію математичних формул формату LaTeX з використанням <a href="http://www.mathjax.org" target="_new">MathJax</a>.]]></message>
+	<message key="plugins.generic.mathjax.disabled">Плагін MathJax вимкнено.</message>
+	<message key="plugins.generic.mathjax.enabled">Плагін MathJax увімкнено.</message>
+</locale>

--- a/plugins/generic/mathjax/settings.xml
+++ b/plugins/generic/mathjax/settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plugin_settings SYSTEM "../../../lib/pkp/dtd/pluginSettings.dtd">
+
+<!--
+  * plugins/generic/pdfJsViewer/settings.xml
+  *
+  * Copyright (c) 2014-2017 Simon Fraser University
+  * Copyright (c) 2003-2017 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Default plugin settings.
+  *
+  -->
+
+<plugin_settings>
+	<setting type="bool">
+		<name>enabled</name>
+		<value>true</value>
+	</setting>
+</plugin_settings>
+

--- a/plugins/generic/mathjax/version.xml
+++ b/plugins/generic/mathjax/version.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE version SYSTEM "../../../lib/pkp/dtd/pluginVersion.dtd">
+
+<!--
+  * version.xml
+  *
+  * Copyright (c) 2017 Vasyl Ostrovskyi
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * OCS version information.
+  *
+  * $Id$
+  -->
+<version>
+	<application>mathjax</application>
+	<type>plugins.generic</type>
+	<release>1.0.0.1</release>
+	<date>2017-11-26</date>
+	<lazy-load>1</lazy-load>
+	<class>MathJaxPlugin</class>
+<</version>

--- a/plugins/generic/mathjax/version.xml
+++ b/plugins/generic/mathjax/version.xml
@@ -18,4 +18,4 @@
 	<date>2017-11-26</date>
 	<lazy-load>1</lazy-load>
 	<class>MathJaxPlugin</class>
-<</version>
+</version>


### PR DESCRIPTION
Trivial MathJax plugin renders math in $LaTeX$ format. Just insers a few lines of JS into header.