### PR TITLE
pkp/pkp-lib#4366: Exclude archived Published Articles when fetching by setting.

### DIFF
--- a/classes/article/PublishedArticleDAO.inc.php
+++ b/classes/article/PublishedArticleDAO.inc.php
@@ -480,6 +480,7 @@ class PublishedArticleDAO extends DAO {
 			$params[] = (int) $journalId;
 			$sql .= ' AND a.journal_id = ?';
 		}
+		$sql .= ' AND a.status <> ' . STATUS_ARCHIVED;
 		$sql .= ' ORDER BY pa.issue_id, a.article_id';
 		$result =& $this->retrieve($sql, $params);
 


### PR DESCRIPTION
The exclusion of archived articles in the Published Articles DAO should probably be in all `get` methods, but this one in particular because of pkp/pkp-lib#4366.