### PR TITLE
pkp/pkp-lib#3794 Add Reference Number column to subscription overview

### DIFF
--- a/controllers/grid/subscriptions/IndividualSubscriptionsGridHandler.inc.php
+++ b/controllers/grid/subscriptions/IndividualSubscriptionsGridHandler.inc.php
@@ -86,6 +86,15 @@ class IndividualSubscriptionsGridHandler extends SubscriptionsGridHandler {
 				$cellProvider
 			)
 		);
+		$this->addColumn(
+			new GridColumn(
+				'referenceNumber',
+				'manager.subscriptions.referenceNumber',
+				null,
+				null,
+				$cellProvider
+			)
+		);
 	}
 
 

--- a/controllers/grid/subscriptions/InstitutionalSubscriptionsGridHandler.inc.php
+++ b/controllers/grid/subscriptions/InstitutionalSubscriptionsGridHandler.inc.php
@@ -77,6 +77,15 @@ class InstitutionalSubscriptionsGridHandler extends SubscriptionsGridHandler {
 				$cellProvider
 			)
 		);
+		$this->addColumn(
+			new GridColumn(
+				'referenceNumber',
+				'manager.subscriptions.referenceNumber',
+				null,
+				null,
+				$cellProvider
+			)
+		);
 	}
 
 

--- a/controllers/grid/subscriptions/SubscriptionsGridCellProvider.inc.php
+++ b/controllers/grid/subscriptions/SubscriptionsGridCellProvider.inc.php
@@ -52,6 +52,8 @@ class SubscriptionsGridCellProvider extends GridCellProvider {
 				return array('label' => $subscription->getDateStart());
 			case 'dateEnd':
 				return array('label' => $subscription->getDateEnd());
+			case 'referenceNumber':
+				return array('label' => $subscription->getReferenceNumber());
 		}
 		assert(false);
 	}


### PR DESCRIPTION
This is a response to a long standing issue we've had which @neffe first brought up here:
https://forum.pkp.sfu.ca/t/show-reference-numbers-on-the-summary-page/13794
