### PR TITLE
Move self archiving settings under distribution->permissions

### DIFF
--- a/controllers/tab/settings/permissions/form/OJSPermissionSettingsForm.inc.php
+++ b/controllers/tab/settings/permissions/form/OJSPermissionSettingsForm.inc.php
@@ -23,11 +23,33 @@ class OJSPermissionSettingsForm extends PermissionSettingsForm {
 	function __construct($wizardMode = false) {
 		parent::__construct(
 			array(
+				'enableAuthorSelfArchive' => 'bool',
+				'authorSelfArchivePolicy' => 'string',				
 				'copyrightYearBasis' => 'string',
 			),
 			$wizardMode
 		);
 	}
+
+	//
+	// Implement template methods from Form.
+	//
+	/**
+	 * @copydoc Form::getLocaleFieldNames
+	 */
+	function getLocaleFieldNames() {
+		return array_merge(parent::getLocaleFieldNames(), array('authorSelfArchivePolicy'));
+	}
+
+	/**
+	 * @copydoc ContextSettingsForm::fetch
+	 */
+	function fetch($request, $params = null) {
+		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr->assign('scheduledTasksEnabled', (boolean) Config::getVar('general', 'scheduled_tasks'));
+		return parent::fetch($request, $params);
+	}
+
 }
 
 ?>

--- a/templates/controllers/tab/settings/permissions/form/permissionSettingsForm.tpl
+++ b/templates/controllers/tab/settings/permissions/form/permissionSettingsForm.tpl
@@ -9,9 +9,15 @@
  *
  *}
 {capture assign="additionalFormContent"}
+
+	{fbvFormSection label="manager.subscriptionPolicies.authorSelfArchiveDescription" list=true}
+		{fbvElement type="checkbox" id="enableAuthorSelfArchive" name="enableAuthorSelfArchive" value=1 checked=$enableAuthorSelfArchive label="manager.subscriptionPolicies.authorSelfArchive" disabled=$scheduledTasksEnabled|compare:0}
+		{fbvElement type="textarea" id="authorSelfArchivePolicy" value=$authorSelfArchivePolicy rich=true multilingual=true}
+	{/fbvFormSection}
+
 	{fbvFormSection list=true title="manager.setup.copyrightYearBasis"}
 		{fbvElement type="radio" id="copyrightYearBasis-issue" name="copyrightYearBasis" value="issue" checked=$copyrightYearBasis|compare:"issue" label="manager.setup.copyrightYearBasis.issue"}
 		{fbvElement type="radio" id="copyrightYearBasis-submission" name="copyrightYearBasis" value="submission" checked=$copyrightYearBasis|compare:"submission" label="manager.setup.copyrightYearBasis.article"}
-	{/fbvFormSection}
+	{/fbvFormSection}	
 {/capture}
 {include file="core:controllers/tab/settings/permissions/form/permissionSettingsForm.tpl additionalFormContent=$additionalFormContent}

--- a/templates/controllers/tab/settings/permissions/form/permissionSettingsForm.tpl
+++ b/templates/controllers/tab/settings/permissions/form/permissionSettingsForm.tpl
@@ -18,6 +18,6 @@
 	{fbvFormSection list=true title="manager.setup.copyrightYearBasis"}
 		{fbvElement type="radio" id="copyrightYearBasis-issue" name="copyrightYearBasis" value="issue" checked=$copyrightYearBasis|compare:"issue" label="manager.setup.copyrightYearBasis.issue"}
 		{fbvElement type="radio" id="copyrightYearBasis-submission" name="copyrightYearBasis" value="submission" checked=$copyrightYearBasis|compare:"submission" label="manager.setup.copyrightYearBasis.article"}
-	{/fbvFormSection}	
+	{/fbvFormSection}
 {/capture}
 {include file="core:controllers/tab/settings/permissions/form/permissionSettingsForm.tpl additionalFormContent=$additionalFormContent}


### PR DESCRIPTION
Self archiving settings are at the moment under Payment settings, which does not make sense, because self archiving policies are not connected to subscription settings.

So, move settings concerning self archiving under settings=>distribution=>permissions

