### PR TITLE
Homepage Image Alt Text Missing

### DIFF
--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -23,7 +23,7 @@
 	{call_hook name="Templates::Index::journal"}
 
 	{if !$activeTheme->getOption('useHomepageImageAsHeader') && $homepageImage}
-		<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" alt="{$homepageImageAltText|escape}">
+		<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" alt="{$homepageImage.altText|escape}">
 	{/if}
 
 	{* Journal Description *}

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -24,7 +24,7 @@
 
 	{if !$activeTheme->getOption('useHomepageImageAsHeader') && $homepageImage}
 		<div class="homepage_image">
-			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" {if $homepageImage.altText} alt="{$homepageImage.altText|escape}"{/if}>
+			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}"{if $homepageImage.altText} alt="{$homepageImage.altText|escape}"{/if}>
 		</div>
 	{/if}
 

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -23,7 +23,9 @@
 	{call_hook name="Templates::Index::journal"}
 
 	{if !$activeTheme->getOption('useHomepageImageAsHeader') && $homepageImage}
-		<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" alt="{$homepageImage.altText|escape}">
+		<div class="homepage_image">
+			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" alt="{$homepageImage.altText|escape}">
+		</div>
 	{/if}
 
 	{* Journal Description *}

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -24,7 +24,7 @@
 
 	{if !$activeTheme->getOption('useHomepageImageAsHeader') && $homepageImage}
 		<div class="homepage_image">
-			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" alt="{$homepageImage.altText|escape}">
+			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}" {if $homepageImage.altText} alt="{$homepageImage.altText|escape}"{/if}>
 		</div>
 	{/if}
 


### PR DESCRIPTION
L. 26 is wrong – »$homepageImage.altText« is the right variable.
And `<div>` was missing.