### PR TITLE
Stable 3 1 2: Enhancement in mEDRA plugin

### DIFF
--- a/plugins/importexport/medra/MedraExportPlugin.inc.php
+++ b/plugins/importexport/medra/MedraExportPlugin.inc.php
@@ -93,7 +93,8 @@ class MedraExportPlugin extends DOIPubIdExportPlugin {
 		// Use a different endpoint for testing and
 		// production.
 		$this->import('classes.MedraWebservice');
-		$endpoint = ($this->isTestMode($context) ? MEDRA_WS_ENDPOINT_DEV : MEDRA_WS_ENDPOINT);
+		// New endpoint introduced: if the user select the checkbox to deposit also in Crossref, the relative and correct endpoint is choosen. it could be the staging endpoint o production endpoint
+		$endpoint = ($this->isTestMode($context) ? ($this->_request->getUserVar('crEnabled') == 'on' ? MEDRA2CR_WS_ENDPOINT_DEV : MEDRA_WS_ENDPOINT_DEV) : ($this->_request->getUserVar('crEnabled') == 'on' ? MEDRA2CR_WS_ENDPOINT : MEDRA_WS_ENDPOINT));
 
 		// Get credentials.
 		$username = $this->getSetting($context->getId(), 'username');
@@ -102,11 +103,21 @@ class MedraExportPlugin extends DOIPubIdExportPlugin {
 		assert(is_readable($filename));
 		$xml = file_get_contents($filename);
 		assert($xml !== false && !empty($xml));
+		
+		// Select the language
+		$lang = 'eng';
+		if(substr($this->_request->getUserVar('language'), 0, 2) == 'it'){
+		    $lang = 'ita';
+		} else if(substr($this->_request->getUserVar('language'), 0, 2) == 'de'){
+		    $lang = 'ger';
+		}
 
 		// Instantiate the mEDRA web service wrapper.
 		$ws = new MedraWebservice($endpoint, $username, $password);
 		// Register the XML with mEDRA.
-		$result = $ws->upload($xml);
+		//$result = $ws->upload($xml);
+		//The selected checkbox determines the only deposit on mEDRA or the further deposit also in Crossref 
+		$result = $this->_request->getUserVar('crEnabled') == 'on' ? $ws->deposit($xml, $lang) : $ws->upload($xml);
 
 		if ($result === true) {
 			// Mark all objects as registered.
@@ -115,14 +126,94 @@ class MedraExportPlugin extends DOIPubIdExportPlugin {
 				$this->saveRegisteredDoi($context, $object);
 			}
 		} else {
-			// Handle errors.
-			if (is_string($result)) {
-				$result = array(
-					array('plugins.importexport.common.register.error.mdsError', $result)
-				);
-			} else {
-				$result = false;
-			}
+			// Handle errors. There are validations before sending the request of submission to Crossref endpoint, and there is a need to throw a readable exception to the end user
+			//the exception are shown in a table as represented in the code below.
+		    if(!assert(PKPString::regexp_match('#<returnCode>success</returnCode>#', $result))){
+		        $doc = new DOMDocument();
+		        $doc->loadXML($result);
+		        
+		        $charset = Config::getVar('i18n', 'client_charset');
+		        header('Content-type: text/html; charset=' . $charset);
+		        echo '<html><body>';
+		        echo '<h2>' . __('plugins.importexport.common.validationErrors') . '</h2>';
+		        if($doc->getElementsByTagName('statusCode')->item(0)->textContent == 'FAILED'){
+		            $numberError = $doc->getElementsByTagName('errorsNumber')->item(0)->textContent;
+		            if($numberError > 0){
+		                if($lang == 'it'){
+		                    echo '<div> mEDRA - Messaggio di errore. </div> <br/>';
+		                    echo '<div> Motivo: file non valido rispetto ai requisiti di mEDRA e/o Crossref. </div> <br/>';
+		                    echo '<div> Numero di errori: ' . $numberError . '</div> <br/>';
+		                    echo '<div> Non sono stati rispettati i seguenti requisiti: </div> <br/>';
+		                } else {
+		                    echo '<div> mEDRA - Error Message. </div> <br/>';
+		                    echo '<div> Cause: file not valid in respect to the mEDRA and/or Crossref requirements. </div> <br/>';
+		                    echo '<div> The following requirements have not been met: </div> <br/>';
+		                    echo '<div> Number of errors: ' . $numberError . '</div> <br/>';
+		                }
+		                echo "<table style='border-collapse:collapse; font-size:18;'>";
+		                
+		                echo "<tr>";
+		                
+		                if(substr($this->_request->getUserVar('language'), 0, 2) == 'it'){
+		                    echo "<td style='border:1px solid black; font-size:18; font-weight:bold; padding:10px;'>CODICE</td>";
+		                    echo "<td style='border:1px solid black; font-size:18; font-weight:bold; padding:10px;'>ELEMENTO</td>";
+		                    echo "<td style='border:1px solid black; font-size:18; font-weight:bold; padding:10px;'>DESCRIZIONE</td>";
+		                } else {
+		                    echo "<td style='border:1px solid black; font-size:18; font-weight:bold; padding:10px;'>CODE</td>";
+		                    echo "<td style='border:1px solid black; font-size:18; font-weight:bold; padding:10px;'>ELEMENT</td>";
+		                    echo "<td style='border:1px solid black; font-size:18; font-weight:bold; padding:10px;'>DESCRIPTION</td>";
+		                }
+		                
+		                echo '</tr>';
+		            }
+		            
+		            $nodeList = $doc->getElementsByTagName('error');
+		            $length = $nodeList->length;
+		            for ($i = 0; $i < $length; $i++) {
+		                
+		                $doc->getElementsByTagName('code')->item($i)->textContent;
+		                if($i % 2 == 0){
+		                    echo "<tr style='background-color: #ABCDEF;'>";
+		                } else {
+		                    echo "<tr style='background-color: #BDB9AA;'>";
+		                }
+		                
+		                echo "<td style='border:1px solid black; font-size:18; padding:10px;'>" .
+		  		                '<a style="text-decoration:none;" href="' . substr($endpoint, 0, strrpos($endpoint, "servlet")) . 'en/crossrefErrorList.htm#' . $doc->getElementsByTagName('code')->item($i)->textContent . '">' .
+		  		                $doc->getElementsByTagName('code')->item($i)->textContent  .
+		  		                '</a>' .
+		  		                '</td>';
+		  		                echo "<td style='border:1px solid black; font-size:18; padding:10px;'>" . $doc->getElementsByTagName('reference')->item($i)->textContent  . '</td>';
+		  		                echo "<td style='border:1px solid black; font-size:18; padding:10px;'>" . $doc->getElementsByTagName('description')->item($i)->textContent  . '</td>';
+		  		                echo '</tr>';
+		  		                
+		            }
+		            
+		            if($numberError > 0){
+		                echo '</table>';
+		            }
+		            
+		        }
+		        
+		        libxml_clear_errors();
+		        echo '<h3>' . __('plugins.importexport.common.invalidXML') . '</h3>';
+		        echo '<p><pre>' . htmlspecialchars($xml) . '</pre></p>';
+		        echo '</body></html>';
+		    } else
+		        if (is_string($result)) {
+		            
+		            error_log($result);
+		            $doc = new DOMDocument();
+		            $doc->loadXML($result);
+		            $resultCode = $doc->getElementsByTagName('statusCode')->item(0)->nodeValue;
+		            
+		            $result = array(
+		                array('plugins.importexport.common.register.error.mdsError', $resultCode)
+		            );
+		        } else {
+		            
+		            $result = false;
+			     }
 		}
 		return $result;
 	}

--- a/plugins/importexport/medra/MedraExportPlugin.inc.php
+++ b/plugins/importexport/medra/MedraExportPlugin.inc.php
@@ -155,16 +155,13 @@ class MedraExportPlugin extends DOIPubIdExportPlugin {
 		        }
 		        
 		        $templateMgr->assign(
-		            'htmlspecialchars', htmlspecialchars($xml)
-		        );
-		        
-		        $templateMgr->assign(
+		            'htmlspecialchars', htmlspecialchars($xml),
 		            'numberError', $numberError
 		        );
 		        
 		        $templateMgr->display($this->getTemplateResource('crDepositErrors.tpl'));
-		        
-		    } else
+
+		 } else
 		        if (is_string($result)) {
 		            $doc = new DOMDocument();
 		            $doc->loadXML($result);

--- a/plugins/importexport/medra/MedraExportPlugin.inc.php
+++ b/plugins/importexport/medra/MedraExportPlugin.inc.php
@@ -107,7 +107,7 @@ class MedraExportPlugin extends DOIPubIdExportPlugin {
 		// Select the language
 		$language = 'en_US';
 		foreach($objects as $object) {
-		    $language = $object->getLocale();
+			$language = $object->getLocale();
 		}
 		
 		// Instantiate the mEDRA web service wrapper.
@@ -132,48 +132,38 @@ class MedraExportPlugin extends DOIPubIdExportPlugin {
 				$numberError = '';
 				
 				if($doc->getElementsByTagName('statusCode')->item(0)->textContent == 'FAILED'){
-				    $numberError = $doc->getElementsByTagName('errorsNumber')->item(0)->textContent;
-		            $nodeList = $doc->getElementsByTagName('error');
-		            
-		            $headlines = array();
-		            
-		            foreach($nodeList as $node) {
-		                $headline = array();
-		                if($node->childNodes->length) {
-		                    foreach($node->childNodes as $i) {
-		                        $headline[$i->nodeName] = $i->nodeValue;
-		                    }
-		                }
-		                
-		                $headlines[] = $headline;
-		            }
-		            
-		            $templateMgr->assign(
-		                'headlines', $headlines
-		            );
-		            
-		        }
-		        
-		        $templateMgr->assign(
-		            'htmlspecialchars', htmlspecialchars($xml),
-		            'numberError', $numberError
-		        );
-		        
-		        $templateMgr->display($this->getTemplateResource('crDepositErrors.tpl'));
-
-		 } else
-		        if (is_string($result)) {
-		            $doc = new DOMDocument();
-		            $doc->loadXML($result);
-		            $resultCode = $doc->getElementsByTagName('statusCode')->item(0)->nodeValue;
-		            
-		            $result = array(
-		                array('plugins.importexport.common.register.error.mdsError', $resultCode)
-		            );
-		        } 
-		        else {
-		            $result = false;
-			    }
+					$numberError = $doc->getElementsByTagName('errorsNumber')->item(0)->textContent;
+					$nodeList = $doc->getElementsByTagName('error');
+					$headlines = array();
+					foreach($nodeList as $node) {
+						$headline = array();
+						if($node->childNodes->length) {
+							foreach($node->childNodes as $i) {
+								$headline[$i->nodeName] = $i->nodeValue;
+							}
+						}
+						$headlines[] = $headline;
+					}
+					$templateMgr->assign(
+						'headlines', $headlines
+					);
+				}
+				$templateMgr->assign(
+					'htmlspecialchars', htmlspecialchars($xml),
+					'numberError', $numberError
+				);
+				$templateMgr->display($this->getTemplateResource('crDepositErrors.tpl'));
+		} else
+			if (is_string($result)) {
+				$doc = new DOMDocument();
+				$doc->loadXML($result);
+				$resultCode = $doc->getElementsByTagName('statusCode')->item(0)->nodeValue;
+				$result = array(
+					array('plugins.importexport.common.register.error.mdsError', $resultCode)
+				);
+			} else {
+				$result = false;
+			}
 		}
 		return $result;
 	}

