### PR TITLE
[Feature] XML File create and upload support

### DIFF
--- a/controllers/tab/workflow/WorkflowTabHandler.inc.php
+++ b/controllers/tab/workflow/WorkflowTabHandler.inc.php
@@ -15,17 +15,112 @@
 
 // Import the base Handler.
 import('lib.pkp.controllers.tab.workflow.PKPWorkflowTabHandler');
+import('lib.pkp.classes.submission.SubmissionFile');
 
 class WorkflowTabHandler extends PKPWorkflowTabHandler {
+
+
+	var $_uploaderRoles;
+
+	/**
+	 * Constructor
+	 */
+	function __construct() {
+
+		parent::__construct();
+
+		AppLocale::requireComponents(
+			LOCALE_COMPONENT_APP_COMMON,
+			LOCALE_COMPONENT_APP_EDITOR,
+			LOCALE_COMPONENT_APP_MANAGER,
+			LOCALE_COMPONENT_PKP_SUBMISSION,
+			LOCALE_COMPONENT_APP_SUBMISSION
+
+		);
+
+		$this->addRoleAssignment(array(ROLE_ID_SUB_EDITOR, ROLE_ID_MANAGER, ROLE_ID_ASSISTANT),
+			array('createFile', 'deleteFile', 'displayFileCreateForm', 'displayFileUploadForm', 'finishFileSubmission', 'uploadFile'));
+	}
+
+	//
+	// Implement template methods from PKPHandler
+	//
+	/**
+	 * @copydoc PKPHandler::initialize()
+	 */
+	function initialize($request) {
+		parent::initialize($request);
+		// Set the uploader roles (if given).
+		$uploaderRoles = $request->getUserVar('uploaderRoles');
+		if (!empty($uploaderRoles)) {
+			$this->_uploaderRoles = array();
+			$uploaderRoles = explode('-', $uploaderRoles);
+			foreach ($uploaderRoles as $uploaderRole) {
+				if (!is_numeric($uploaderRole)) fatalError('Invalid uploader role!');
+				$this->_uploaderRoles[] = (int)$uploaderRole;
+			}
+		}
+	}
+
+
+	// Getters and Setters
+	//
+	/*
+	* Get the workflow stage file storage that
+	* we upload files to. One of the SUBMISSION_FILE_*
+	* constants.
+	* @return integer
+	*/
+	function getFileStage() {
+		return SUBMISSION_FILE_PRODUCTION_READY;
+	}
+
+	/**
+	 * The submission to which we upload files.
+	 * @return Submission
+	 */
+
+	function getSubmission() {
+		return $this->getAuthorizedContextObject(ASSOC_TYPE_SUBMISSION);
+	}
+
+	/**
+	 * Get the authorized workflow stage.
+	 * @return integer One of the WORKFLOW_STAGE_ID_* constants.
+	 */
+	function getStageId() {
+		return $this->getAuthorizedContextObject(ASSOC_TYPE_WORKFLOW_STAGE);
+	}
+
+	/**
+	 * Get the uploader roles.
+	 * @return array
+	 */
+	function getUploaderRoles() {
+		return $this->_uploaderRoles;
+	}
 
 	/**
 	 * @copydoc PKPWorkflowTabHandler::fetchTab
 	 */
 	function fetchTab($args, $request) {
-		$this->setupTemplate($request);
 		$templateMgr = TemplateManager::getManager($request);
-		$stageId = $this->getAuthorizedContextObject(ASSOC_TYPE_WORKFLOW_STAGE);
 		$submission = $this->getAuthorizedContextObject(ASSOC_TYPE_SUBMISSION);
+		$stageId = $this->getStageId();
+		$templateMgr->assign(array(
+			'submissionId' => $this->getSubmission()->getId(),
+			'stageId' => $stageId,
+			'uploaderRoles' => implode('-', (array)$this->getUploaderRoles()),
+			'fileStage' => $this->getStageId(),
+			'isReviewer' => '',
+			'revisionOnly' => '',
+			'reviewRoundId' => '',
+			'revisedFileId' => '',
+			'assocType' => '',
+			'assocId' => '',
+			'dependentFilesOnly' => '',
+		));
+
 		switch ($stageId) {
 			case WORKFLOW_STAGE_ID_PRODUCTION:
 				$dispatcher = $request->getDispatcher();
@@ -44,7 +139,27 @@ class WorkflowTabHandler extends PKPWorkflowTabHandler {
 					__('editor.article.schedulePublication')
 				);
 				$templateMgr->assign('schedulePublicationLinkAction', $schedulePublicationLinkAction);
+
+				$schedulePublicationLinkAction = $this->displaySchedulePublicationLinkAction($request);
+				$templateMgr->assign('schedulePublicationLinkAction', $schedulePublicationLinkAction);
+
+				$xmlFileCreateLinkAction = $this->xmlFileCreateLinkAction($request);
+				$templateMgr->assign('xmlFileCreateLinkAction', $xmlFileCreateLinkAction);
+
+				$xmlFileUploadLinkAction = $this->xmlFileUploadLinkAction($request);
+				$templateMgr->assign('xmlFileUploadLinkAction', $xmlFileUploadLinkAction);
+
+
+				// Get if jatsTemplatePlugin is enabled
+
+				$pluginSettingsDao = DAORegistry::getDAO('PluginSettingsDAO');
+				$context = $request->getContext();
+				if ($pluginSettingsDao->settingExists($context->getId(), 'jatstemplateplugin', 'enabled')) {
+					$isJatsTemplatePluginEnabled = $pluginSettingsDao->getSetting($context->getId(), 'jatstemplateplugin', 'enabled');
+					$templateMgr->assign('isJatsTemplatePluginEnabled', $isJatsTemplatePluginEnabled);
+				}
 				break;
+
 		}
 		return parent::fetchTab($args, $request);
 	}
@@ -65,6 +180,244 @@ class WorkflowTabHandler extends PKPWorkflowTabHandler {
 			NOTIFICATION_LEVEL_TRIVIAL => array()
 		);
 	}
