### PR TITLE
Allow installations to limit the creation of session cookies to logged in users

### DIFF
--- a/classes/i18n/AppLocale.inc.php
+++ b/classes/i18n/AppLocale.inc.php
@@ -70,16 +70,10 @@ class AppLocale extends PKPLocale {
 				$locale = self::$request->getUserVar('setLocale');
 				if (empty($locale) || !in_array($locale, array_keys(AppLocale::getSupportedLocales()))) $locale = self::$request->getCookieVar('currentLocale');
 			} else {
-				$sessionManager = SessionManager::getManager();
-				$session = $sessionManager->getUserSession();
 				$locale = self::$request->getUserVar('uiLocale');
 
 				$journal = self::$request->getJournal();
 				$site = self::$request->getSite();
-
-				if (!isset($locale)) {
-					$locale = $session->getSessionVar('currentLocale');
-				}
 
 				if (!isset($locale)) {
 					$locale = self::$request->getCookieVar('currentLocale');

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -41,6 +41,10 @@ session_cookie_name = OJSSID
 ; (set to 0 to force expiration at end of current session)
 session_lifetime = 30
 
+; Only create session cookies for users that are logged in
+; Ensures GDPR compliance
+session_limit = Off
+
 ; Enable support for running scheduled tasks
 ; Set this to On if you have set up the scheduled tasks script to
 ; execute periodically


### PR DESCRIPTION
@asmecher @jmacgreg (@NateWr as well while you have been dealing with GDPR as well...)

Part of the GDPR changes in OJS: https://github.com/pkp/pkp-lib/issues/3624

Details:
- new `session_limit` setting in config.inc.php
- language settings are now stored to separate cookie, not in the session data. This cookie does not require consent, because it contains no personal data
- if `session_limit` is turned `On` sessions cookies are not created for users that are not logged in
- when goes to the login form, consent is asked for the privacy policy. The field is required for logging in. The privacy policy should of course mention the cookies.
- after user is logged in, a new `allowCookies` cookie is created (1 year), when the cookie exists, a session is created for the user
- when user logs out and returns, the login form will not show the consent checkbox anymore as long as the `allowCookies` exists.
- the IP in the session is always stored in encrypted form







