### PR TITLE
Add timezone %Z to all time_formats

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -58,9 +58,9 @@ time_zone = "UTC"
 date_format_trunc = "%m-%d"
 date_format_short = "%Y-%m-%d"
 date_format_long = "%B %e, %Y"
-datetime_format_short = "%Y-%m-%d %I:%M %p"
-datetime_format_long = "%B %e, %Y - %I:%M %p"
-time_format = "%I:%M %p"
+datetime_format_short = "%Y-%m-%d %I:%M %p %Z"
+datetime_format_long = "%B %e, %Y - %I:%M %p %Z"
+time_format = "%I:%M %p %Z"
 
 ; Use URL parameters instead of CGI PATH_INFO. This is useful for broken server
 ; setups that don't support the PATH_INFO environment variable.


### PR DESCRIPTION
[https://forum.pkp.sfu.ca/t/ojs3-timestamps-fixed-in-utc-and-display-no-timezone/60808/7?u=maifeld](url)

We have users across all timezones in the United States.  Seeing an unlabelled UTC time while sitting in their own timezone has caused some confusion.