+
+	/**
+	 * @param $args array
+	 * @param $request
+	 * @return JSONMessage JSON object
+	 */
+	function displayFileUploadForm($args, $request) {
+		import('lib.pkp.controllers.tab.workflow.form.FileUploadFormXML');
+		$submission = $this->getSubmission();
+		$fileForm = new FileUploadFormXML($request, $submission->getId(), $this->getStageId(), $this->getUploaderRoles(), $this->getFileStage());
+		$fileForm->initData();
+
+		return new JSONMessage(true, $fileForm->fetch($request));
+	}
+
+
+	/**
+	 * @param $args array
+	 * @param $request
+	 * @return JSONMessage JSON object
+	 */
+	function displayFileCreateForm($args, $request) {
+		import('lib.pkp.controllers.tab.workflow.form.FileCreateFormXML');
+		$fileForm = new FileCreateFormXML($request, $this->getSubmission()->getId(), $this->getStageId(), $this->getFileStage());
+		$fileForm->initData();
+
+		return new JSONMessage(true, $fileForm->fetch($request));
+	}
+
+	/**
+	 * @param $request
+	 * @return LinkAction
+	 */
+	public function xmlFileUploadLinkAction($request) {
+		import('lib.pkp.classes.linkAction.request.AjaxModal');
+		$dispatcher = $request->getDispatcher();
+
+		$actionArgs = array('submissionId' => $this->getSubmission()->getId(), 'stageId' => $this->getStageId(), 'fileStage' => $this->getFileStage());
+		$xmlFileUploadLinkAction = new LinkAction(
+			'xmlFileUpload',
+			new AjaxModal(
+				$dispatcher->url(
+					$request, ROUTE_COMPONENT, null, null, 'displayFileUploadForm', null,
+					$actionArgs
+				),
+				__('submission.upload.productionReadyXML.description')
+			),
+			__('submission.upload.productionReadyXML')
+		);
+		return $xmlFileUploadLinkAction;
+	}
+
+
+	/**
+	 * @param $request
+	 * @return LinkAction
+	 */
+	public function xmlFileCreateLinkAction($request) {
+
+		$dispatcher = $request->getDispatcher();
+		$actionArgs = array('submissionId' => $this->getSubmission()->getId(), 'stageId' => $this->getStageId(), 'fileStage' => $this->getFileStage());
+
+		import('lib.pkp.classes.linkAction.request.AjaxModal');
+		$xmlFileCreateLinkAction = new LinkAction(
+			'xmlFileUpload',
+			new AjaxModal(
+				$dispatcher->url(
+					$request, ROUTE_COMPONENT, null,
+					'tab.workflow.WorkflowTabHandler',
+					'displayFileCreateForm', null,
+					$actionArgs
+				),
+				__('submission.create.productionReadyXML.description')
+			),
+			__('submission.create.productionReadyXML')
+		);
+		return $xmlFileCreateLinkAction;
+	}
+
+	/**
+	 * Creates XML file from jats template
+	 *
+	 * @param $args
+	 * @param $request
+	 * @return JSONMessage
+	 */
+
+	public function createFile($args, $request) {
+
+		if ($request->checkCSRF()) {
+			$doc = $this->_getJatsTemplate($request);
+			$user = $request->getUser();
+
+			$originalFileName = (strpos($args['fileName'], 'xml', -3)) ? $args['fileName'] : $args['fileName'] . '.xml';
+
+			$tempFileName = tempnam(sys_get_temp_dir(), 'jatsTemplateXML');
+			file_put_contents($tempFileName, $doc->saveXML());
+
+
+			$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO');
+
+			import('lib.pkp.classes.submission.Genre');
+			$submissionFile = $submissionFileDao->newDataObjectByGenreId(GENRE_CATEGORY_DOCUMENT);
+			$submissionFile->setSubmissionId($this->getSubmission()->getId());
+			$submissionFile->setSubmissionLocale($this->getSubmission()->getLocale());
+			$submissionFile->setGenreId(GENRE_CATEGORY_DOCUMENT);
+			$submissionFile->setFileStage(SUBMISSION_FILE_PRODUCTION_READY);
+			$submissionFile->setDateUploaded(Core::getCurrentDate());
+			$submissionFile->setDateModified(Core::getCurrentDate());
+			$submissionFile->setUploaderUserId($user->getId());
+			$submissionFile->setFileSize(filesize($tempFileName));
+			$submissionFile->setFileType('text/xml');
+			$submissionFile->setOriginalFileName($originalFileName);
+			$submissionFile->setName($originalFileName, null);
+			$submissionFileDao->insertObject($submissionFile, $tempFileName, false);
+
+			return DAO::getDataChangedEvent();
+		} else {
+			return new JSONMessage(false);
+		}
+
+	}
+
+	/***
+	 * @param $request
+	 * @return LinkAction
+	 */
+	protected function displaySchedulePublicationLinkAction($request) {
+		import('lib.pkp.classes.linkAction.request.AjaxModal');
+		$dispatcher = $request->getDispatcher();
+		$schedulePublicationLinkAction = new LinkAction(
+			'schedulePublication',
+			new AjaxModal(
+				$dispatcher->url(
+					$request, ROUTE_COMPONENT, null,
+					'tab.issueEntry.IssueEntryTabHandler',
+					'publicationMetadata', null,
+					array('submissionId' => $this->getSubmission()->getId(), 'stageId' => $this->getStageId())
+				),
+				__('submission.issueEntry.publicationMetadata')
+			),
+			__('editor.article.scheduleForPublication')
+		);
+		return $schedulePublicationLinkAction;
+	}
+
+	/**
+	 *
+	 * @param $args
+	 * @param $request
+	 * @return JSONMessage
+	 */
+	function uploadFile($args, $request) {
+		import('lib.pkp.controllers.tab.workflow.form.FileUploadFormXML');
+
+		$submissionId = $this->getSubmission()->getId();
+		$uploadForm = new FileUploadFormXML($request, $submissionId, $this->getStageId(), $this->getUploaderRoles(), $this->getFileStage());
+
+		$uploadForm->readInputData();
+		if ($uploadForm->validate()) {
+			$uploadedFile = $uploadForm->execute();
+			if (!is_a($uploadedFile, 'SubmissionFile')) {
+			} else {
+
+				$revisionId = 1;
+
+				$templateMgr = TemplateManager::getManager($request);
+				$csrfToken = $request->getSession()->getCSRFToken();
+				$templateMgr->assign(array(
+						'csrfToken' >= $csrfToken,
+						'fileId' >= $uploadedFile->getFileId(),
+						'revision' >= $revisionId,
+						'submissionId' >= $submissionId,
+						'uploaderRoles' >= $this->getUploaderRoles(),
+						'stageId' >= $this->getStageId(),
+					)
+				);
+
+				import('lib.pkp.controllers.tab.workflow.form.FileUploadConfirmationForm');
+				$fileUploadConfirmation = new FileUploadConfirmationForm($request, $uploadedFile->getFileId(), $revisionId, $submissionId, $this->getStageId(), $this->getFileStage(), $request->getSession()->getCSRFToken());
+				$fileUploadConfirmation->initData();
+
+				return new JSONMessage(true, $fileUploadConfirmation->fetch($request), '0');
+
+			}
+			return new JSONMessage(false, __('common.uploadFailed'));
+
+		} else {
+			return new JSONMessage(false, __('common.uploadFailed'));
+		}
+	}
+
+	function finishFileSubmission($args, $request) {
+		$submission = $this->getSubmission();
+
+		$fileId = (int)$request->getUserVar('fileId');
+		$revisionId = 1;
+
+		$templateMgr = TemplateManager::getManager($request);
+
+		$templateMgr->assign('csrfToken', $request->getSession()->getCSRFToken());
+		$templateMgr->assign('fileId', $fileId);
+		$templateMgr->assign('revision', $revisionId);
+		$templateMgr->assign('submissionId', $submission->getId());
+		$templateMgr->assign('stageId', $this->getStageId());
+
+		return DAO::getDataChangedEvent();
+	}
+
+	/**
+	 * @param $request
+	 * @return $doc
+	 */
+	protected function _getJatsTemplate($request) {
+		$doc = null;
+		$this->validate(null, $request);
+		$journal = $request->getContext();
+		$sectionDao = DAORegistry::getDAO('SectionDAO');
+		$section = $sectionDao->getById($this->getSubmission()->getSectionId(), $journal->getId(), true);
+		$article = $this->getSubmission();
+		$galleyDao = DAORegistry::getDAO('ArticleGalleyDAO');
+		$galleys = $galleyDao->getBySubmissionId($article->getId());
+		$issueDao = DAORegistry::getDAO('IssueDAO');
+		$issue = $issueDao->getCurrent($journal->getId(), true);
+
+		import('classes.oai.ojs.OAIDAO');
+		$record = new OAIRecord();
+
+		$record->setData('article', $article);
+		$record->setData('journal', $journal);
+		$record->setData('section', $section);
+		$record->setData('galleys', $galleys);
+		$record->setData('issue', $issue);
+
+		HookRegistry::call('OAIMetadataFormat_JATS::findJats', array(&$this, &$record, [], &$doc));
+		return $doc;
+	}
+
 }
 
 

