### PR TITLE
pkp/pkp-lib#5089 fix variable test for section editor count

### DIFF
--- a/templates/controllers/grid/settings/sections/form/sectionForm.tpl
+++ b/templates/controllers/grid/settings/sections/form/sectionForm.tpl
@@ -21,7 +21,7 @@
 
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="sectionFormNotification"}
 
-	{if $sectionEditorCount == 0}
+	{if !$hasSubEditors}
 		<span class="pkp_form_error"><p>{translate key="manager.section.noSectionEditors"}</p></span>
 	{/if}
 


### PR DESCRIPTION
This trivial fix adjusts the variable in the template so the warning goes away if section editors are assigned.  Although the form is slightly different in master, this fix also works in stable-3_1_2