### PR TITLE
Replace call to deprecated split() function with explode() for PHP 7

### DIFF
--- a/classes/manager/form/setup/JournalSetupStep5Form.inc.php
+++ b/classes/manager/form/setup/JournalSetupStep5Form.inc.php
@@ -234,7 +234,7 @@ class JournalSetupStep5Form extends JournalSetupForm {
 		// Save the block plugin layout settings.
 		$blockVars = array('blockSelectLeft', 'blockUnselected', 'blockSelectRight');
 		foreach ($blockVars as $varName) {
-			$$varName = array_map('urldecode', split(' ', Request::getUserVar($varName)));
+			$$varName = array_map('urldecode', explode(' ', Request::getUserVar($varName)));
 		}
 
 		$plugins =& PluginRegistry::loadCategory('blocks');


### PR DESCRIPTION
Hello

I'm running OJS 2.4.8-4 on Ubuntu 16.04, with PHP 7.0, and noticed that there is a call to split() in the code for step 5 of the setup page. It causes any changes to the existing configuration on that page to fail with a fatal error.

This change replaces the call to split() with a call to explode().