### PR TITLE
pkp/pkp-lib#3948: Ensure RSS2 validates with RDF namespace and author/creator distinction

### DIFF
--- a/plugins/generic/webFeed/templates/rss2.tpl
+++ b/plugins/generic/webFeed/templates/rss2.tpl
@@ -9,7 +9,7 @@
  *
  *}
 <?xml version="1.0" encoding="{$defaultCharset|escape}"?>
-<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/">
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<channel>
 		{* required elements *}
 		<title>{$journal->getLocalizedName()|strip|escape:"html"}</title>
@@ -61,7 +61,8 @@
 					<description>{$article->getLocalizedAbstract()|strip|escape:"html"}</description>
 
 					{* optional elements *}
-					<author>{$article->getAuthorString(false)|escape:"html"}</author>
+					{* <author/> *}
+					<dc:creator>{$article->getAuthorString(false)|escape:"html"}</dc:creator>
 					{* <category/> *}
 					{* <comments/> *}
 					{* <source/> *}


### PR DESCRIPTION
This addresses strict validation for RSS2: 
* RDF namespace was missing. (pkp/pkp-lib#3948)
* RSS `author` element should be an email or emails; `dc:creator` can be used for names; both should not be used together.