### PR TITLE
Remove reference in call to callbackBaseUrl to avoid warning

### DIFF
--- a/tools/rebuildSearchIndex.php
+++ b/tools/rebuildSearchIndex.php
@@ -74,7 +74,7 @@ class rebuildSearchIndex extends CommandLineTool {
 	 * when constructing galley/supp file download URLs.
 	 * @see PKPRequest::getBaseUrl()
 	 */
-	function callbackBaseUrl($hookName, &$params) {
+	function callbackBaseUrl($hookName, $params) {
 		$baseUrl =& $params[0];
 		$baseUrl = Config::getVar('general', 'base_url');
 		return true;


### PR DESCRIPTION
We are getting a PHP warning (PHP Warning:  Parameter 2 to rebuildSearchIndex::callbackBaseUrl() expected to be a reference, value given in/lib/pkp/classes/plugins/HookRegistry.inc.php on line 107
) when runing rebuildSearchIndex therefor I have removed the reference in the call to callbackBaseUrl  in tools/rebuildSearchIndex.php