### PR TITLE
pkp/pkp-lib#4273: Move h1 out of breadcrumbs nav, hide in default theme

### DIFF
--- a/plugins/themes/default/styles/components.less
+++ b/plugins/themes/default/styles/components.less
@@ -430,6 +430,11 @@
 	}
 }
 
+// Heading 1, now independent of Breadcrumbs
+h1.pageCurrentTitle {
+	display: none;
+}
+
 // Breadcrumbs
 .cmp_breadcrumbs {
 	display: inline-block;

--- a/templates/frontend/components/breadcrumbs_article.tpl
+++ b/templates/frontend/components/breadcrumbs_article.tpl
@@ -37,16 +37,12 @@
 		</li>
 		<li class="current">
 			<a href="{$currentUrl}" aria-current="page">
-			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			{/capture}
-			{$smarty.capture.currentTitleH1}
 			</a>
 		</li>
 	</ol>
 </nav>
-<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>

--- a/templates/frontend/components/breadcrumbs_article.tpl
+++ b/templates/frontend/components/breadcrumbs_article.tpl
@@ -36,11 +36,15 @@
 			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
+			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
+			{/capture}
+			{$smarty.capture.currentTitleH1}
 		</li>
 	</ol>
 </nav>
+<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>

--- a/templates/frontend/components/breadcrumbs_article.tpl
+++ b/templates/frontend/components/breadcrumbs_article.tpl
@@ -36,6 +36,7 @@
 			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
+			<a href="{$currentUrl}" aria-current="page">
 			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
@@ -44,6 +45,7 @@
 				{/if}
 			{/capture}
 			{$smarty.capture.currentTitleH1}
+			</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs_catalog.tpl
+++ b/templates/frontend/components/breadcrumbs_catalog.tpl
@@ -32,13 +32,15 @@
 			</li>
 		{/if}
 		<li class="current">
-			<h1>
+			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			</h1>
+			{/capture}
+			{$smarty.capture.currentTitleH1}
 		</li>
 	</ol>
 </nav>
+<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>

--- a/templates/frontend/components/breadcrumbs_catalog.tpl
+++ b/templates/frontend/components/breadcrumbs_catalog.tpl
@@ -33,16 +33,12 @@
 		{/if}
 		<li class="current">
 			<a href="{$currentUrl}" aria-current="page">
-			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			{/capture}
-			{$smarty.capture.currentTitleH1}
 			</a>
 		</li>
 	</ol>
 </nav>
-<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>

--- a/templates/frontend/components/breadcrumbs_catalog.tpl
+++ b/templates/frontend/components/breadcrumbs_catalog.tpl
@@ -32,6 +32,7 @@
 			</li>
 		{/if}
 		<li class="current">
+			<a href="{$currentUrl}" aria-current="page">
 			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
@@ -40,6 +41,7 @@
 				{/if}
 			{/capture}
 			{$smarty.capture.currentTitleH1}
+			</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs_issue.tpl
+++ b/templates/frontend/components/breadcrumbs_issue.tpl
@@ -30,16 +30,12 @@
 		</li>
 		<li class="current">
 			<a href="{$currentUrl}" aria-current="page">
-			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			{/capture}
-			{$smarty.capture.currentTitleH1}
 			</a>
 		</li>
 	</ol>
 </nav>
-<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>

--- a/templates/frontend/components/breadcrumbs_issue.tpl
+++ b/templates/frontend/components/breadcrumbs_issue.tpl
@@ -29,6 +29,7 @@
 			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
+			<a href="{$currentUrl}" aria-current="page">
 			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
@@ -37,6 +38,7 @@
 				{/if}
 			{/capture}
 			{$smarty.capture.currentTitleH1}
+			</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs_issue.tpl
+++ b/templates/frontend/components/breadcrumbs_issue.tpl
@@ -29,13 +29,15 @@
 			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li class="current">
-			<h1>
+			{capture name="currentTitleH1"}
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			</h1>
+			{/capture}
+			{$smarty.capture.currentTitleH1}
 		</li>
 	</ol>
 </nav>
+<h1 class="pageCurrentTitle">{$smarty.capture.currentTitleH1}</h1>

--- a/templates/frontend/pages/aboutThisPublishingSystem.tpl
+++ b/templates/frontend/pages/aboutThisPublishingSystem.tpl
@@ -15,6 +15,9 @@
 
 <div class="page page_about_publishing_system">
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="about.aboutThisPublishingSystem"}
+	<h1 class="pageCurrentTitle">
+		{translate key="about.aboutThisPublishingSystem"}
+	</h1>
 
 	<p>
 		{if $currentJournal}