--- a/templates/controllers/tab/workflow/form/fileCreateFormXML.tpl
+++ b/templates/controllers/tab/workflow/form/fileCreateFormXML.tpl
@@ -1,0 +1,31 @@
+{**
+ * templates/controllers/tab/workflow/form/fileCreateFormXML.tpl
+ *
+ * Copyright (c) 2014-2019 Simon Fraser University
+ * Copyright (c) 2003-2019 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Xml file create form.
+ *}
+{* generate a unique ID for the form *}
+{assign var="createFormXML" value="createFormXML"|uniqid|escape}
+<script type="text/javascript">
+	// Attach the file upload form handler.
+	$(function() {ldelim}
+		$('#{$createFormXML}').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+
+		{rdelim});
+</script>
+
+
+<form id="{$createFormXML}" class="pkp_form" action="{url op="createFile" submissionId=$submissionId stageId=$stageId fileStage=$fileStage}" method="post">
+	{csrf}
+
+	{fbvFormArea id="extraFileData"}
+		{fbvFormSection title="common.fileName"}
+			{fbvElement type="text" label="common.fileName" required=true id="fileName" value=$fileName}
+		{/fbvFormSection}
+	{/fbvFormArea}
+
+	{fbvFormButtons}
+</form>

--- a/templates/controllers/tab/workflow/form/fileSubmissionComplete.tpl
+++ b/templates/controllers/tab/workflow/form/fileSubmissionComplete.tpl
@@ -1,0 +1,34 @@
+{**
+ * templates/controllers/tab/workflow/form/fileSubmissionComplete.tpl
+ *
+ * Copyright (c) 2014-2019 Simon Fraser University
+ * Copyright (c) 2003-2019 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ *}
+{assign var=finishXMLSubmissionForm value="finishXMLSubmissionForm"|uniqid}
+
+<div id="finishXMLSubmission" class="pkp_helpers_text_center">
+	<h2>{translate key="submission.submit.fileAdded"}</h2>
+
+	<br>
+	<script>
+		// Attach the handler.
+		$(function() {ldelim}
+			$('#{$finishXMLSubmissionForm}').pkpHandler(
+					'$.pkp.controllers.form.CancelActionAjaxFormHandler',
+					{ldelim}
+						csrfToken: {csrf type=json},
+						cancelUrl: {url|json_encode component="api.file.ManageFileApiHandler" op="deleteFile" fileId=$fileId submissionId=$submissionId revision=$revision stageId=$stageId fileStage=$fileStage csrfToken=$csrfToken suppressNotification=true escape=false},
+
+		{rdelim}
+			);
+			{rdelim});
+	</script>
+
+	<form id="{$finishXMLSubmissionForm}" class="pkp_form" action="{url op="finishFileSubmission" fileId=$fileId submissionId=$submissionId revision=$revision stageId=$stageId fileStage=$fileStage}" method="post">
+		{csrf}
+		{fbvFormButtons}
+	</form>
+
+</div>

