### PR TITLE
Removing display:block on links in journal description (index) in default theme

### DIFF
--- a/plugins/themes/default/styles/pages/indexSite.less
+++ b/plugins/themes/default/styles/pages/indexSite.less
@@ -25,7 +25,6 @@
 			margin: @triple 0;
 		}
 
-		a,
 		img {
 			display: block;
 			max-height: 20em;


### PR DESCRIPTION
Default theme did not consider links in journal description, but introduced a line break after the link. I think that this is an easy fix, but please correct me if I'm wrong.