### PR TITLE
Add fi locale template for initial decline

### DIFF
--- a/locale/fi_FI/emailTemplates.xml
+++ b/locale/fi_FI/emailTemplates.xml
@@ -825,4 +825,17 @@ Ystävällisin terveisin,<br />
 		<body><![CDATA[Kirjoita viesti]]></body>
 		<description>The default (blank) message used in the Notification Center Message Listbuilder.</description>
 	</email_text>
+	<email_text key="EDITOR_DECISION_INITIAL_DECLINE">
+		<subject>Toimittajan päätös</subject>
+		<body>
+			<![CDATA[Hyvä {$authorName},<br />
+<br />
+Olemme tehneet päätöksen julkaisuun {$contextName} lähettämäänne käsikirjoitusta &quot;{$submissionTitle}&quot; koskien.<br />
+<br />
+Päätöksemme on: Käsikirjoitus on hylätty<br />
+<br />
+{$editorialContactSignature}<br />]]></body>
+		<description>This email is send to the author if the editor declines his submission initially, before the review stage</description>
+	</email_text>	
+	
 </email_texts>


### PR DESCRIPTION
Add fi locale for the new template added here: https://github.com/pkp/pkp-lib/issues/2434

ps. how do other translators track down these new additions? I think that I follow the development fairly closely but still I did not notice that this new tempalte was added. It was only after a journal contacted me asked whether there could be a template for the initial rejection that I found this. The translator tool does not seem to solve this although it works well with the other translations.
