### PR TITLE
pkp/pkp-lib#3674: If ArticleFile upload fails, remove temporary file created by file_id and revision

### DIFF
--- a/classes/file/ArticleFileManager.inc.php
+++ b/classes/file/ArticleFileManager.inc.php
@@ -517,7 +517,7 @@ class ArticleFileManager extends FileManager {
 
 		if (!$this->uploadFile($fileName, $dir.$newFileName)) {
 			// Delete the dummy file we inserted
-			$articleFileDao->deleteArticleFileById($articleFile->getFileId());
+			$articleFileDao->deleteArticleFileById($articleFile->getFileId(), $articleFile->getRevision());
 
 			return false;
 		}


### PR DESCRIPTION
Fixes the potential delete of all uploaded files for a review on a single upload failure.