### PR TITLE
Fix published article cache collision bug

### DIFF
--- a/classes/article/PublishedArticleDAO.inc.php
+++ b/classes/article/PublishedArticleDAO.inc.php
@@ -301,7 +301,7 @@ class PublishedArticleDAO extends ArticleDAO {
 			$cache = $this->_getPublishedArticleCache();
 			$returner = $cache->get($articleId);
 			if ($returner && $journalId != null && $journalId != $returner->getJournalId()) $returner = null;
-			return $returner;
+			if (!empty($returner)) return $returner;
 		}
 
 		$params = $this->getFetchParameters();
@@ -344,7 +344,7 @@ class PublishedArticleDAO extends ArticleDAO {
 			$cache = $this->_getPublishedArticleCache();
 			$returner = $cache->get($pubId);
 			if ($returner && $journalId != null && $journalId != $returner->getJournalId()) $returner = null;
-			return $returner;
+			if (!empty($returner)) return $returner;
 		}
 
 		$publishedArticle = null;


### PR DESCRIPTION
Problem description:
- We have a multi-journal installation. Object cache using memcached.
- We are looking for an article published with id 109 (journal 7).
- A cached article is returned with pub-id::published-id = 109 (journal 571).
- The journals do not match, so null is setted and returned, causing an error 500.

The workaround is to add "if (!empty($returner))" to the return forcing the recovery of the article when the cache fails.