--- a/templates/controllers/tab/workflow/form/fileUploadFormXML.tpl
+++ b/templates/controllers/tab/workflow/form/fileUploadFormXML.tpl
@@ -1,0 +1,45 @@
+{**
+ * templates/controllers/tab/workflow/form/lfileUploadFormXML.tpl
+ *
+ * Copyright (c) 2014-2019 Simon Fraser University
+ * Copyright (c) 2003-2019 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Xml file upload form.
+ *}
+
+{* generate a unique ID for the form *}
+{assign var="uploadFormXML" value="uploadFormXML"|uniqid|escape}
+
+<script type="text/javascript">
+	// Attach the file upload form handler.
+	$(function() {ldelim}
+		$('#{$uploadFormXML}').pkpHandler(
+			'$.pkp.controllers.form.FileUploadFormHandler',
+			{ldelim}
+				$uploader: $('#plupload'),
+				uploaderOptions: {ldelim}
+					uploadUrl: {url|json_encode router=$smarty.const.ROUTE_COMPONENT  op="uploadFile" submissionId=$submissionId stageId=$stageId uploadRoles=$uploadRoles fileStage=$fileStage  escape=false},
+					baseUrl: {$baseUrl|json_encode},
+					filters: {ldelim}
+						mime_types : [
+							{ldelim} title : "XML", extensions : "xml" {rdelim}
+						]
+					{rdelim}
+				{rdelim}
+			{rdelim}
+		);
+	{rdelim});
+</script>
+
+<form id="{$uploadFormXML}" class="pkp_form" action="{url op="finishUpload" submissionId=$submissionId stageId=$stageId fileStage=$fileStage}" method="post">
+	{csrf}
+
+	{fbvFormArea id="file"}
+		{fbvFormSection title="common.file"}
+			{include file="controllers/fileUploadContainer.tpl" id="plupload" browseButton=""}
+		{/fbvFormSection}
+	{/fbvFormArea}
+
+	{fbvFormButtons}
+</form>

