### PR TITLE
Added call_hooks for AdditionalFilters and PreResults

### DIFF
--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -58,12 +58,15 @@
 				</label>
 				<input type="text" for="authors" name="authors" value="{$authors|escape}">
 			</div>
+			{call_hook name="Templates::Search::SearchResults::AdditionalFilters"}
 		</fieldset>
 
 		<div class="submit">
 			<button class="submit" type="submit">{translate key="common.search"}</button>
 		</div>
 	</form>
+
+	{call_hook name="Templates::Search::SearchResults::PreResults"}
 
 	{* Search results, finally! *}
 	<div class="search_results">


### PR DESCRIPTION
@asmecher 
Hi Alec,
In order to be able to show Spellingsuggestion and  Additional Filters from facets, I added two call_hooks to search.tpl. Would be great if they could be added to OJS 3.1.2-1 release, so the Lucene Plugin could function from that release on when it gets released.