### PR TITLE
pkp/pkp-lib#3016 remove repairSuppFilesFilestage

### DIFF
--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -198,7 +198,6 @@
 	</upgrade>
 
 	<upgrade minversion="3.0.0.0" maxversion="3.1.0.9">
-		<code function="repairSuppFilesFilestage" />
 		<code function="fixAuthorGroup" /><!-- Run again after previous invalid fix (#3289) -->
 		<note file="docs/release-notes/README-3.1.1" />
 	</upgrade>


### PR DESCRIPTION
Remove function repairSuppFilesFilestage, that tries to repair supp files already migrated from OJS 2.4.x to OJS 3.x, because it is not possible to differentiate if the supp file is from ojs 2.4.x or from 3.x. (that could be any files of a category defined as supplementary) 
S. also: https://forum.pkp.sfu.ca/t/ojs-3-1-1-bug-image-files-missing-for-all-papers-including-published-papers/40645/9
s. https://github.com/pkp/pkp-lib/issues/3016