### PR TITLE
pkp/pkp-lib#2291: Add pageTitleTranslated to site index to display site title instead of default key

### DIFF
--- a/pages/index/IndexHandler.inc.php
+++ b/pages/index/IndexHandler.inc.php
@@ -81,6 +81,7 @@ class IndexHandler extends Handler {
 				$request->redirect($journal->getPath());
 			}
 
+			$templateMgr->assign('pageTitleTranslated', $site->getLocalizedPageHeaderTitle());
 			$templateMgr->assign('about', $site->getLocalizedAbout());
 			$templateMgr->assign('journalFilesPath', $request->getBaseUrl() . '/' . Config::getVar('files', 'public_files_dir') . '/journals/');
 


### PR DESCRIPTION
Resolves pkp/pkp-lib#2291