--- a/templates/frontend/pages/article.tpl
+++ b/templates/frontend/pages/article.tpl
@@ -22,6 +22,14 @@
 	{else}
 		{include file="frontend/components/breadcrumbs_article.tpl" currentTitleKey="article.article"}
 	{/if}
+	<h1 class="pageCurrentTitle">
+	{if $section}
+		{$section->getLocalizedTitle()|escape}
+	
+	{else}
+		{translate key="article.article"}
+	{/if}
+	</h1>
 
 	{* Show article overview *}
 	{include file="frontend/objects/article_details.tpl"}

--- a/templates/frontend/pages/catalogCategory.tpl
+++ b/templates/frontend/pages/catalogCategory.tpl
@@ -23,6 +23,9 @@
 
 	{* Breadcrumb *}
 	{include file="frontend/components/breadcrumbs_catalog.tpl" type="category" parent=$parentCategory currentTitle=$category->getLocalizedTitle()}
+	<h1 class="pageCurrentTitle">
+		{$category->getLocalizedTitle()|escape}
+	</h1>
 
 	{* Count of articles in this category *}
 	<div class="article_count">

--- a/templates/frontend/pages/issue.tpl
+++ b/templates/frontend/pages/issue.tpl
@@ -21,11 +21,17 @@
 	{* Display a message if no current issue exists *}
 	{if !$issue}
 		{include file="frontend/components/breadcrumbs_issue.tpl" currentTitleKey="current.noCurrentIssue"}
+		<h1 class="pageCurrentTitle">
+			{translate key="current.noCurrentIssue"}
+		</h1>
 		{include file="frontend/components/notification.tpl" type="warning" messageKey="current.noCurrentIssueDesc"}
 
 	{* Display an issue with the Table of Contents *}
 	{else}
 		{include file="frontend/components/breadcrumbs_issue.tpl" currentTitle=$issueIdentification}
+		<h1 class="pageCurrentTitle">
+			{$issueIdentification|escape}
+		</h1>
 		{include file="frontend/objects/issue_toc.tpl"}
 	{/if}
 </div>

--- a/templates/frontend/pages/issueArchive.tpl
+++ b/templates/frontend/pages/issueArchive.tpl
@@ -25,6 +25,9 @@
 
 <div class="page page_issue_archive">
 	{include file="frontend/components/breadcrumbs.tpl" currentTitle=$pageTitle}
+	<h1 class="pageCurrentTitle">
+		{$pageTitle|escape}
+	</h1>
 
 	{* No issues have been published *}
 	{if empty($issues)}

--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -21,6 +21,9 @@
 <div class="page page_search">
 
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="common.search"}
+	<h1 class="pageCurrentTitle">
+		{translate key="common.search"}
+	</h1>
 
 	{capture name="searchFormUrl"}{url op="search" escape=false}{/capture}
 	{$smarty.capture.searchFormUrl|parse_url:$smarty.const.PHP_URL_QUERY|parse_str:$formUrlParameters}

--- a/templates/frontend/pages/subscriptions.tpl
+++ b/templates/frontend/pages/subscriptions.tpl
@@ -12,6 +12,9 @@
 
 <div class="page page_subscriptions">
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="about.subscriptions"}
+	<h1 class="pageCurrentTitle">
+		{translate key="about.subscriptions"}
+	</h1>
 	{include file="frontend/components/subscriptionContact.tpl"}
 
 	<a name="subscriptionTypes"></a>

--- a/templates/frontend/pages/userSubscriptions.tpl
+++ b/templates/frontend/pages/userSubscriptions.tpl
@@ -19,6 +19,9 @@
 
 <div class="page page_user_subscriptions">
 	{include file="frontend/components/breadcrumbs.tpl" currentTitleKey="user.subscriptions.mySubscriptions"}
+	<h1 class="pageCurrentTitle">
+		{translate key="user.subscriptions.mySubscriptions"}
+	</h1>
 	{include file="frontend/components/subscriptionContact.tpl"}
 
 	{if $paymentsEnabled}


### PR DESCRIPTION
Moves the `h1` out of the breadcrumbs `nav`.  Style it to not display in the default theme.  pkp/pkp-lib#4273