### PR TITLE
Change input type from text to tel

### DIFF
--- a/templates/payments/subscriptionPolicyForm.tpl
+++ b/templates/payments/subscriptionPolicyForm.tpl
@@ -22,7 +22,7 @@
 		<p>{translate key="manager.subscriptionPolicies.subscriptionContactDescription"}</p>
 		{fbvElement type="text" label="user.name" required=true id="subscriptionName" value=$subscriptionName maxlength="60" inline=true size=$fbvStyles.size.MEDIUM}
 		{fbvElement type="text" label="user.email" id="subscriptionEmail" value=$subscriptionEmail size=$fbvStyles.size.MEDIUM required=true}
-		{fbvElement type="text" label="user.phone" name="subscriptionPhone" id="subscriptionPhone" value=$subscriptionPhone maxlength="24" size=$fbvStyles.size.SMALL}
+		{fbvElement type="tel" label="user.phone" name="subscriptionPhone" id="subscriptionPhone" value=$subscriptionPhone maxlength="24" size=$fbvStyles.size.SMALL}
 		{fbvElement type="textarea" id="subscriptionMailingAddress" value=$subscriptionMailingAddress height=$fbvStyles.height.SHORT required=true label="common.mailingAddress"}
 	{/fbvFormSection}
 


### PR DESCRIPTION
In comparison with text inputs, on mobile phones, [input tel](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel) present a custom keypad optimized for entering phone numbers. This eases user experience, which often access web content through their phones.