--- a/plugins/importexport/medra/classes/MedraWebservice.inc.php
+++ b/plugins/importexport/medra/classes/MedraWebservice.inc.php
@@ -108,7 +108,7 @@ class MedraWebservice {
 				'</SOAP-ENV:Body>' .
 			'</SOAP-ENV:Envelope>';
 		
-		//Rebuild the multipart SOAP message for the deposit in CRossref: the action is 'deposit' insteaf of upload
+		//Rebuild the multipart SOAP message for the deposit in CRossref: the action is 'deposit' instead of upload
 		if($action == 'deposit'){
 		    $soapMessage =
 		    '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" ' .

--- a/plugins/importexport/medra/classes/MedraWebservice.inc.php
+++ b/plugins/importexport/medra/classes/MedraWebservice.inc.php
@@ -118,7 +118,7 @@ class MedraWebservice {
 		          "<med:$action>" .
 		              "<med:accessMode>01</med:accessMode>" .
 		              "<med:language>$arg</med:language>" .
-		              "<med:contentID>" . key(htmlspecialchars($attachment)) . "</med:contentID>" .
+		              "<med:contentID>" . key($attachment) . "</med:contentID>" .
 		          "</med:$action>" .
 		      '</SOAP-ENV:Body>' .
 		    '</SOAP-ENV:Envelope>';
@@ -131,7 +131,7 @@ class MedraWebservice {
 				"--MIME_boundary\r\n" .
 				$this->_getMimePart($soapMessageId, $soapMessage) .
 				"--MIME_boundary\r\n" .
-				$this->_getMimePart(key(htmlspecialchars($attachment)), current(htmlspecialchars($attachment))) .
+				$this->_getMimePart(key($attachment), current($attachment)) .
 				"--MIME_boundary--\r\n";
 			$contentType = 'multipart/related; type="text/xml"; boundary="MIME_boundary"';
 		} else {
@@ -183,8 +183,7 @@ class MedraWebservice {
 			PKPString::regexp_match_get('#<faultstring>([^<]*)</faultstring>#', $response, $matches);
 			if (empty($matches)) {
 				if ($attachment) {
-					assert(PKPString::regexp_match('#<returnCode>success</returnCode>#', $response));
-					if(!assert(PKPString::regexp_match('#<returnCode>success</returnCode>#', $response))){
+					if(empty(PKPString::regexp_match('#<returnCode>success</returnCode>#', $response))){
 					    $parts = explode("\r\n\r\n", $response);
 					    $result = array_pop($parts);
 					    $result = PKPString::regexp_replace('/>[^>]*$/', '>', $result);

--- a/plugins/importexport/medra/classes/MedraWebservice.inc.php
+++ b/plugins/importexport/medra/classes/MedraWebservice.inc.php
@@ -51,7 +51,7 @@ class MedraWebservice {
 	//
 	/**
 	 * mEDRA upload operation.
-	 * @param $xml
+	 * @param $xml String
 	 */
 	function upload($xml) {
 		$attachmentId = $this->_getContentId('metadata');
@@ -66,8 +66,8 @@ class MedraWebservice {
 	//
 	/**
 	 * mEDRA deposit operation.
-	 * @param $xml
-	 * @param $language
+	 * @param $xml String
+	 * @param $language String
 	 */
 	function deposit($xml, $language) {
 	    $attachmentId = $this->_getContentId('metadata');
@@ -118,7 +118,7 @@ class MedraWebservice {
 		          "<med:$action>" .
 		              "<med:accessMode>01</med:accessMode>" .
 		              "<med:language>$arg</med:language>" .
-		              "<med:contentID>" . key($attachment) . "</med:contentID>" .
+		              "<med:contentID>" . key(htmlspecialchars($attachment)) . "</med:contentID>" .
 		          "</med:$action>" .
 		      '</SOAP-ENV:Body>' .
 		    '</SOAP-ENV:Envelope>';
@@ -131,7 +131,7 @@ class MedraWebservice {
 				"--MIME_boundary\r\n" .
 				$this->_getMimePart($soapMessageId, $soapMessage) .
 				"--MIME_boundary\r\n" .
-				$this->_getMimePart(key($attachment), current($attachment)) .
+				$this->_getMimePart(key(htmlspecialchars($attachment)), current(htmlspecialchars($attachment))) .
 				"--MIME_boundary--\r\n";
 			$contentType = 'multipart/related; type="text/xml"; boundary="MIME_boundary"';
 		} else {

--- a/plugins/importexport/medra/classes/MedraWebservice.inc.php
+++ b/plugins/importexport/medra/classes/MedraWebservice.inc.php
@@ -70,10 +70,10 @@ class MedraWebservice {
 	 * @param $language String
 	 */
 	function deposit($xml, $language) {
-	    $attachmentId = $this->_getContentId('metadata');
-	    $attachment = array($attachmentId => $xml);
-	    $result = $this->_doRequest('deposit', $language, $attachment);
-	    return $result;
+		$attachmentId = $this->_getContentId('metadata');
+		$attachment = array($attachmentId => $xml);
+		$result = $this->_doRequest('deposit', $language, $attachment);
+		return $result;
 	}
 	
 
@@ -110,18 +110,18 @@ class MedraWebservice {
 		
 		//Rebuild the multipart SOAP message for the deposit in CRossref: the action is 'deposit' instead of upload
 		if($action == 'deposit'){
-		    $soapMessage =
-		    '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" ' .
-		    'xmlns:med="http://www.medra.org">' .
-		      '<SOAP-ENV:Header/>' .
-		      '<SOAP-ENV:Body>' .
-		          "<med:$action>" .
-		              "<med:accessMode>01</med:accessMode>" .
-		              "<med:language>$arg</med:language>" .
-		              "<med:contentID>" . key($attachment) . "</med:contentID>" .
-		          "</med:$action>" .
-		      '</SOAP-ENV:Body>' .
-		    '</SOAP-ENV:Envelope>';
+			$soapMessage =
+			'<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" ' .
+			'xmlns:med="http://www.medra.org">' .
+				'<SOAP-ENV:Header/>' .
+				'<SOAP-ENV:Body>' .
+					"<med:$action>" .
+						"<med:accessMode>01</med:accessMode>" .
+						"<med:language>$arg</med:language>" .
+						"<med:contentID>" . key($attachment) . "</med:contentID>" .
+					"</med:$action>" .
+				'</SOAP-ENV:Body>' .
+			'</SOAP-ENV:Envelope>';
 		}
 
 		$soapMessageId = $this->_getContentId($action);

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -354,6 +354,10 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$invertedPersonName = $author->getFullName(false, true);
 		assert(!empty($invertedPersonName));
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PersonNameInverted', htmlspecialchars($invertedPersonName, ENT_COMPAT, 'UTF-8')));
+		// Key names (mandatory)
+		$keyNames = $author->getFullName(false);
+		assert(!empty($keyNames));
+		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'KeyNames', htmlspecialchars($keyNames, ENT_COMPAT, 'UTF-8')));		
 		// Affiliation
 		$affiliation = $this->getPrimaryTranslation($author->getAffiliation(null), $objectLocalePrecedence);
 		if (!empty($affiliation)) {

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -346,6 +346,10 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'SequenceNumber', $seq));
 		// Contributor role (mandatory)
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ContributorRole', O4DOI_CONTRIBUTOR_ROLE_ACTUAL_AUTHOR));
+		// Contributor ORCID '21'
+		if (!empty($author->getOrcid())) {
+		    $this->createRelatedNode($doc, '21', $author->getOrcid());
+		}
 		// Person name (mandatory)
 		$personName = $author->getFullName(false);
 		assert(!empty($personName));
@@ -354,8 +358,13 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$invertedPersonName = $author->getFullName(false, true);
 		assert(!empty($invertedPersonName));
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'PersonNameInverted', htmlspecialchars($invertedPersonName, ENT_COMPAT, 'UTF-8')));
+		$locale = AppLocale::getLocale();
+		// Name before key
+		$nameBeforeKey = $author->getGivenName($locale);
+		assert(!empty($nameBeforeKey));
+		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'NamesBeforeKey', htmlspecialchars($nameBeforeKey, ENT_COMPAT, 'UTF-8')));
 		// Key names (mandatory)
-		$keyNames = $author->getFullName(false);
+		$keyNames = $author->getFamilyName($locale);
 		assert(!empty($keyNames));
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'KeyNames', htmlspecialchars($keyNames, ENT_COMPAT, 'UTF-8')));		
 		// Affiliation

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -348,7 +348,7 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ContributorRole', O4DOI_CONTRIBUTOR_ROLE_ACTUAL_AUTHOR));
 		// Contributor ORCID '21'
 		if (!empty($author->getOrcid())) {
-            $this->createNameIdentifierNode($doc, '21', $author->getOrcid());
+			$this->createNameIdentifierNode($doc, '21', $author->getOrcid());
 		}
 		// Person name (mandatory)
 		$personName = $author->getFullName(false);

--- a/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/ArticleMedraXmlFilter.inc.php
@@ -348,7 +348,7 @@ class ArticleMedraXmlFilter extends O4DOIXmlFilter {
 		$contributorNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ContributorRole', O4DOI_CONTRIBUTOR_ROLE_ACTUAL_AUTHOR));
 		// Contributor ORCID '21'
 		if (!empty($author->getOrcid())) {
-		    $this->createRelatedNode($doc, '21', $author->getOrcid());
+            $this->createNameIdentifierNode($doc, '21', $author->getOrcid());
 		}
 		// Person name (mandatory)
 		$personName = $author->getFullName(false);

--- a/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
@@ -43,7 +43,7 @@ define('O4DOI_EPUB_FORMAT_HTML', '01');
 define('O4DOI_EPUB_FORMAT_PDF', '02');
 
 // Date formats
-define('O4DOI_DATE_FORMAT_YYYY', '06');
+define('O4DOI_DATE_FORMAT_YYYY', '05');
 
 // Extent types
 define('O4DOI_EXTENT_TYPE_FILESIZE', '22');
@@ -260,7 +260,7 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		}
 		// ISSN
 		if (!empty($issn)) {
-			$issn = PKPString::regexp_replace('/[^0-9]/', '', $issn);
+			// $issn = PKPString::regexp_replace('/[^0-9]/', '', $issn); There is no more need to remove character that is NOT in 0-9 
 			$serialVersionNode->appendChild($this->createIdentifierNode($doc, 'Product', O4DOI_ID_TYPE_ISSN, $issn));
 		}
 		// Product Form

--- a/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
@@ -260,7 +260,6 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		}
 		// ISSN
 		if (!empty($issn)) {
-			// $issn = PKPString::regexp_replace('/[^0-9]/', '', $issn); There is no more need to remove character that is NOT in 0-9 
 			$serialVersionNode->appendChild($this->createIdentifierNode($doc, 'Product', O4DOI_ID_TYPE_ISSN, $issn));
 		}
 		// Product Form

--- a/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
+++ b/plugins/importexport/medra/filter/O4DOIXmlFilter.inc.php
@@ -29,6 +29,11 @@ define('O4DOI_TEXTFORMAT_ASCII', '00');
 define('O4DOI_TITLE_TYPE_FULL', '01');
 define('O4DOI_TITLE_TYPE_ISSUE', '07');
 
+// Name identifier types
+define('O4DOI_NAME_IDENTIFIER_TYPE_PROPRIETARY', '01');
+define('O4DOI_NAME_IDENTIFIER_TYPE_ISNI', '16');
+define('O4DOI_NAME_IDENTIFIER_TYPE_ORCID', '21');
+
 // Publishing roles
 define('O4DOI_PUBLISHING_ROLE_PUBLISHER', '01');
 
@@ -216,6 +221,23 @@ class O4DOIXmlFilter extends NativeExportFilter {
 		// Title text (mandatory)
 		$titleNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'TitleText', htmlspecialchars(PKPString::html2text($localizedTitle), ENT_COMPAT, 'UTF-8')));
 		return $titleNode;
+	}
+	
+	/**
+	 * Create a NameIdentifier node.
+	 * @param $doc DOMDocument
+	 * @param $nameIDType string One of the O4DOI_NAME_IDENTIFIER_TYPE_* constants.
+	 * @param $idValue string
+	 * @return DOMElement
+	 */
+	function createNameIdentifierNode($doc, $nameIDType, $idValue) {
+	    $deployment = $this->getDeployment();
+	    $nameIdentifierNode = $doc->createElementNS($deployment->getNamespace(), 'NameIdentifier');
+	    // NameIDType (mandatory)
+	    $nameIdentifierNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'NameIDType', $nameIDType));
+	    // IDValue (mandatory)
+	    $nameIdentifierNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'IDValue', $idValue));
+	    return $nameIdentifierNode;
 	}
 
 	/**

--- a/plugins/importexport/medra/locale/en_US/locale.xml
+++ b/plugins/importexport/medra/locale/en_US/locale.xml
@@ -50,6 +50,14 @@
 	<message key="plugins.importexport.medra.senderTask.name">mEDRA automatic registration task</message>
 	<message key="plugins.importexport.common.send.to.crossref">Send to Crossref</message>
 	
+	<message key="plugins.importexport.medra.crossref.error.cause">Cause: file not valid in respect to the mEDRA and/or Crossref requirements.</message>
+	<message key="plugins.importexport.medra.crossref.error.number">Number of errors</message>
+	<message key="plugins.importexport.medra.crossref.error.details">The following requirements were not met</message>
+	
+	<message key="plugins.importexport.medra.crossref.error.code">CODE</message>
+	<message key="plugins.importexport.medra.crossref.error.element">ELEMENT</message>
+	<message key="plugins.importexport.medra.crossref.error.description">DESCRIPTION</message>
+	
 	<message key="plugins.importexport.medra.cliUsage"><![CDATA[Usage: 
 {$scriptName} {$pluginName} export [xmlFileName] [journal_path] {issues|articles|galleys} objectId1 [objectId2] ...
 {$scriptName} {$pluginName} register [journal_path] {issues|articles|galleys} objectId1 [objectId2] ...

--- a/plugins/importexport/medra/locale/en_US/locale.xml
+++ b/plugins/importexport/medra/locale/en_US/locale.xml
@@ -48,7 +48,8 @@
 	<message key="plugins.importexport.medra.workOrProduct"><![CDATA[NB: DOIs assigned to articles will be exported to mEDRA as <a href="http://www.medra.org/en/metadata_td.htm" target="_blank">'works'</a>. DOIs assigned to galleys will be exported as <a href="http://www.medra.org/en/metadata_td.htm" target="_blank">'manifestations'</a>.]]></message>
 
 	<message key="plugins.importexport.medra.senderTask.name">mEDRA automatic registration task</message>
-
+	<message key="plugins.importexport.common.send.to.crossref">Send to Crossref</message>
+	
 	<message key="plugins.importexport.medra.cliUsage"><![CDATA[Usage: 
 {$scriptName} {$pluginName} export [xmlFileName] [journal_path] {issues|articles|galleys} objectId1 [objectId2] ...
 {$scriptName} {$pluginName} register [journal_path] {issues|articles|galleys} objectId1 [objectId2] ...

--- a/plugins/importexport/medra/locale/it_IT/locale.xml
+++ b/plugins/importexport/medra/locale/it_IT/locale.xml
@@ -42,6 +42,7 @@
 	<message key="plugins.importexport.medra.workOrProduct"><![CDATA[NB: I DOI assegnati agli articoli verranno esportati in mEDRA come <a href="http://www.medra.org/en/metadata_td.htm" target="_blank">'opere'</a>. I DOI assegnati ai file principali degli articoli verranno esportati come <a href="http://www.medra.org/en/metadata_td.htm" target="_blank">'manifestazioni'</a>.]]></message>
 
 	<message key="plugins.importexport.medra.senderTask.name">Registrazione automatica DOI mEDRA</message>
+	<message key="plugins.importexport.common.send.to.crossref">Invio a Crossref</message>
 
 	<message key="plugins.importexport.medra.cliUsage"><![CDATA[Uso: 
 {$scriptName} {$pluginName} export [xmlFileName] [journal_path] {issues|articles|galleys} objectId1 [objectId2] ...

--- a/plugins/importexport/medra/locale/it_IT/locale.xml
+++ b/plugins/importexport/medra/locale/it_IT/locale.xml
@@ -43,6 +43,14 @@
 
 	<message key="plugins.importexport.medra.senderTask.name">Registrazione automatica DOI mEDRA</message>
 	<message key="plugins.importexport.common.send.to.crossref">Invio a Crossref</message>
+	
+	<message key="plugins.importexport.medra.crossref.error.cause">Motivo: file non valido rispetto ai requisiti di mEDRA e/o Crossref.</message>
+	<message key="plugins.importexport.medra.crossref.error.number">Numero di errori</message>
+	<message key="plugins.importexport.medra.crossref.error.details">I seguenti requisiti non sono stati rispettati</message>
+	
+	<message key="plugins.importexport.medra.crossref.error.code">CODICE</message>
+	<message key="plugins.importexport.medra.crossref.error.element">ELEMENTO</message>
+	<message key="plugins.importexport.medra.crossref.error.description">DESCRIZIONE</message>
 
 	<message key="plugins.importexport.medra.cliUsage"><![CDATA[Uso: 
 {$scriptName} {$pluginName} export [xmlFileName] [journal_path] {issues|articles|galleys} objectId1 [objectId2] ...

--- a/plugins/importexport/medra/templates/crDepositErrors.tpl
+++ b/plugins/importexport/medra/templates/crDepositErrors.tpl
@@ -48,15 +48,15 @@
 			<tbody>
 				{foreach from=$headlines key=k item=v}
 					<tr>
-						<td>{$v['code']}</td>
-						<td>{$v['reference']}</td>
-						<td>{$v['description']}</td>
+						<td>{$v['code']|escape}</td>
+						<td>{$v['reference']|escape}</td>
+						<td>{$v['description']|escape}</td>
 					</tr>
 				{/foreach}
 			</tbody>
 		</table>
 		<h3>  {translate key="plugins.importexport.common.invalidXML"} </h3>
-		<pre>{$htmlspecialchars}</pre>
+		<pre>{$htmlspecialchars|strip_unsafe_html}</pre>
 		
 	</body>
 </html>

--- a/plugins/importexport/medra/templates/crDepositErrors.tpl
+++ b/plugins/importexport/medra/templates/crDepositErrors.tpl
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset={$defaultCharset|escape}" />
+		<style type="text/css">
+			table thead th {
+				border: 1px solid black; 
+				font-size: 18; 
+				font-weight: bold; 
+				padding: 10px;
+			}
+			table {
+				border-collapse: collapse;
+				font-size: 18;
+			}
+			table tbody td {
+				border: 1px solid black; 
+				font-size: 18; 
+				padding: 10px;
+			}
+			
+			table tbody tr:nth-child(even) {
+				background: #ABCDEF;
+			}
+			table tbody tr:nth-child(odd) {
+				background: #BDB9AA;
+			}
+			
+		</style>
+	</head>
+	<body>
+		<h2> {translate key="plugins.importexport.common.validationErrors"} </h2>
+		
+		<div> {translate key="plugins.importexport.medra.crossref.error.cause"} </div> <br/>
+		<div> {translate key="plugins.importexport.medra.crossref.error.number"}:  {$numberError} </div> <br/>
+		<div> {translate key="plugins.importexport.medra.crossref.error.details"}: </div> <br/>
+		<table>
+			<thead>
+				<tr>
+					<th>{translate key="plugins.importexport.medra.crossref.error.code"}</th>
+					<th>{translate key="plugins.importexport.medra.crossref.error.element"}</th>
+					<th>{translate key="plugins.importexport.medra.crossref.error.description"}</th>
+				</tr>
+				
+			</thead>
+			<tbody>
+				{foreach from=$headlines key=k item=v}
+					<tr>
+						<td>{$v['code']}</td>
+						<td>{$v['reference']}</td>
+						<td>{$v['description']}</td>
+					</tr>
+				{/foreach}
+			</tbody>
+		</table>
+		<h3>  {translate key="plugins.importexport.common.invalidXML"} </h3>
+		<pre>{$htmlspecialchars}</pre>
+		
+	</body>
+</html>

--- a/plugins/importexport/medra/templates/index.tpl
+++ b/plugins/importexport/medra/templates/index.tpl
@@ -65,6 +65,8 @@
 					$(function() {ldelim}
 						// Attach the form handler.
 						$('#exportSubmissionXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
+						//Initialization of the language with the value of the html file tag
+						$('#language').val($('html')[0].lang);
 					{rdelim});
 				</script>
 				<form id="exportSubmissionXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
@@ -74,6 +76,10 @@
 						{load_url_in_div id="submissionsListGridContainer" url=$submissionsListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+							// the checkbox that the user have to select to deposit submission either in medra, either in Crossref 
+							{fbvElement type="checkbox" id="crEnabled" label="plugins.importexport.common.send.to.crossref" checked=$crEnabled|default:false}
+							//The input type hidden insert in the form 
+							{fbvElement type="hidden" id="language"}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}
@@ -97,6 +103,8 @@
 					$(function() {ldelim}
 						// Attach the form handler.
 						$('#exportIssueXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
+						//Initialization of the language with the value of the html file tag
+						$('#language').val($('html')[0].lang);
 					{rdelim});
 				</script>
 				<form id="exportIssueXmlForm" class="pkp_form" action="{plugin_url path="exportIssues"}" method="post">
@@ -106,6 +114,10 @@
 						{load_url_in_div id="issuesListGridContainer" url=$issuesListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+							// the checkbox that the user have to select to deposit submission either in medra, either in Crossref 
+							{fbvElement type="checkbox" id="crEnabled" label="plugins.importexport.common.send.to.crossref" checked=$crEnabled|default:false}
+							//The input type hidden insert in the form 
+							{fbvElement type="hidden" id="language"}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}
@@ -129,6 +141,8 @@
 					$(function() {ldelim}
 						// Attach the form handler.
 						$('#exportRepresentationXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
+						//Initialization of the language with the value of the html file tag
+						$('#language').val($('html')[0].lang);
 					{rdelim});
 				</script>
 				<form id="exportRepresentationXmlForm" class="pkp_form" action="{plugin_url path="exportRepresentations"}" method="post">
@@ -138,6 +152,8 @@
 						{load_url_in_div id="representationsListGridContainer" url=$representationsListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+							//The input type hidden insert in the form 
+							{fbvElement type="hidden" id="language"}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}

--- a/plugins/importexport/medra/templates/index.tpl
+++ b/plugins/importexport/medra/templates/index.tpl
@@ -65,8 +65,6 @@
 					$(function() {ldelim}
 						// Attach the form handler.
 						$('#exportSubmissionXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
-						//Initialization of the language with the value of the html file tag
-						$('#language').val($('html')[0].lang);
 					{rdelim});
 				</script>
 				<form id="exportSubmissionXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
@@ -76,10 +74,7 @@
 						{load_url_in_div id="submissionsListGridContainer" url=$submissionsListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
-							// the checkbox that the user have to select to deposit submission either in medra, either in Crossref 
 							{fbvElement type="checkbox" id="crEnabled" label="plugins.importexport.common.send.to.crossref" checked=$crEnabled|default:false}
-							//The input type hidden insert in the form 
-							{fbvElement type="hidden" id="language"}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}
@@ -103,8 +98,6 @@
 					$(function() {ldelim}
 						// Attach the form handler.
 						$('#exportIssueXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
-						//Initialization of the language with the value of the html file tag
-						$('#language').val($('html')[0].lang);
 					{rdelim});
 				</script>
 				<form id="exportIssueXmlForm" class="pkp_form" action="{plugin_url path="exportIssues"}" method="post">
@@ -114,10 +107,7 @@
 						{load_url_in_div id="issuesListGridContainer" url=$issuesListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
-							// the checkbox that the user have to select to deposit submission either in medra, either in Crossref 
 							{fbvElement type="checkbox" id="crEnabled" label="plugins.importexport.common.send.to.crossref" checked=$crEnabled|default:false}
-							//The input type hidden insert in the form 
-							{fbvElement type="hidden" id="language"}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}
@@ -141,8 +131,6 @@
 					$(function() {ldelim}
 						// Attach the form handler.
 						$('#exportRepresentationXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
-						//Initialization of the language with the value of the html file tag
-						$('#language').val($('html')[0].lang);
 					{rdelim});
 				</script>
 				<form id="exportRepresentationXmlForm" class="pkp_form" action="{plugin_url path="exportRepresentations"}" method="post">
@@ -152,8 +140,6 @@
 						{load_url_in_div id="representationsListGridContainer" url=$representationsListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
-							//The input type hidden insert in the form 
-							{fbvElement type="hidden" id="language"}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}

--- a/plugins/importexport/medra/templates/index.tpl
+++ b/plugins/importexport/medra/templates/index.tpl
@@ -140,6 +140,7 @@
 						{load_url_in_div id="representationsListGridContainer" url=$representationsListGridUrl}
 						{fbvFormSection list="true"}
 							{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+							{fbvElement type="checkbox" id="crEnabled" label="plugins.importexport.common.send.to.crossref" checked=$crEnabled|default:false}
 						{/fbvFormSection}
 						{if !empty($actionNames)}
 							{fbvFormSection}


### PR DESCRIPTION
Modification of plugin mEDRA to allow user to deposit metadata not only
on mEDRA, but also in Crossref. implementation of logic that allows
mEDRA plugin user to choose either to deposit only on mEDRA, or to
deposit also in Crossref. This new implementation allows also the
display of some validations before the deposit in Crossref in case of
errors. The errors are displayed in a table. Some other enhancements:
insert as contributor the keyNames. Some bugfixes: remotion of the
control that remove on issn the value that is NOT in 0-9.