### PR TITLE
pkp/pkp-lib#2294: Update frontend search to use GET instead of POST

### DIFF
--- a/templates/frontend/components/searchForm_simple.tpl
+++ b/templates/frontend/components/searchForm_simple.tpl
@@ -10,8 +10,13 @@
  * @uses $searchQuery string Previously input search query
  *}
 {if !$currentJournal || $currentJournal->getData('publishingMode') != $smarty.const.PUBLISHING_MODE_NONE}
-	<form class="pkp_search" action="{url page="search" op="search"}" method="post" role="search">
+	{capture name="searchFormUrl"}{url page="search" op="search" escape=false}{/capture}
+	{$smarty.capture.searchFormUrl|parse_url:$smarty.const.PHP_URL_QUERY|parse_str:$formUrlParameters}
+	<form class="pkp_search" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}" method="get" role="search">
 		{csrf}
+		{foreach from=$formUrlParameters key=paramKey item=paramValue}
+			<input type="hidden" name="{$paramKey|escape}" value="{$paramValue|escape}"/>
+		{/foreach}
 		{block name=searchQuerySimple}
 			<input name="query" value="{$searchQuery|escape}" type="text" aria-label="{translate|escape key="common.searchQuery"}">
 		{/block}

--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -22,8 +22,13 @@
 
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="common.search"}
 
-	<form class="cmp_form" method="post" action="{url op="search"}">
+	{capture name="searchFormUrl"}{url op="search" escape=false}{/capture}
+	{$smarty.capture.searchFormUrl|parse_url:$smarty.const.PHP_URL_QUERY|parse_str:$formUrlParameters}
+	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}">
 		{csrf}
+		{foreach from=$formUrlParameters key=paramKey item=paramValue}
+			<input type="hidden" name="{$paramKey|escape}" value="{$paramValue|escape}"/>
+		{/foreach}
 
 		{* Repeat the label text just so that screen readers have a clear
 		   label/input relationship *}


### PR DESCRIPTION
Resolves pkp/pkp-lib#2294 for the default theme, while considering the increasingly unlikely case of https://github.com/pkp/pkp-lib/issues/2300.  Other themes may need to be updated.