### PR TITLE
pkp/pkp-lib#5264: Correct Crossref temporary filename construction

### DIFF
--- a/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
+++ b/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
@@ -452,8 +452,8 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 					$exportXml = $this->exportXML(array($object), $filter, $context);
 					// Write the XML to a file.
 					// export file name example: crossref-20160723-160036-articles-1-1.xml
-					$objectsFileNamePart = $objectsFileNamePart . '-' . $object->getId();
-					$exportFileName = $this->getExportFileName($this->getExportPath(), $objectsFileNamePart, $context, '.xml');
+					$objectsFileNamePartId = $objectsFileNamePart . '-' . $object->getId();
+					$exportFileName = $this->getExportFileName($this->getExportPath(), $objectsFileNamePartId, $context, '.xml');
 					$fileManager->writeFile($exportFileName, $exportXml);
 					// Deposit the XML file.
 					$result = $this->depositXML($object, $context, $exportFileName);

--- a/plugins/importexport/crossref/CrossrefInfoSender.inc.php
+++ b/plugins/importexport/crossref/CrossrefInfoSender.inc.php
@@ -124,8 +124,8 @@ class CrossrefInfoSender extends ScheduledTask {
 			$exportXml = $plugin->exportXML(array($object), $filter, $journal);
 			// Write the XML to a file.
 			// export file name example: crossref-20160723-160036-articles-1-1.xml
-			$objectsFileNamePart = $objectsFileNamePart . '-' . $object->getId();
-			$exportFileName = $plugin->getExportFileName($plugin->getExportPath(), $objectsFileNamePart, $journal, '.xml');
+			$objectsFileNamePartId = $objectsFileNamePart . '-' . $object->getId();
+			$exportFileName = $plugin->getExportFileName($plugin->getExportPath(), $objectsFileNamePartId, $journal, '.xml');
 			$fileManager->writeFile($exportFileName, $exportXml);
 			// Deposit the XML file.
 			$result = $plugin->depositXML($object, $journal, $exportFileName);


### PR DESCRIPTION
Resolves pkp/pkp-lib#5264