### PR TITLE
#4686: SearchIndexing: Submissions marked dirty are immediately marke…

### DIFF
--- a/controllers/modals/submissionMetadata/form/IssueEntrySubmissionReviewForm.inc.php
+++ b/controllers/modals/submissionMetadata/form/IssueEntrySubmissionReviewForm.inc.php
@@ -79,13 +79,13 @@ class IssueEntrySubmissionReviewForm extends SubmissionMetadataViewForm {
 		$publishedArticle = $publishedArticleDao->getByArticleId($submission->getId(), null, false);
 		$isExistingEntry = $publishedArticle?true:false;
 
+		$submissionDao->updateObject($submission);
+
 		if ($isExistingEntry) {
 			// Update the search index for this published article.
 			import('classes.search.ArticleSearchIndex');
 			ArticleSearchIndex::articleMetadataChanged($submission);
 		}
-
-		$submissionDao->updateObject($submission);
 	}
 }
 


### PR DESCRIPTION
…d clean again

Make call to articleMetadataChanged after updating submission resolves the issue.