### PR TITLE
CrossRef Plugin: Add »Select/Unselect All« Capabilities

### DIFF
--- a/plugins/importexport/crossref/templates/index.tpl
+++ b/plugins/importexport/crossref/templates/index.tpl
@@ -87,8 +87,8 @@
 				}			
 			</script>
 			<p>
-				<input class="pkp_button" type="button" onclick='selectAll()' value="Select All"/>
-				<input class="pkp_button" type="button" onclick='UnSelectAll()' value="Unselect All"/>
+				<input class="pkp_button" type="button" onclick='selectAll()' value="{translate key="common.selectAll"}"/>
+				<input class="pkp_button" type="button" onclick='UnSelectAll()' value="{translate key="common.selectNone"}"/>
 			</p>
 			<form id="exportSubmissionXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
 				{csrf}

--- a/plugins/importexport/crossref/templates/index.tpl
+++ b/plugins/importexport/crossref/templates/index.tpl
@@ -70,7 +70,26 @@
 					// Attach the form handler.
 					$('#exportSubmissionXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
 				{rdelim});
+				function selectAll() {
+					var items = document.getElementsByName('selectedSubmissions[]');
+					for (var i = 0; i < items.length; i++) {
+						if (items[i].type == 'checkbox')
+							items[i].checked = true;
+					}
+				}
+
+				function UnSelectAll() {
+					var items = document.getElementsByName('selectedSubmissions[]');
+					for (var i = 0; i < items.length; i++) {
+						if (items[i].type == 'checkbox')
+							items[i].checked = false;
+					}
+				}			
 			</script>
+			<p>
+				<input class="pkp_button" type="button" onclick='selectAll()' value="Select All"/>
+				<input class="pkp_button" type="button" onclick='UnSelectAll()' value="Unselect All"/>
+			</p>
 			<form id="exportSubmissionXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
 				{csrf}
 				<input type="hidden" name="tab" value="exportSubmissions-tab" />

--- a/plugins/importexport/crossref/templates/index.tpl
+++ b/plugins/importexport/crossref/templates/index.tpl
@@ -70,25 +70,17 @@
 					// Attach the form handler.
 					$('#exportSubmissionXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
 				{rdelim});
-				function selectAll() {
+				function toggleSelectAll(state) {
 					var items = document.getElementsByName('selectedSubmissions[]');
 					for (var i = 0; i < items.length; i++) {
 						if (items[i].type == 'checkbox')
-							items[i].checked = true;
+							items[i].checked = state;
 					}
 				}
-
-				function UnSelectAll() {
-					var items = document.getElementsByName('selectedSubmissions[]');
-					for (var i = 0; i < items.length; i++) {
-						if (items[i].type == 'checkbox')
-							items[i].checked = false;
-					}
-				}			
 			</script>
 			<p>
-				<input class="pkp_button" type="button" onclick='selectAll()' value="{translate key="common.selectAll"}"/>
-				<input class="pkp_button" type="button" onclick='UnSelectAll()' value="{translate key="common.selectNone"}"/>
+				<button class="pkp_button" onclick="toggleSelectAll(true)" value="{translate key="common.selectAll"}"/>
+				<button class="pkp_button" onclick="toggleSelectAll(false)" value="{translate key="common.selectNone"}"/>
 			</p>
 			<form id="exportSubmissionXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
 				{csrf}


### PR DESCRIPTION
To reduce click rate there should be a »Select All« and a »Unselect All« button.
I can’t see, where the `name` attribute (»selectedSubmissions[]«) is generated. This should be changed so that every name change is respected automatically.