### PR TITLE
Allow applications to extend the workflow settings

### DIFF
--- a/pages/management/SettingsHandler.inc.php
+++ b/pages/management/SettingsHandler.inc.php
@@ -37,6 +37,17 @@ class SettingsHandler extends ManagementHandler {
 	}
 
 	/**
+	 * Add the workflow settings page
+	 *
+	 * @param $args array
+	 * @param $request Request
+	 */
+	function workflow($args, $request) {
+		parent::workflow($args, $request);
+		TemplateManager::getManager($request)->display('management/workflow.tpl');
+	}
+
+	/**
 	 * Add the archive and payments tabs to the distribution settings page
 	 *
 	 * @param $args array


### PR DESCRIPTION
OMP and OJS do not have app specific workflow settings, but PPS will have one tab. This change allows apps to extend the workflow settings if needed.

Also see https://github.com/pkp/omp/pull/731