### PR TITLE
pkp/pkp-lib#3181 Add id attribute to TOC sections for styling

### DIFF
--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -94,8 +94,8 @@
 
 	{* Articles *}
 	<div class="sections">
-	{foreach name=sections from=$publishedArticles item=section}
-		<div class="section">
+	{foreach name=sections key=currSectionId from=$publishedArticles item=section}
+		<div class="section" id="sectionId_{$currSectionId}">
 		{if $section.articles}
 			{if $section.title}
 				<h2>


### PR DESCRIPTION
Hello there,

as mentioned https://forum.pkp.sfu.ca/t/add-section-id-to-toc/36173 it would be a good feature to add section ids to the issue tocs, so people might be able to style every section in a different way and it might be a foundation for anchor links.

Kind regards
Daniela