### PR TITLE
pkp/pkp-lib#4236: Remove export of author email within DOAJ

### DIFF
--- a/plugins/importexport/doaj/classes/DOAJExportDom.inc.php
+++ b/plugins/importexport/doaj/classes/DOAJExportDom.inc.php
@@ -210,7 +210,6 @@ class DOAJExportDom {
 		$root = XMLCustomWriter::createElement($doc, 'author');
 
 		XMLCustomWriter::createChildWithText($doc, $root, 'name', $author->getFullName());
-		XMLCustomWriter::createChildWithText($doc, $root, 'email', $author->getEmail(), false);
 
 		if(in_array($author->getAffiliation($article->getLocale()), $affilList)  && !empty($affilList[0])) {
 			XMLCustomWriter::createChildWithText($doc, $root, 'affiliationId', current(array_keys($affilList, $author->getAffiliation($article->getLocale()))));


### PR DESCRIPTION
For OJS 2.4.x; should cherry pick cleanly against ojs-stable-2_4_8