### PR TITLE
Fix delayedOpenAccessDuration settings pull down

### DIFF
--- a/templates/payments/subscriptionPolicyForm.tpl
+++ b/templates/payments/subscriptionPolicyForm.tpl
@@ -70,7 +70,7 @@
 	{fbvFormSection label="manager.subscriptionPolicies.openAccessOptions" list=true}
 		<p>{translate key="manager.subscriptionPolicies.openAccessOptionsDescription"}</p>
 
-		{fbvElement type="select" id="delayedOpenAccessDuration" name="delayedOpenAccessDuration" value=$delayedOpenAccessDuration selected=$validDuration label="manager.subscriptionPolicies.delayedOpenAccessDescription" size=$fbvStyles.size.MEDIUM translate=false}
+		{fbvElement type="select" id="delayedOpenAccessDuration" name="delayedOpenAccessDuration" value=$delayedOpenAccessDuration from=$validDuration label="manager.subscriptionPolicies.delayedOpenAccessDescription" size=$fbvStyles.size.MEDIUM translate=false}
 		{fbvElement type="checkbox" id="enableOpenAccessNotification" name="enableOpenAccessNotification" value=1 checked=$enableOpenAccessNotification label="manager.subscriptionPolicies.openAccessNotificationDescription" disabled=$scheduledTasksEnabled|compare:0}
 
 		<p>{translate key="manager.subscriptionPolicies.delayedOpenAccessPolicyDescription"}</p>

--- a/templates/payments/subscriptionPolicyForm.tpl
+++ b/templates/payments/subscriptionPolicyForm.tpl
@@ -70,7 +70,7 @@
 	{fbvFormSection label="manager.subscriptionPolicies.openAccessOptions" list=true}
 		<p>{translate key="manager.subscriptionPolicies.openAccessOptionsDescription"}</p>
 
-		{fbvElement type="select" id="delayedOpenAccessDuration" name="delayedOpenAccessDuration" value=$delayedOpenAccessDuration from=$validDuration label="manager.subscriptionPolicies.delayedOpenAccessDescription" size=$fbvStyles.size.MEDIUM translate=false}
+		{fbvElement type="select" id="delayedOpenAccessDuration" name="delayedOpenAccessDuration" selected=$delayedOpenAccessDuration from=$validDuration label="manager.subscriptionPolicies.delayedOpenAccessDescription" size=$fbvStyles.size.MEDIUM translate=false}
 		{fbvElement type="checkbox" id="enableOpenAccessNotification" name="enableOpenAccessNotification" value=1 checked=$enableOpenAccessNotification label="manager.subscriptionPolicies.openAccessNotificationDescription" disabled=$scheduledTasksEnabled|compare:0}
 
 		<p>{translate key="manager.subscriptionPolicies.delayedOpenAccessPolicyDescription"}</p>


### PR DESCRIPTION
@asmecher, the pull down menu for setting the embargo length for a journal was broken due to a small typo. https://forum.pkp.sfu.ca/t/some-problems-with-subscriptions-after-upgrade-to-3-1-0-1/37347
