### PR TITLE
Fix mapping of role ids to role i18n keys.

### DIFF
--- a/classes/core/Application.inc.php
+++ b/classes/core/Application.inc.php
@@ -249,7 +249,7 @@ class Application extends PKPApplication {
 	 */
 	static function getRoleNames($contextOnly = false, $roleIds = null) {
 		$roleNames = parent::getRoleNames($contextOnly, $roleIds);
-		if (!$roleIds || !in_array(ROLE_ID_SUBSCRIPTION_MANAGER, $roleIds)) {
+		if (!$roleIds || in_array(ROLE_ID_SUBSCRIPTION_MANAGER, $roleIds)) {
 			$roleNames[ROLE_ID_SUBSCRIPTION_MANAGER] = 'user.role.subscriptionManager';
 		}
 		return $roleNames;


### PR DESCRIPTION
The function `Application::getRoleNames()` introduced with https://github.com/pkp/ojs/commit/35cb328da2d84723a40168fc1b543c054bc08ec7 can erroneously return the subscription manager role key.

As a result a lot of the email templates on the 'Prepared Email Templates' grid of OJS 3.1.2 have the subscription manager role as sender or recipient (also see [this comment](https://github.com/pkp/pkp-lib/issues/2724#issuecomment-347220421)).

It also applies to `master` even after the role ids of template emails have been fixed with pkp/pkp-lib#2906.
