### PR TITLE
#4666: Deleting galley does not remove it from search index

### DIFF
--- a/controllers/grid/articleGalleys/ArticleGalleyGridHandler.inc.php
+++ b/controllers/grid/articleGalleys/ArticleGalleyGridHandler.inc.php
@@ -308,6 +308,12 @@ class ArticleGalleyGridHandler extends GridHandler {
 			);
 		}
 
+		//inform search index that file has been deleted
+		import('classes.search.ArticleSearchIndex');
+		$articleSearchIndex = new ArticleSearchIndex();
+		$articleSearchIndex->submissionFileDeleted($galley->getSubmissionId());
+		$articleSearchIndex->articleChangesFinished();
+
 		return DAO::getDataChangedEvent($galley->getId());
 	}
 


### PR DESCRIPTION
If I delete Galley file from Submission, it now get's deleted from search index. But I am not sure if this is the best position to inform the searchindexer that a file has been deleted. Maybe from within ArticleGalleyDAO->deleteObject?