### PR TITLE
pkp/pkp-lib#4300: Display frontend references as list items.

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -197,9 +197,11 @@
 					</h3>
 					<div class="value">
 						{if $parsedCitations->getCount()}
+							<ul class="references">
 							{iterate from=parsedCitations item=parsedCitation}
-								<p>{$parsedCitation->getCitationWithLinks()|strip_unsafe_html} {call_hook name="Templates::Article::Details::Reference" citation=$parsedCitation}</p>
+								<li>{$parsedCitation->getCitationWithLinks()|strip_unsafe_html} {call_hook name="Templates::Article::Details::Reference" citation=$parsedCitation}</li>
 							{/iterate}
+							</ul>
 						{elseif $article->getCitations()}
 							{$article->getCitations()|nl2br}
 						{/if}


### PR DESCRIPTION
Resolves pkp/pkp-lib#4300, unless anyone wants to argue for converting the unparsed references to list items as well.