### PR TITLE
#4800: Allow Lucene Plugin to add Syntax-Instructions to search page

### DIFF
--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -90,6 +90,9 @@
 			{page_links anchor="results" iterator=$results name="search" query=$query searchJournal=$searchJournal authors=$authors title=$title abstract=$abstract galleyFullText=$galleyFullText discipline=$discipline subject=$subject type=$type coverage=$coverage indexTerms=$indexTerms dateFromMonth=$dateFromMonth dateFromDay=$dateFromDay dateFromYear=$dateFromYear dateToMonth=$dateToMonth dateToDay=$dateToDay dateToYear=$dateToYear orderBy=$orderBy orderDir=$orderDir}
 		</div>
 	{/if}
+
+	{* Search Syntax Instructions *}
+	{block name=searchSyntaxInstructions}{/block}
 </div><!-- .page -->
 
 {include file="frontend/components/footer.tpl"}


### PR DESCRIPTION
Added block for SearchSyntaxInstructions