### PR TITLE
 Fix missing submission id event log parameters

### DIFF
--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -387,6 +387,10 @@
 		<code function="installEmailTemplate" key="REVIEW_REQUEST_REMIND_AUTO_ONECLICK" locales="ar_IQ,ca_ES,cs_CZ,da_DK,de_DE,el_GR,en_US,es_AR,es_ES,eu_ES,fa_IR,fr_CA,fr_FR,gl_ES,hr_HR,id_ID,it_IT,ja_JP,mk_MK,ml_IN,nl_NL,no_NO,pl_PL,pt_BR,pt_PT,ro_RO,ru_RU,sr_SR,sv_SE,tr_TR,uk_UA,vi_VN,zh_CN,zh_TW" />
 	</upgrade>
 
+	<upgrade minversion="2.3.3.1" maxversion="2.4.8.3">
+		<data file="dbscripts/xml/upgrade/event_log_submissionid.xml" />
+	</upgrade>
+
 	<!-- update plugin configuration - should be done as the final upgrade task -->
 	<code function="addPluginVersions" />
 </install>

--- a/dbscripts/xml/upgrade/event_log_submissionid.xml
+++ b/dbscripts/xml/upgrade/event_log_submissionid.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE data SYSTEM "../../../lib/pkp/dtd/xmlData.dtd">
+
+<!--
+  * event_log_submissionid.xml
+  *
+  * Copyright (c) 2013-2018 Simon Fraser University
+  * Copyright (c) 2003-2018 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Add missing submissionId param for the log.author.submitted events.
+  *
+  -->
+
+<data>
+	<sql>
+		<query>
+			INSERT INTO event_log_settings (log_id, setting_name, setting_value, setting_type)
+			SELECT event_log.log_id, 'submissionId', event_log.assoc_id, 'string' FROM event_log
+			WHERE event_log.message='log.author.submitted'
+			AND NOT EXISTS (SELECT * FROM event_log_settings WHERE setting_name='submissionId' AND log_id=event_log.log_id)
+		</query>
+	</sql>
+</data>


### PR DESCRIPTION
With OJS 2.4, the `log.author.submitted` events of submissions prior to 642fa8543782c3df69e2e0f77d08d6d43bbe753d are missing the `submissionId` param.
