### PR TITLE
Correcting two emails' descriptions

### DIFF
--- a/locale/en_US/emailTemplates.xml
+++ b/locale/en_US/emailTemplates.xml
@@ -348,7 +348,7 @@ Review Guidelines<br />
 We have decided at this point to cancel our request for you to review the submission, &quot;{$submissionTitle},&quot; for {$contextName}. We apologize for any inconvenience this may cause you and hope that we will be able to call on you to assist with this journal's review process in the future.<br />
 <br />
 If you have any questions, please contact me.]]></body>
-		<description>This email is sent by the Section Editor to a Reviewer who has a submission review in progress to notify them that a cancelled review has been reinstated.</description>
+		<description>This email is sent by the Section Editor to a Reviewer who has a submission review in progress to notify them that the review has been cancelled.</description>
 	</email_text>
 	<email_text key="REVIEW_REINSTATE">
 		<subject>Request for Review Reinstated</subject>
@@ -357,7 +357,7 @@ If you have any questions, please contact me.]]></body>
 We would like to reinstate our request for you to review the submission, &quot;{$submissionTitle},&quot; for {$contextName}. We hope that you will be able to assist with this journal's review process.<br />
 <br />
 If you have any questions, please contact me.]]></body>
-		<description>This email is sent by the Section Editor to a Reviewer who has a submission review in progress to notify them that the review has been cancelled.</description>
+		<description>This email is sent by the Section Editor to a Reviewer who has a submission review in progress to notify them that a cancelled review has been reinstated.</description>
 	</email_text>
 	<email_text key="REVIEW_CONFIRM">
 		<subject>Able to Review</subject>


### PR DESCRIPTION
Description text for "REVIEW_REINSTATE" email message should exchange places with the description text for "REVIEW_CANCEL" email message.