### PR TITLE
pkp/pkp-lib#3404 Fix opening of file upload wizard when galley created

### DIFF
--- a/js/controllers/grid/articleGalleys/ArticleGalleyGridHandler.js
+++ b/js/controllers/grid/articleGalleys/ArticleGalleyGridHandler.js
@@ -58,11 +58,18 @@
 		// FIXME: Inter-widget messaging is needed here.
 		var selector = 'a[id^="component-grid-articlegalleys-articlegalleygrid-row-' +
 				rowId + '-addFile-button-"]';
-		$.when($(selector)).then(function() {
-			$(function() {
+
+		function defferedClick(selector) {
+			if ($(selector).length) {
 				$(selector).click();
-			});
-		});
+			} else {
+				setTimeout(function() {
+					defferedClick(selector);
+				}, 200);
+			}
+		}
+
+		defferedClick(selector);
 	};
 
 

--- a/js/controllers/grid/articleGalleys/ArticleGalleyGridHandler.js
+++ b/js/controllers/grid/articleGalleys/ArticleGalleyGridHandler.js
@@ -59,17 +59,17 @@
 		var selector = 'a[id^="component-grid-articlegalleys-articlegalleygrid-row-' +
 				rowId + '-addFile-button-"]';
 
-		function defferedClick(selector) {
+		function deferredClick(selector) {
 			if ($(selector).length) {
 				$(selector).click();
 			} else {
 				setTimeout(function() {
-					defferedClick(selector);
+					deferredClick(selector);
 				}, 200);
 			}
 		}
 
-		defferedClick(selector);
+		deferredClick(selector);
 	};
 
 


### PR DESCRIPTION
I ran into a test failures because the file upload wizard was not being opened when the galley was created. I believe this is due to breaking changes in jQuery 3.0's `when` method:

https://jquery.com/upgrade-guide/3.0/#breaking-change-and-feature-jquery-when-arguments

I just wrote a quick deferral function in this case.

@asmecher can you take a look a second look at this? Also did you upgrade jQuery in the stable branches or does this PR take care of it?