### PR TITLE
Instead of issue title, show issue identification in statistics output

### DIFF
--- a/pages/management/ToolsHandler.inc.php
+++ b/pages/management/ToolsHandler.inc.php
@@ -45,7 +45,7 @@ class ToolsHandler extends PKPToolsHandler {
 				$issueDao = DAORegistry::getDAO('IssueDAO');
 				$issue = $issueDao->getById($assocId);
 				if ($issue) {
-					$objectTitle = $issue->getLocalizedTitle();
+					$objectTitle = $issue->getIssueIdentification();
 				}
 				break;
 		}


### PR DESCRIPTION
Hi @asmecher 

At the moment if you output statistics that have issue information, the report generator will either show the issue title or just the id. This does not tell a lot for the editors.

Instead, getIssueIdentification should be used.