### PR TITLE
pkp/pkp-lib#4097: fix grouping when ordering issues by custom sequence

### DIFF
--- a/classes/services/queryBuilders/IssueListQueryBuilder.inc.php
+++ b/classes/services/queryBuilders/IssueListQueryBuilder.inc.php
@@ -158,7 +158,7 @@ class IssueListQueryBuilder extends BaseQueryBuilder {
 					->leftJoin('issue_settings as is', 'i.issue_id', '=', 'is.issue_id')
 					->leftJoin('custom_issue_orders as o', 'o.issue_id', '=', 'i.issue_id')
 					->orderBy($this->orderColumn, $this->orderDirection)
-					->groupBy('i.issue_id');
+					->groupBy('i.issue_id', $this->orderColumn);
 
 		// published
 		if (!is_null($this->isPublished)) {


### PR DESCRIPTION
Addresses the proximate issue for pkp/pkp-lib#4097. Probably we should look at test coverage for PostgreSQL, though…