### PR TITLE
pkp/pkp-lib#2683: remove password value from user block

### DIFF
--- a/plugins/blocks/user/block.tpl
+++ b/plugins/blocks/user/block.tpl
@@ -48,7 +48,7 @@
 						</tr>
 						<tr>
 							<td><label for="sidebar-password">{translate key="user.password"}</label></td>
-							<td><input type="password" id="sidebar-password" name="password" value="{$password|escape}" size="12" class="textField" /></td>
+							<td><input type="password" id="sidebar-password" name="password" value="" size="12" class="textField" /></td>
 						</tr>
 						<tr>
 							<td colspan="2"><input type="checkbox" id="remember" name="remember" value="1" /> <label for="remember">{translate key="plugins.block.user.rememberMe"}</label></td>


### PR DESCRIPTION
Resolves pkp/pkp-lib#2683.

Like the username, the password field should never be pre-populated in the block.