### PR TITLE
Replace generic exception "getStatus() on null"

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -1056,6 +1056,9 @@ class Upgrade extends Installer {
 				$creatorUserId = $managerUsers->next()->getId();
 			}
 			$article = $articleDao->getById($row['article_id']);
+			if (!$article){
+                                error_log("ERROR: Article ".$row['article_id']." could not be found in the original OJS database. Check if the article and submission exist and if the section_id field is correctly set");
+                        }
 
 			// if it is a remote supp file and article is published, convert it to a remote galley
 			if (!$row['file_id'] && $row['remote_url'] != '' && $article->getStatus() == STATUS_PUBLISHED) {


### PR DESCRIPTION

A generic error (Call to a member function getStatus() on null) was shown when articles didn't have a properly section set. This commit intends to log the correct message showing the root cause of the problem.