### PR TITLE
pkp/pkp-lib#3578: harmonizing Plugin signatures

### DIFF
--- a/plugins/generic/externalFeed/ExternalFeedBlockPlugin.inc.php
+++ b/plugins/generic/externalFeed/ExternalFeedBlockPlugin.inc.php
@@ -79,7 +79,7 @@ class ExternalFeedBlockPlugin extends BlockPlugin {
 	 * @param $request PKPRequest
 	 * @return $string
 	 */
-	function getContents(&$templateMgr, $request = null) {
+	function getContents($templateMgr, $request = null) {
 		$journal = $request->getJournal();
 		if (!$journal) return '';
 

--- a/plugins/generic/lucene/LuceneFacetsBlockPlugin.inc.php
+++ b/plugins/generic/lucene/LuceneFacetsBlockPlugin.inc.php
@@ -99,11 +99,11 @@ class LuceneFacetsBlockPlugin extends BlockPlugin {
 	// Implement template methods from LazyLoadPlugin
 	//
 	/**
-	 * @see LazyLoadPlugin::getEnabled()
+	 * @copydoc LazyLoadPlugin::getEnabled()
 	 */
-	function getEnabled() {
+	function getEnabled($contextId = null) {
 		$plugin =& $this->_getLucenePlugin();
-		return $plugin->getEnabled();
+		return $plugin->getEnabled($contextId);
 	}
 
 

--- a/plugins/generic/lucene/LuceneFacetsBlockPlugin.inc.php
+++ b/plugins/generic/lucene/LuceneFacetsBlockPlugin.inc.php
@@ -137,7 +137,7 @@ class LuceneFacetsBlockPlugin extends BlockPlugin {
 	/**
 	 * @see BlockPlugin::getContents()
 	 */
-	function getContents(&$templateMgr, $request = null) {
+	function getContents($templateMgr, $request = null) {
 		// Get facets from the parent plug-in.
 		$plugin =& $this->_getLucenePlugin();
 		$facets = $plugin->getFacets();


### PR DESCRIPTION
Fixes some of pkp/pkp-lib#3578. Some other specific plugins still have problems in `getContents()`, `getEnabled()`, and `register()`.