### PR TITLE
pkp/pkp-lib#4112 Add ability to edit galley file metadata

### DIFF
--- a/controllers/grid/articleGalleys/ArticleGalleyGridRow.inc.php
+++ b/controllers/grid/articleGalleys/ArticleGalleyGridRow.inc.php
@@ -52,6 +52,7 @@ class ArticleGalleyGridRow extends GridRow {
 
 			// Add row-level actions
 			import('lib.pkp.classes.linkAction.request.AjaxModal');
+			AppLocale::requireComponents(LOCALE_COMPONENT_APP_SUBMISSION); // submission.layout.editGalley
 			$this->addAction(new LinkAction(
 				'editGalley',
 				new AjaxModal(
@@ -59,11 +60,17 @@ class ArticleGalleyGridRow extends GridRow {
 					__('submission.layout.editGalley'),
 					'modal_edit'
 				),
-				__('grid.action.edit'),
-				'edit'
+				__('grid.action.editGalley'),
+				'editGalley'
 			));
 
 			$galley = $this->getData();
+			if ($galleyFile = $galley->getFile()) {
+				import('lib.pkp.controllers.api.file.linkAction.EditFileLinkAction');
+				$this->addAction($linkAction = new EditFileLinkAction($request, $galleyFile, WORKFLOW_STAGE_ID_PRODUCTION));
+				$linkAction->setTitle(__('grid.action.editFile'));
+			}
+
 			if ($galley->getRemoteUrl() == '') {
 				import('lib.pkp.controllers.api.file.linkAction.AddFileLinkAction');
 				import('lib.pkp.classes.submission.SubmissionFile'); // Constants

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -28,6 +28,8 @@
 	<message key="submission.submit.whatNext.description">The journal has been notified of your submission, and you've been emailed a confirmation for your records.  Once the editor has reviewed the submission, they will contact you.</message>
 	<message key="grid.action.galleyInIssueEntry">Galley appears in issue entry</message>
 	<message key="grid.action.issueEntry">View this submission's metadata</message>
+	<message key="grid.action.editGalley">Edit Galley</message>
+	<message key="grid.action.editFile">Edit File</message>
 
 	<!-- Submission Information Modal -->
 	<message key="submission.issueEntry.modalTitle">Submission and Publication Metadata</message>


### PR DESCRIPTION
Add the ability to edit galley file metadata. Currently it's only possible to edit *galley* metadata (URL, name, and identifiers) but not *galley file* metadata (filename, possible DC metadata, etc).