### PR TITLE
Proper migration of no_NO to nb_NO

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -2636,18 +2636,16 @@ class Upgrade extends Installer {
 	}
 
 	/**
-	 * Migrate sr_SR locale to the new sr_RS@latin.
+	 * Migrate old locale to new locale.
+	 * @param oldLocale string
+	 * @param newLocale string
+	 * @param oldLocaleStringLength string
 	 * @return boolean
 	 */
-	function migrateSRLocale() {
-		$oldLocale = 'sr_SR';
-		$newLocale = 'sr_RS@latin';
-
-		$oldLocaleStringLength = 's:5';
-
+	function migrateLocale($oldLocale, $newLocale, $oldLocaleStringLength) {
 		$journalSettingsDao = DAORegistry::getDAO('JournalSettingsDAO');
 
-		// Check if the sr_SR is used, and if not do not run further
+		// Check if the old locale is used, and if not do not run further
 		$srExistResult = $journalSettingsDao->retrieve('SELECT COUNT(*) FROM site WHERE installed_locales LIKE ?', array('%'.$oldLocale.'%'));
 		$srExist = $srExistResult->fields[0] ? true : false;
 		$srExistResult->Close();
@@ -2762,6 +2760,21 @@ class Upgrade extends Installer {
 			$settingValueResult->MoveNext();
 		}
 		$settingValueResult->Close();
+
+		return true;
+	}
+
+	/**
+	 * Migrate sr_SR locale to the new sr_RS@latin.
+	 * @return boolean
+	 */
+	function migrateSRLocale() {
+		$oldLocale = 'sr_SR';
+		$newLocale = 'sr_RS@latin';
+
+		$oldLocaleStringLength = 's:5';
+
+		$this->migrateLocale($oldLocale, $newLocale, $oldLocaleStringLength);
 
 		return true;
 	}

--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -2779,6 +2779,21 @@ class Upgrade extends Installer {
 		return true;
 	}
 
+	/**
+	 * Migrate no_NO locale to the new nb_NO.
+	 * @return boolean
+	 */
+	function migrateNOLocale() {
+		$oldLocale = 'no_NO';
+		$newLocale = 'nb_NO';
+
+		$oldLocaleStringLength = 's:5';
+
+		$this->migrateLocale($oldLocale, $newLocale, $oldLocaleStringLength);
+
+		return true;
+	}
+
 }
 
 ?>

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -85,6 +85,7 @@
 
 	<upgrade minversion="2.4.0.0" maxversion="3.1.1.9">
 		<code function="migrateSRLocale" />
+		<code function="migrateNOLocale" />
 	</upgrade>
 
 	<upgrade minversion="2.4.0.0" maxversion="2.4.9.9">

--- a/dbscripts/xml/upgrade/3.0.0_update.xml
+++ b/dbscripts/xml/upgrade/3.0.0_update.xml
@@ -101,36 +101,6 @@
 		<query driver="mysqli">UPDATE submission_files sf, article_galleys_migration agm SET sf.assoc_type = 515, sf.assoc_id = agm.file_id WHERE sf.file_id = agm.style_file_id</query>
 		<query driver="postgres7">UPDATE submission_files sf SET assoc_type = 515, assoc_id = agm.file_id FROM article_galleys_migration agm WHERE sf.file_id = agm.style_file_id</query>
 	</sql>
-	<!-- Bug #7745: Change no_NO to nb_NO -->
-	<sql>
-		<query>UPDATE announcement_type_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE announcement_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE user_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE notification_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE email_templates_default_data SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE email_templates_data SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE controlled_vocab_entry_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE citation_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE metadata_description_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE filter_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE review_form_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE review_form_element_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE user_group_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE submission_file_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE author_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE data_object_tombstone_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE journal_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE section_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE issue_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE issue_galleys SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE issue_galley_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE submissions SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE submission_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE submission_galleys SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE submission_galley_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE rt_versions SET locale='nb_NO' WHERE locale='no_NO'</query>
-		<query>UPDATE subscription_type_settings SET locale='nb_NO' WHERE locale='no_NO'</query>
-	</sql>
 	<sql><!-- Bug #8397 -->
 		<query>UPDATE submissions SET status=4 WHERE status=0</query><!-- STATUS_ARCHIVED to STATUS_DECLINED -->
 	</sql>


### PR DESCRIPTION
I noticed that there where hundreds of no_NO references still in the database after a test upgrade from 2.4.8.1 to 3.1.1-1.
This patch series attempts to fix this by using the code from pkp/pkp-lib#3416 to do a more complete migration.

In my testing this has converted all traces of no_NO to nb_NO as expected.