### PR TITLE
pkp/pkp-lib#4242 provide subjects via OAI

### DIFF
--- a/plugins/metadata/dc11/filter/Dc11SchemaArticleAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaArticleAdapter.inc.php
@@ -89,11 +89,24 @@ class Dc11SchemaArticleAdapter extends MetadataDataObjectAdapter {
 		}
 
 		// Subject
-		$subjects = array_merge_recursive(
-			(array) $article->getDiscipline(null),
-			(array) $article->getSubject(null)
+		$disciplineDao = DAORegistry::getDAO('SubmissionDisciplineDAO');
+		$disciplines = $disciplineDao->getDisciplines($article->getId(), $journal->getSupportedSubmissionLocales());
+		$disciplinesStrings = array_map(function($e){ return implode('; ', $e); }, $disciplines);
+
+		$keywordDao = DAORegistry::getDAO('SubmissionKeywordDAO');
+		$keywords = $keywordDao->getKeywords($article->getId(), $journal->getSupportedSubmissionLocales());
+		$keywordsStrings = array_map(function($e){ return implode('; ', $e); }, $keywords);
+
+		$subjectDao = DAORegistry::getDAO('SubmissionSubjectDAO');
+		$subjects = $subjectDao->getSubjects($article->getId(), $journal->getSupportedSubmissionLocales());
+		$subjectsStrings = array_map(function($e){ return implode('; ', $e); }, $subjects);
+
+		$dcSubjects = array_merge_recursive(
+			(array) $disciplinesStrings,
+			(array) $keywordsStrings,
+			(array) $subjectsStrings
 		);
-		$this->_addLocalizedElements($dc11Description, 'dc:subject', $subjects);
+		$this->_addLocalizedElements($dc11Description, 'dc:subject', $dcSubjects);
 
 		// Description
 		$this->_addLocalizedElements($dc11Description, 'dc:description', $article->getAbstract(null));


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/4242

This provides all the "subjects" via OAI in the same way it was in OJS 2. 
Shall maybe each "subject" be listed in its own dc element?