### PR TITLE
pkp/pkp-lib#3795 Link up reference_number field to institutional subscription form

### DIFF
--- a/templates/payments/institutionalSubscriptionForm.tpl
+++ b/templates/payments/institutionalSubscriptionForm.tpl
@@ -46,6 +46,9 @@
 		{fbvFormSection label="manager.subscriptions.form.ipRange"}
 			{fbvElement type="textarea" name="ipRanges" id="ipRanges" value=$ipRanges label="manager.subscriptions.form.ipRangeInstructions" size=$fbvStyles.size.MEDIUM}
 		{/fbvFormSection}
+		{fbvFormSection label="manager.subscriptions.form.referenceNumber"}
+			{fbvElement type="text" name="referenceNumber" id="referenceNumber" value=$referenceNumber size=$fbvStyles.size.MEDIUM inline=true}
+		{/fbvFormSection}
 		{fbvFormSection label="manager.subscriptions.form.notes"}
 			{fbvElement type="textarea" name="notes" id="notes" value=$notes rich=true}
 		{/fbvFormSection}


### PR DESCRIPTION
This adds the Reference Number field to the Institutional subscription form to have parity with Individual subscriptions and to correct a regression from OJS 2.

This should take care of https://forum.pkp.sfu.ca/t/no-reference-number-in-the-subscription-settings-in-ojs-3/41261