### PR TITLE
changing the accept title from skipReview to accept

### DIFF
--- a/classes/workflow/EditorDecisionActionsManager.inc.php
+++ b/classes/workflow/EditorDecisionActionsManager.inc.php
@@ -135,7 +135,7 @@ class EditorDecisionActionsManager {
 			SUBMISSION_EDITOR_DECISION_ACCEPT => array(
 				'name' => 'accept',
 				'operation' => 'promote',
-				'title' => 'editor.submission.decision.skipReview',
+				'title' => 'editor.submission.decision.accept',
 				'toStage' => 'submission.copyediting',
 			),
 			SUBMISSION_EDITOR_DECISION_INITIAL_DECLINE => array(


### PR DESCRIPTION
Dear all, I suggest to not use editor.submission.decision.skipReview for submission stage, because it will be recorded as (Accept and Skip Review) in editorial history (even with the review process has been conducted). I did a quick fix but if there is a more elegant solution it will be better I think.