### PR TITLE
[OJS] include journal info on index journal page

### DIFF
--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -27,7 +27,11 @@
 			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" alt="{$homepageImageAltText|escape}">
 		</div>
 	{/if}
-
+	{if $journalDescription}
+		<div class="journal-description">
+			{$journalDescription}
+		</div>
+	{/if}
 	{* Announcements *}
 	{if $numAnnouncementsHomepage && $announcements|@count}
 		<div class="cmp_announcements highlight_first">


### PR DESCRIPTION
the journal page only allows to show additional content at the end of the page, after showing the contents, I think it is good to show some information before displaying the contents, such as a brief introduction to the journal. (I know this change can be added to a custom template, but for the importance, I propose it for the default template, I think is good for SEO too like brief site description on index page)