### PR TITLE
Remove unused arguments from initData()

### DIFF
--- a/classes/manager/form/UserManagementForm.inc.php
+++ b/classes/manager/form/UserManagementForm.inc.php
@@ -138,7 +138,7 @@ class UserManagementForm extends Form {
 	/**
 	 * Initialize form data from current user profile.
 	 */
-	function initData(&$args, &$request) {
+	function initData() {
 		if (isset($this->userId)) {
 			$userDao =& DAORegistry::getDAO('UserDAO');
 			$user =& $userDao->getById($this->userId);


### PR DESCRIPTION
Hello,

We are running OJS 2.4.8 on PHP7.2. When I go to either institutional or individual subscriptions and attempt to "create new user" (Subscription Manager > individual subscriptions OR institutional subscriptions > create new subscription > create new user), I get a Fatal error:
```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function UserManagementForm::initData(), 0 passed in /var/www/ojs/pages/subscriptionManager/SubscriptionManagerHandler.inc.php on line 368 and exactly 2 expected in /var/www/ojs/classes/manager/form/UserManagementForm.inc.php:141 Stack trace: #0 /var/www/ojs/pages/subscriptionManager/SubscriptionManagerHandler.inc.php(368): UserManagementForm->initData() #1 /var/www/ojs/lib/pkp/classes/core/PKPRouter.inc.php(362): SubscriptionManagerHandler->createUser(Array, Object(Request)) #2 /var/www/ojs/lib/pkp/classes/core/PKPPageRouter.inc.php(220): PKPRouter->_authorizeInitializeAndCallRequest(Array, Object(Request), Array, false) #3 /var/www/ojs/lib/pkp/classes/core/Dispatcher.inc.php(134): PKPPageRouter->route(Object(Request)) #4 /var/www/ojs/lib/pkp/classes/core/PKPA in /var/www/ojs/classes/manager/form/UserManagementForm.inc.php on line 141
```
Both arguments of initData() are not used in the function. Remove them seems to fix the problem.