### PR TITLE
Include institution name and IP range variables in subscription locales

### DIFF
--- a/plugins/blocks/subscription/locale/ca_ES/locale.xml
+++ b/plugins/blocks/subscription/locale/ca_ES/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Aquest mòdul proporciona informació sobre la subscripció a la barra lateral.</message>
 	<message key="plugins.block.subscription.blockTitle">Subscripció</message>
 	<message key="plugins.block.subscription.expires">Venciment</message>
-	<message key="plugins.block.subscription.providedBy">Accés proporcionat per</message>
-	<message key="plugins.block.subscription.comingFromIP">De</message>
+	<message key="plugins.block.subscription.providedBy">Accés proporcionat per {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">De {$ip}</message>
 	<message key="plugins.block.subscription.about">Subscripcions</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Inicieu la sessió per confirmar la subscripció</message>
 </locale>

--- a/plugins/blocks/subscription/locale/cs_CZ/locale.xml
+++ b/plugins/blocks/subscription/locale/cs_CZ/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Tento plugin přidá do postranního panelu blok s informací o předplatném.</message>
 	<message key="plugins.block.subscription.blockTitle">Předplatné</message>
 	<message key="plugins.block.subscription.expires">Vyprší</message>
-	<message key="plugins.block.subscription.providedBy">Přístup poskytl:</message>
-	<message key="plugins.block.subscription.comingFromIP">Přichází z IP:</message>
+	<message key="plugins.block.subscription.providedBy">Přístup poskytl: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Přichází z IP: {$ip}</message>
 	<message key="plugins.block.subscription.about">Předplatné</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Přihlaste se pro ověření předplatného</message>
 </locale>

--- a/plugins/blocks/subscription/locale/el_GR/locale.xml
+++ b/plugins/blocks/subscription/locale/el_GR/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Το πρόσθετο αυτό παρέχει πληροφορίες συνδρομών στην πλαϊνή μπάρα.</message>
 	<message key="plugins.block.subscription.blockTitle">Συνδρομή</message>
 	<message key="plugins.block.subscription.expires">Λήγει</message>
-	<message key="plugins.block.subscription.providedBy">Η πρόσβαση παρέχετε από:</message>
-	<message key="plugins.block.subscription.comingFromIP">Από το</message>
+	<message key="plugins.block.subscription.providedBy">Η πρόσβαση παρέχετε από: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Από το {$ip}</message>
 	<message key="plugins.block.subscription.about">Συνδρομές</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Συνδεθείτε για να επιβεβαιώσετε τη συνδρομή</message>
 </locale>

--- a/plugins/blocks/subscription/locale/es_AR/locale.xml
+++ b/plugins/blocks/subscription/locale/es_AR/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Este plugin muestra información de la suscripción en la barra lateral.</message>
 	<message key="plugins.block.subscription.blockTitle">Suscripción</message>
 	<message key="plugins.block.subscription.expires">Expira</message>
-	<message key="plugins.block.subscription.providedBy">Acceso provisto por:</message>
-	<message key="plugins.block.subscription.comingFromIP">Desde la IP:</message>
+	<message key="plugins.block.subscription.providedBy">Acceso provisto por: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Desde la IP: {$ip}</message>
 	<message key="plugins.block.subscription.about">Suscripciones</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Entre en la revista para verificar la suscripción</message>
 </locale>

--- a/plugins/blocks/subscription/locale/es_ES/locale.xml
+++ b/plugins/blocks/subscription/locale/es_ES/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Este módulo proporciona información sobre las suscripciones en la barra lateral.</message>
 	<message key="plugins.block.subscription.blockTitle">Suscripción</message>
 	<message key="plugins.block.subscription.expires">Caduca</message>
-	<message key="plugins.block.subscription.providedBy">Acceso proporcionado por</message>
-	<message key="plugins.block.subscription.comingFromIP">De</message>
+	<message key="plugins.block.subscription.providedBy">Acceso proporcionado por {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">De {$ip}</message>
 	<message key="plugins.block.subscription.about">Suscripciones</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Inicie sesión para verificar la suscripción</message>
 </locale>

--- a/plugins/blocks/subscription/locale/eu_ES/locale.xml
+++ b/plugins/blocks/subscription/locale/eu_ES/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Plugin honek harpidetzen informazioa ematen du alboko barran.</message>
 	<message key="plugins.block.subscription.blockTitle">Harpidetza</message>
 	<message key="plugins.block.subscription.expires">Iraungi</message>
-	<message key="plugins.block.subscription.providedBy">Sarbide-emailea: </message>
-	<message key="plugins.block.subscription.comingFromIP">IP honetatik: </message>
+	<message key="plugins.block.subscription.providedBy">Sarbide-emailea: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">IP honetatik: {$ip}</message>
 	<message key="plugins.block.subscription.about">Harpidetzak</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Hasi saioa harpidetza egiaztatzeko</message>
 </locale>

--- a/plugins/blocks/subscription/locale/fr_CA/locale.xml
+++ b/plugins/blocks/subscription/locale/fr_CA/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Ce plugiciel fournit un encadré contenant l'information d'abonnement.</message>
 	<message key="plugins.block.subscription.blockTitle">Abonnement</message>
 	<message key="plugins.block.subscription.expires">Échéance</message>
-	<message key="plugins.block.subscription.providedBy">Accès fournit par :</message>
-	<message key="plugins.block.subscription.comingFromIP">Adresse IP de provenance :</message>
+	<message key="plugins.block.subscription.providedBy">Accès fournit par : {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Adresse IP de provenance : {$ip}</message>
 	<message key="plugins.block.subscription.about">Abonnements</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Ouvrir une session pour vérifier l'abonnement</message>
 </locale>

--- a/plugins/blocks/subscription/locale/fr_FR/locale.xml
+++ b/plugins/blocks/subscription/locale/fr_FR/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Ce plugiciel fournit un encadré contenant l'information d'abonnement.</message>
 	<message key="plugins.block.subscription.blockTitle">Abonnement</message>
 	<message key="plugins.block.subscription.expires">Échéance</message>
-	<message key="plugins.block.subscription.providedBy">Accès fournit par :</message>
-	<message key="plugins.block.subscription.comingFromIP">Adresse IP de provenance :</message>
+	<message key="plugins.block.subscription.providedBy">Accès fournit par : {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Adresse IP de provenance : {$ip}</message>
 	<message key="plugins.block.subscription.about">Abonnements</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Ouvrir une session pour vérifier l'abonnement</message>
 </locale>

--- a/plugins/blocks/subscription/locale/hr_HR/locale.xml
+++ b/plugins/blocks/subscription/locale/hr_HR/locale.xml
@@ -18,7 +18,7 @@
 	<message key="plugins.block.subscription.description">Ovaj dodatak u rubni izbornik dodaje informacije o pretplati.</message>
 	<message key="plugins.block.subscription.blockTitle">Pretplata</message>
 	<message key="plugins.block.subscription.expires">Ističe</message>
-	<message key="plugins.block.subscription.providedBy">Osnova pristupa:</message>
+	<message key="plugins.block.subscription.providedBy">Osnova pristupa: {$institutionName}</message>
 	<message key="plugins.block.subscription.providedByInstitution">Pretplata vaše institucije</message>
-	<message key="plugins.block.subscription.comingFromIP">Sa IP adrese:</message>
+	<message key="plugins.block.subscription.comingFromIP">Sa IP adrese: {$ip}</message>
 </locale>

--- a/plugins/blocks/subscription/locale/id_ID/locale.xml
+++ b/plugins/blocks/subscription/locale/id_ID/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Plugin ini menyediakan informasi langganan.</message>
 	<message key="plugins.block.subscription.blockTitle">Langganan</message>
 	<message key="plugins.block.subscription.expires">Kadaluwarsa</message>
-	<message key="plugins.block.subscription.providedBy">Akses disediakan oleh</message>
-	<message key="plugins.block.subscription.comingFromIP">Dari</message>
+	<message key="plugins.block.subscription.providedBy">Akses disediakan oleh {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Dari {$ip}</message>
 	<message key="plugins.block.subscription.about">Langganan</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Login untuk memverifikasi langganan</message>
 </locale>

--- a/plugins/blocks/subscription/locale/it_IT/locale.xml
+++ b/plugins/blocks/subscription/locale/it_IT/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Questo plugin visualizza nella barra laterale informazioni sugli abbonamenti.</message>
 	<message key="plugins.block.subscription.blockTitle">Abbonamento</message>
 	<message key="plugins.block.subscription.expires">Scadenza</message>
-	<message key="plugins.block.subscription.providedBy">Ente abbonato</message>
-	<message key="plugins.block.subscription.comingFromIP">IP</message>
+	<message key="plugins.block.subscription.providedBy">Ente abbonato {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">IP {$ip}</message>
 	<message key="plugins.block.subscription.about">Abbonamenti</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Entra per verificare l'abbonamento</message>
 </locale>

--- a/plugins/blocks/subscription/locale/ja_JP/locale.xml
+++ b/plugins/blocks/subscription/locale/ja_JP/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">サイドバーに購読情報を表示します。</message>
 	<message key="plugins.block.subscription.blockTitle">購読</message>
 	<message key="plugins.block.subscription.expires">購読期限</message>
-	<message key="plugins.block.subscription.providedBy">個人購読: </message>
-	<message key="plugins.block.subscription.comingFromIP">接続可能IP: </message>
+	<message key="plugins.block.subscription.providedBy">個人購読: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">接続可能IP: {$ip}</message>
 	<message key="plugins.block.subscription.about">購読</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">ログインして購読を確認</message>
 </locale>

--- a/plugins/blocks/subscription/locale/nl_NL/locale.xml
+++ b/plugins/blocks/subscription/locale/nl_NL/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Deze plugin levert informatie over het abonnement in de sidebar.</message>
 	<message key="plugins.block.subscription.blockTitle">Abonnement</message>
 	<message key="plugins.block.subscription.expires">Verloopt</message>
-	<message key="plugins.block.subscription.providedBy">Toegang verzorgd door:</message>
-	<message key="plugins.block.subscription.comingFromIP">Komend van IP:</message>
+	<message key="plugins.block.subscription.providedBy">Toegang verzorgd door: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Komend van IP: {$ip}</message>
 	<message key="plugins.block.subscription.about">Abonnementen</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Log in om uw abonnement te verifiëren</message>
 </locale>

--- a/plugins/blocks/subscription/locale/no_NO/locale.xml
+++ b/plugins/blocks/subscription/locale/no_NO/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Denne programutvidelsen oppretter abonnementsinformasjon i sidespalten.</message>
 	<message key="plugins.block.subscription.blockTitle">Abonnement</message>
 	<message key="plugins.block.subscription.expires">Utløper</message>
-	<message key="plugins.block.subscription.providedBy">Tilgangen gis av:</message>
-	<message key="plugins.block.subscription.comingFromIP">Kommer fra IP:</message>
+	<message key="plugins.block.subscription.providedBy">Tilgangen gis av: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Kommer fra IP: {$ip}</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Logg inn for å bekrefte abonnementet</message>
 	<message key="plugins.block.subscription.about">Abonnementer</message>
 </locale>

--- a/plugins/blocks/subscription/locale/pl_PL/locale.xml
+++ b/plugins/blocks/subscription/locale/pl_PL/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Wtyczka elementu blokowego informacji o subskrypcji.</message>
 	<message key="plugins.block.subscription.blockTitle">Subskrypcje</message>
 	<message key="plugins.block.subscription.expires">Kończy się</message>
-	<message key="plugins.block.subscription.providedBy">Dostęp zapewnia</message>
-	<message key="plugins.block.subscription.comingFromIP">Z</message>
+	<message key="plugins.block.subscription.providedBy">Dostęp zapewnia {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Z {$ip}</message>
 	<message key="plugins.block.subscription.about">Subskrypcje</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Zaloguj się w celu sprawdzenia subskrypcji</message>
 </locale>

--- a/plugins/blocks/subscription/locale/pt_BR/locale.xml
+++ b/plugins/blocks/subscription/locale/pt_BR/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Este plugin oferece informações sobre a assinatura nas barras laterais.</message>
 	<message key="plugins.block.subscription.blockTitle">Assinatura</message>
 	<message key="plugins.block.subscription.expires">Expiração</message>
-	<message key="plugins.block.subscription.providedBy">Acesso fornecido por:</message>
-	<message key="plugins.block.subscription.comingFromIP">IP de proveniência:</message>
+	<message key="plugins.block.subscription.providedBy">Acesso fornecido por: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">IP de proveniência: {$ip}</message>
 	<message key="plugins.block.subscription.about">Assinaturas</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Acesse o sistema para verificar sua assinatura</message>
 </locale>

--- a/plugins/blocks/subscription/locale/ro_RO/locale.xml
+++ b/plugins/blocks/subscription/locale/ro_RO/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Acest modul oferă informaţii privind abonamentele.</message>
 	<message key="plugins.block.subscription.blockTitle">Abonament</message>
 	<message key="plugins.block.subscription.expires">Expiră</message>
-	<message key="plugins.block.subscription.providedBy">Acces oferit de: </message>
-	<message key="plugins.block.subscription.comingFromIP">De la</message>
+	<message key="plugins.block.subscription.providedBy">Acces oferit de: {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">De la {$ip}</message>
 	<message key="plugins.block.subscription.about">Abonamentele</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Autentificare pentru a verifica abonamentul</message>
 </locale>

--- a/plugins/blocks/subscription/locale/sr_RS@latin/locale.xml
+++ b/plugins/blocks/subscription/locale/sr_RS@latin/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Ovaj blok prikazuje informacije o pretplat.</message>
 	<message key="plugins.block.subscription.blockTitle">Pretplata</message>
 	<message key="plugins.block.subscription.expires">Ističe</message>
-	<message key="plugins.block.subscription.providedBy">Pristup odobrio</message>
-	<message key="plugins.block.subscription.comingFromIP">Od</message>
+	<message key="plugins.block.subscription.providedBy">Pristup odobrio {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">Od {$ip}</message>
 	<message key="plugins.block.subscription.about">Pretplate</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Prijavite se da potvrdite pretplatu</message>
 </locale>

--- a/plugins/blocks/subscription/locale/sv_SE/locale.xml
+++ b/plugins/blocks/subscription/locale/sv_SE/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Det här tilläget placerar prenumerationsinformation i sidomenyn</message>
 	<message key="plugins.block.subscription.blockTitle">Prenumeration</message>
 	<message key="plugins.block.subscription.expires">Löper ut</message>
-	<message key="plugins.block.subscription.providedBy">Tillgång tillhandahålls av</message>
-	<message key="plugins.block.subscription.comingFromIP">från</message>
+	<message key="plugins.block.subscription.providedBy">Tillgång tillhandahålls av {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">från {$ip}</message>
 	<message key="plugins.block.subscription.about">Prenumerationer</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Logga in för att bekräfta prenumerationen</message>
 </locale>

--- a/plugins/blocks/subscription/locale/tr_TR/locale.xml
+++ b/plugins/blocks/subscription/locale/tr_TR/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Bu eklenti yan tarafta abonelik bilgileri sağlar.</message>
 	<message key="plugins.block.subscription.blockTitle">Abone</message>
 	<message key="plugins.block.subscription.expires">Sona Eriyor</message>
-	<message key="plugins.block.subscription.providedBy">Erişimi destekleyen</message>
-	<message key="plugins.block.subscription.comingFromIP">den</message>
+	<message key="plugins.block.subscription.providedBy">Erişimi destekleyen {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">den {$ip}</message>
 	<message key="plugins.block.subscription.about">Aboneler</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Aboneliğinizi doğrulamak için giriş yapın</message>
 </locale>

--- a/plugins/blocks/subscription/locale/uk_UA/locale.xml
+++ b/plugins/blocks/subscription/locale/uk_UA/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">Цей модуль відображає панель з інформацією про передплату.</message>
 	<message key="plugins.block.subscription.blockTitle">Передплата</message>
 	<message key="plugins.block.subscription.expires">закінчується</message>
-	<message key="plugins.block.subscription.providedBy">Доступ забезпечує</message>
-	<message key="plugins.block.subscription.comingFromIP">З</message>
+	<message key="plugins.block.subscription.providedBy">Доступ забезпечує {$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">З {$ip}</message>
 	<message key="plugins.block.subscription.about">Передплати</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">Увійдіть, щоб підтвердити передплату</message>
 </locale>

--- a/plugins/blocks/subscription/locale/vi_VN/locale.xml
+++ b/plugins/blocks/subscription/locale/vi_VN/locale.xml
@@ -18,7 +18,7 @@
 	<message key="plugins.block.subscription.description">Công cụ này cung cấp thông tin về đặt tạp chí ở cột bên.</message>
 	<message key="plugins.block.subscription.blockTitle">Đặt tạp chí</message>
 	<message key="plugins.block.subscription.expires">Hết hạn</message>
-	<message key="plugins.block.subscription.providedBy">Cung cấp truy cập:</message>
+	<message key="plugins.block.subscription.providedBy">Cung cấp truy cập: {$institutionName}</message>
 	<message key="plugins.block.subscription.providedByInstitution">Bạn được cơ quan cấp quyền truy cập</message>
-	<message key="plugins.block.subscription.comingFromIP">Từ địa chỉ IP:</message>
+	<message key="plugins.block.subscription.comingFromIP">Từ địa chỉ IP: {$ip}</message>
 </locale>

--- a/plugins/blocks/subscription/locale/zh_CN/locale.xml
+++ b/plugins/blocks/subscription/locale/zh_CN/locale.xml
@@ -18,8 +18,8 @@
 	<message key="plugins.block.subscription.description">本插件提供在边栏显示订阅信息的功能。</message>
 	<message key="plugins.block.subscription.blockTitle">订阅</message>
 	<message key="plugins.block.subscription.expires">过期</message>
-	<message key="plugins.block.subscription.providedBy">接入提供者是：</message>
-	<message key="plugins.block.subscription.comingFromIP">来自IP为：</message>
+	<message key="plugins.block.subscription.providedBy">接入提供者是：{$institutionName}</message>
+	<message key="plugins.block.subscription.comingFromIP">来自IP为：{$ip}</message>
 	<message key="plugins.block.subscription.about">订阅</message>
 	<message key="plugins.block.subscription.loginToVerifySubscription">登录验证订阅</message>
 </locale>


### PR DESCRIPTION
Noticed these were missing in our French and Spanish language journals, and thought it may be helpful to include them in all missing locale files as well.