### PR TITLE
pkp/pkp-lib#4021 Use full titles in DC.Title (meta), Title (OAI DC), and title (DataCite/CrossRef) formats

### DIFF
--- a/plugins/generic/dublinCoreMeta/DublinCoreMetaPlugin.inc.php
+++ b/plugins/generic/dublinCoreMeta/DublinCoreMetaPlugin.inc.php
@@ -124,9 +124,9 @@ class DublinCoreMetaPlugin extends GenericPlugin {
 			}
 		}
 
-		$templateMgr->addHeader('dublinCoreTitle', '<meta name="DC.Title" content="' . htmlspecialchars($article->getTitle($article->getLocale())) . '"/>');
+		$templateMgr->addHeader('dublinCoreTitle', '<meta name="DC.Title" content="' . htmlspecialchars($article->getFullTitle($article->getLocale())) . '"/>');
 		$i=0;
-		foreach ($article->getTitle(null) as $locale => $title) {
+		foreach ($article->getFullTitle(null) as $locale => $title) {
 			if ($locale == $article->getLocale()) continue;
 			$templateMgr->addHeader('dublinCoreAltTitle' . $i++, '<meta name="DC.Title.Alternative" xml:lang="' . htmlspecialchars(substr($locale, 0, 2)) . '" content="' . htmlspecialchars($title) . '"/>');
 		}

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -216,7 +216,7 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 			if ($galleyFile) $contentItemNode->appendChild($this->createExtentNode($doc, $galleyFile));
 		}
 		// Article Title (mandatory)
-		$titles = $this->getTranslationsByPrecedence($article->getTitle(null), $objectLocalePrecedence);
+		$titles = $this->getTranslationsByPrecedence($article->getFullTitle(null), $objectLocalePrecedence);
 		assert(!empty($titles));
 		foreach ($titles as $locale => $title) {
 			$contentItemNode->appendChild($this->createTitleNode($doc, $locale, $title, O4DOI_TITLE_TYPE_FULL));

--- a/plugins/metadata/dc11/filter/Dc11SchemaArticleAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaArticleAdapter.inc.php
@@ -80,7 +80,7 @@ class Dc11SchemaArticleAdapter extends MetadataDataObjectAdapter {
 		$dc11Description = $this->instantiateMetadataDescription();
 
 		// Title
-		$this->_addLocalizedElements($dc11Description, 'dc:title', $article->getTitle(null));
+		$this->_addLocalizedElements($dc11Description, 'dc:title', $article->getFullTitle(null));
 
 		// Creator
 		$authors = $article->getAuthors();


### PR DESCRIPTION
Use full titles (including subtitles) for the following metadata extracts:
- DC.Title (DC meta tag plugin)
- Dublin Core title (OAI)
- DataCite/CrossRef