### PR TITLE
New oai_max_identifiers config setting

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -389,6 +389,9 @@ repository_id = ojs.pkp.sfu.ca
 ; Maximum number of records per request to serve via OAI
 oai_max_records = 100
 
+; Maximum number of identifiers per request to serve via OAI
+oai_max_identifiers = 500
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ; Interface Settings ;
 ;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
It will aloud to control the number of identifiers in the oai listing