### PR TITLE
i5180 Made alt text for footer more descriptive

### DIFF
--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -1566,7 +1566,7 @@ msgid "about.memberships"
 msgstr "Memberships"
 
 msgid "about.aboutThisPublishingSystem"
-msgstr "About this Publishing System"
+msgstr "More information about the publishing system, Platform and Workflow by OJS/PKP."
 
 msgid "about.aboutThisPublishingSystem.altText"
 msgstr "OJS Editorial and Publishing Process"


### PR DESCRIPTION
From this issue "Address alt text / link location confusion in the OJS/OMP branding image on themes" (just the alt text for now): https://github.com/pkp/pkp-lib/issues/5180