--- a/templates/controllers/tab/workflow/production.tpl
+++ b/templates/controllers/tab/workflow/production.tpl
@@ -1,18 +1,43 @@
 {**
  * templates/controllers/tab/workflow/production.tpl
  *
- * Copyright (c) 2014-2019 Simon Fraser University
- * Copyright (c) 2003-2019 John Willinsky
+* Copyright (c) 2014-2019 Simon Fraser University
+* Copyright (c) 2003-2019 John Willinsky
  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
  *
  * Production workflow stage
  *}
+<script type="text/javascript">
+// Attach the JS file tab handler.
+$(function () {ldelim}
+	$('#submissionVersions').pkpHandler(
+			'$.pkp.controllers.TabHandler',
+			{ldelim}
+				{assign var=selectedTabIndex value=$currentSubmissionVersion - 1}
+				selected: {$selectedTabIndex}
+				{rdelim}
+	);
+	{rdelim});
+</script>
 
 {* Help tab *}
 {help file="editorial-workflow/production.md" class="pkp_help_tab"}
 
 <div id="production">
 {include file="controllers/notification/inPlaceNotification.tpl" notificationId="productionNotification" requestOptions=$productionNotificationRequestOptions refreshOn="stageStatusUpdated"}
+	{if $isJatsTemplatePluginEnabled}
+		<div id="productionXmlUploadNotification" class="pkp_notification">
+			<div class="notifyInfo">
+				<span class="title"></span>
+				<span class="description">
+					{translate key="submission.upload.productionReadyXML.notification"}
+					<div class="pkp_button">{include file="linkAction/linkAction.tpl" action=$xmlFileCreateLinkAction submissionId=$submissionId stageId=$stageId fileStage=$fileStage}</div>
+					<div class="pkp_button">{include file="linkAction/linkAction.tpl" action=$xmlFileUploadLinkAction submissionId=$submissionId stageId=$stageId fileStage=$fileStage}</div>
+				</span>
+			</div>
+		</div>
+	{/if}
+
 
 	<div class="pkp_context_sidebar">
 		{if array_intersect(array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR), (array)$userRoles)}


### PR DESCRIPTION
Hi @asmecher ,

This PR adds the texture UI implementation  for stable-3_1_2 branch.

There are two things, what I was not sure.

 *  Adding the newly create form in the ojs branch, cause the  prodcution.tpl is there.
https://github.com/withanage/ojs/blob/stable-3_1_2/templates/controllers/tab/workflow/production.tpl
https://github.com/withanage/ojs/tree/stable-3_1_2/templates/controllers/tab/workflow/form/
Other  forms, I added in the pkp-lib, cause  I think those functionality, we will need also in OMP.

* The upload buttons have a underline due to href although, I just used the normal button. Tried  with all available  button classes,  but it did not went away. 

Functionality as a gif.


![xmlCreateandUpload](https://user-images.githubusercontent.com/42486456/65353538-adbbaa00-dbed-11e9-82b5-9422467a1214.gif)



