### PR TITLE
pkp/pkp-lib#3016 patch not to migrate supp files as galleys but as su…

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -1074,50 +1074,6 @@ class Upgrade extends Installer {
 
 			// if it is a remote supp file and article is published, convert it to a remote galley
 			if (!$row['file_id'] && $row['remote_url'] != '' && $article->getStatus() == STATUS_PUBLISHED) {
-				$remoteSuppFileSettingsResult = $submissionFileDao->retrieve('SELECT * FROM article_supp_file_settings WHERE supp_id = ? AND setting_value IS NOT NULL', array($row['supp_id']));
-				$extraRemoteGalleySettings = $remoteSuppFileTitle = array();
-				while (!$remoteSuppFileSettingsResult->EOF) {
-					$rsfRow = $remoteSuppFileSettingsResult->getRowAssoc(false);
-					$remoteSuppFileSettingsResult->MoveNext();
-					switch ($rsfRow['setting_name']) {
-						case 'title':
-							$remoteSuppFileTitle[$rsfRow['locale']] = $rsfRow['setting_value'];
-							break;
-						case 'pub-id::doi':
-						case 'pub-id::other::urn':
-						case 'pub-id::publisher-id':
-						case 'urnSuffix':
-						case 'doiSuffix':
-						case 'datacite::registeredDoi':
-							$extraRemoteGalleySettings[$rsfRow['setting_name']] = $rsfRow['setting_value'];
-							break;
-						default:
-							// other settings are not relevant for remote galleys
-							break;
-					}
-				}
-				$remoteSuppFileSettingsResult->Close();
-
-				$articleGalley = $articleGalleyDao->newDataObject();
-				$articleGalley->setSubmissionId($article->getId());
-				$articleGalley->setLabel($remoteSuppFileTitle[$article->getLocale()]);
-				$articleGalley->setRemoteURL($row['remote_url']);
-				$articleGalley->setLocale($article->getLocale());
-				$articleGalleyDao->insertObject($articleGalley);
-
-				// Preserve extra settings. (Plugins may not be loaded, so other mechanisms might not work.)
-				foreach ($extraRemoteGalleySettings as $name => $value) {
-					$submissionFileDao->update(
-						'INSERT INTO submission_galley_settings (galley_id, setting_name, setting_value, setting_type) VALUES (?, ?, ?, ?)',
-						array(
-							$articleGalley->getId(),
-							$name,
-							$value,
-							'string'
-						)
-					);
-				}
-
 				// continue with the next supp file
 				continue;
 			}
@@ -1366,7 +1322,7 @@ class Upgrade extends Installer {
 			foreach ((array) $submissionFiles as $submissionFile) {
 				$submissionFile->setGenreId($genre->getId());
 				$submissionFile->setUploaderUserId($creatorUserId);
-				$fileStage = $article->getStatus() == STATUS_PUBLISHED ? SUBMISSION_FILE_PROOF : SUBMISSION_FILE_SUBMISSION;
+				$fileStage = SUBMISSION_FILE_SUBMISSION;
 				$submissionFile->setFileStage($fileStage);
 				$submissionFileDao->updateObject($submissionFile);
 			}
@@ -1435,28 +1391,6 @@ class Upgrade extends Installer {
 							'string'
 						)
 					);
-				}
-
-				if ($article->getStatus() == STATUS_PUBLISHED) {
-					$articleGalley = $articleGalleyDao->newDataObject();
-					$articleGalley->setFileId($submissionFile->getFileId());
-					$articleGalley->setSubmissionId($article->getId());
-					$articleGalley->setLabel($submissionFile->getName($article->getLocale()));
-					$articleGalley->setLocale($article->getLocale());
-					$articleGalleyDao->insertObject($articleGalley);
-
-					// Preserve extra settings. (Plugins may not be loaded, so other mechanisms might not work.)
-					foreach ($extraGalleySettings as $name => $value) {
-						$submissionFileDao->update(
-							'INSERT INTO submission_galley_settings (galley_id, setting_name, setting_value, setting_type) VALUES (?, ?, ?, ?)',
-							array(
-								$articleGalley->getId(),
-								$name,
-								$value,
-								'string'
-							)
-						);
-					}
 				}
 			}
 		}

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -199,7 +199,6 @@
 	</upgrade>
 
 	<upgrade minversion="3.0.0.0" maxversion="3.1.0.9">
-		<code function="repairSuppFilesFilestage" />
 		<code function="fixAuthorGroup" /><!-- Run again after previous invalid fix (#3289) -->
 	</upgrade>
 


### PR DESCRIPTION
…bmissions files on OJS 3.1.1-2

this is the patch for those that do not want to migrate supp files form OJS 2 to the galleys in OJS 3. here, the supp files will be in the submission stage, in the "submission files" grid.