### PR TITLE
pkp/pkp-lib#3425: Fix ReCAPTCHA, correct magic numbers

### DIFF
--- a/classes/comment/form/CommentForm.inc.php
+++ b/classes/comment/form/CommentForm.inc.php
@@ -71,13 +71,14 @@ class CommentForm extends Form {
 		$this->addCheck(new FormValidator($this, 'title', 'required', 'comments.titleRequired'));
 		if ($this->captchaEnabled) {
 			if ($this->reCaptchaEnabled) {
+				import('lib.pkp.lib.recaptcha.recaptchalib');
 				if (Config::getVar('captcha', 'recaptcha_enforce_hostname')) {
 					$host = Request::getServerHost();
 				} else { 
 					$host = '';
 				}
-				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', 0));
-				$this->addCheck(new FormValidatorReCaptcha($this, 'recaptcha_challenge_field', ($reCaptchaVersion === 1 ? 'recaptcha_response_field' : 'g-recaptcha-response'), Request::getRemoteAddr(), 'common.captchaField.badCaptcha', $host));
+				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', RECAPTCHA_VERSION_LEGACY));
+				$this->addCheck(new FormValidatorReCaptcha($this, 'recaptcha_challenge_field', ($reCaptchaVersion === RECAPTCHA_VERSION_LEGACY ? 'recaptcha_response_field' : 'g-recaptcha-response'), Request::getRemoteAddr(), 'common.captchaField.badCaptcha', $host));
 			} else {
 				$this->addCheck(new FormValidatorCaptcha($this, 'captcha', 'captchaId', 'common.captchaField.badCaptcha'));
 			}
@@ -133,7 +134,7 @@ class CommentForm extends Form {
 			$templateMgr->assign('reCaptchaEnabled', $this->reCaptchaEnabled);
 			if ($this->reCaptchaEnabled) {
 				import('lib.pkp.lib.recaptcha.recaptchalib');
-				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', 0));
+				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', RECAPTCHA_VERSION_LEGACY));
 				$publicKey = Config::getVar('captcha', 'recaptcha_public_key');
 				$useSSL = Config::getVar('security', 'force_ssl')||Request::getProtocol()=='https'?true:false;
 				$reCaptchaHtml = recaptcha_versioned_get_html($reCaptchaVersion, $publicKey, null, $useSSL);
@@ -171,8 +172,9 @@ class CommentForm extends Form {
 		);
 		if ($this->captchaEnabled) {
 			if ($this->reCaptchaEnabled) {
-				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', 0));
-				if ($reCaptchaVersion === 0) {
+				import('lib.pkp.lib.recaptcha.recaptchalib');
+				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', RECAPTCHA_VERSION_LEGACY));
+				if ($reCaptchaVersion === RECAPTCHA_VERSION_LEGACY) {
 					$userVars[] = 'recaptcha_challenge_field';
 					$userVars[] = 'recaptcha_response_field';
 				} else {

--- a/classes/user/form/RegistrationForm.inc.php
+++ b/classes/user/form/RegistrationForm.inc.php
@@ -80,13 +80,14 @@ class RegistrationForm extends Form {
 				$this->addCheck(new FormValidatorCustom($this, 'email', 'required', 'user.register.form.emailExists', array(DAORegistry::getDAO('UserDAO'), 'userExistsByEmail'), array(), true));
 				if ($this->captchaEnabled) {
 					if ($this->reCaptchaEnabled) {
+						import('lib.pkp.lib.recaptcha.recaptchalib');
 						if (Config::getVar('captcha', 'recaptcha_enforce_hostname')) {
 							$host = Request::getServerHost();
 						} else { 
 							$host = '';
 						}
-						$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', 0));
-						$this->addCheck(new FormValidatorReCaptcha($this, 'recaptcha_challenge_field', ($reCaptchaVersion === 1 ? 'recaptcha_response_field' : 'g-recaptcha-response'), Request::getRemoteAddr(), 'common.captchaField.badCaptcha', $host));
+						$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', RECAPTCHA_VERSION_LEGACY));
+						$this->addCheck(new FormValidatorReCaptcha($this, 'recaptcha_challenge_field', ($reCaptchaVersion === RECAPTCHA_VERSION_LEGACY ? 'recaptcha_response_field' : 'g-recaptcha-response'), Request::getRemoteAddr(), 'common.captchaField.badCaptcha', $host));
 					} else {
 						$this->addCheck(new FormValidatorCaptcha($this, 'captcha', 'captchaId', 'common.captchaField.badCaptcha'));
 					}
@@ -116,7 +117,7 @@ class RegistrationForm extends Form {
 			$templateMgr->assign('reCaptchaEnabled', $this->reCaptchaEnabled);
 			if ($this->reCaptchaEnabled) {
 				import('lib.pkp.lib.recaptcha.recaptchalib');
-				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', 0));
+				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', RECAPTCHA_VERSION_LEGACY));
 				$publicKey = Config::getVar('captcha', 'recaptcha_public_key');
 				$useSSL = Config::getVar('security', 'force_ssl')||Request::getProtocol()=='https'?true:false;
 				$reCaptchaHtml = recaptcha_versioned_get_html($reCaptchaVersion, $publicKey, null, $useSSL);
@@ -188,8 +189,9 @@ class RegistrationForm extends Form {
 		);
 		if ($this->captchaEnabled) {
 			if ($this->reCaptchaEnabled) {
-				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', 0));
-				if ($reCaptchaVersion === 0) {
+				import('lib.pkp.lib.recaptcha.recaptchalib');
+				$reCaptchaVersion = intval(Config::getVar('captcha', 'recaptcha_version', RECAPTCHA_VERSION_LEGACY));
+				if ($reCaptchaVersion === RECAPTCHA_VERSION_LEGACY) {
 					$userVars[] = 'recaptcha_challenge_field';
 					$userVars[] = 'recaptcha_response_field';
 				} else {


### PR DESCRIPTION
Cleans up usage of magic numbers for ReCAPTCHA, including the incorrect use of a ReCAPTCHA version of "1".

Resolves pkp/pkp-lib#3425
