### PR TITLE
Corrected invalid LOCKSS permission statement for non-CLOCKSS applications

### DIFF
--- a/templates/gateway/lockss.tpl
+++ b/templates/gateway/lockss.tpl
@@ -117,7 +117,7 @@
 
 
 <a href="http://www.lockss.org/"><img src="{$baseUrl}/templates/images/lockss.gif" style="border: 0;" alt="LOCKSS" /></a>
-<p>LOCKSS system has permission to ingest, preserve, and serve this Archival Unit.</p>
+<p>LOCKSS system has permission to collect, preserve, and serve this Archival Unit.</p>
 
 <p><a href="http://pkp.sfu.ca/"><img src="{$baseUrl}/lib/pkp/templates/images/pkp.gif" style="border: 0;" alt="The Public Knowledge Project" /></a></p>
 <p>Open Journal Systems was developed by the Public Knowledge Project.</p>


### PR DESCRIPTION
The verbiage in the LOCKSS permission template for non-CLOCKSS applications was copied from the template for CLOCKSS applications, with "CLOCKSS" replaced by "LOCKSS", resulting in invalid LOCKSS manifest pages (which do not grant permission to crawl).

We are submitting this pull request on the master branch; should we also submit one to other branches for bugfix releases?