### PR TITLE
Add citation_reference tags to GoogleSchorlaPlugin output

### DIFF
--- a/plugins/generic/googleScholar/GoogleScholarPlugin.inc.php
+++ b/plugins/generic/googleScholar/GoogleScholarPlugin.inc.php
@@ -117,6 +117,24 @@ class GoogleScholarPlugin extends GenericPlugin {
 			}
 		}
 
+		// Citations
+		$outputReferences = array();
+		$citationDao = DAORegistry::getDAO('CitationDAO');
+		$parsedCitations = $citationDao->getBySubmissionId($article->getId());
+		if ($parsedCitations->getCount()){
+			while ($citation = $parsedCitations->next()) {
+				$outputReferences[] = $citation->getRawCitation();
+			}
+		}
+		HookRegistry::call('GoogleScholarPlugin::references', array(&$outputReferences, $article->getId()));
+
+		if (!empty($outputReferences)){
+			$i=0;
+			foreach ($outputReferences as $outputReference) {
+				$templateMgr->addHeader('googleScholarReference' . $i++, '<meta name="citation_reference" content="' . htmlspecialchars($outputReference) . '"/>');
+			}
+		}
+
 		return false;
 	}
 

--- a/plugins/generic/googleScholar/GoogleScholarPlugin.inc.php
+++ b/plugins/generic/googleScholar/GoogleScholarPlugin.inc.php
@@ -117,7 +117,7 @@ class GoogleScholarPlugin extends GenericPlugin {
 			}
 		}
 
-		// Citations
+		// citation_refence
 		$outputReferences = array();
 		$citationDao = DAORegistry::getDAO('CitationDAO');
 		$parsedCitations = $citationDao->getBySubmissionId($article->getId());


### PR DESCRIPTION
Show unstructured citation_reference metatags with GoogleScholar Plugin. Also add a hook that allows other plugins dealing with references to add structured references if needed.

https://github.com/pkp/pkp-lib/issues/4619