### PR TITLE
pkp/pkp-lib#4350: Capture current Crossref deposit status before update.

### DIFF
--- a/plugins/importexport/crossref/CrossrefInfoSender.inc.php
+++ b/plugins/importexport/crossref/CrossrefInfoSender.inc.php
@@ -126,15 +126,15 @@ class CrossrefInfoSender extends ScheduledTask {
 		$plugin = $this->_plugin;
 		$objectsToBeDeposited = array();
 		foreach ($unregisteredObjects as $object) {
-			$plugin->updateDepositStatus($journal, $object);
 			// get the current object status
 			$currentStatus = $object->getData($plugin->getDepositStatusSettingName());
-			// deposit only not submitted objects
-			if (!$currentStatus) {
-				array_push($objectsToBeDeposited, $object);
-			}
+			$plugin->updateDepositStatus($journal, $object);
 			// check if the new status after the update == failed to notify the users
 			$newStatus = $object->getData($plugin->getDepositStatusSettingName());
+			// deposit only not submitted objects
+			if (!$newStatus) {
+				array_push($objectsToBeDeposited, $object);
+			}
 			if (!$notify && $newStatus == CROSSREF_STATUS_FAILED && $currentStatus != CROSSREF_STATUS_FAILED) {
 				$notify = true;
 			}


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/4350
this is a cherry-pick https://github.com/pkp/ojs/pull/2232