### PR TITLE
Fixed xml validation errors

### DIFF
--- a/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
@@ -123,8 +123,12 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 				$personNameNode->setAttribute('language', PKPLocale::getIso1FromLocale($locale));
 				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'given_name', htmlspecialchars(ucfirst($givenNames[$locale]), ENT_COMPAT, 'UTF-8')));
 				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'surname', htmlspecialchars(ucfirst($familyNames[$locale]), ENT_COMPAT, 'UTF-8')));
-
 				$hasAltName = false;
+				
+				if ($author->getData('orcid')) {
+				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ORCID', $author->getData('orcid')));
+				}
+				
 				foreach($familyNames as $otherLocal => $familyName) {
 					if ($otherLocal != $locale && isset($familyName) && !empty($familyName)) {
 						if (!$hasAltName) {
@@ -148,10 +152,6 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 
 			} else {
 				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'surname', htmlspecialchars(ucfirst($author->getFullName(false)), ENT_COMPAT, 'UTF-8')));
-			}
-
-			if ($author->getData('orcid')) {
-				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ORCID', $author->getData('orcid')));
 			}
 			
 			$contributorsNode->appendChild($personNameNode);


### PR DESCRIPTION
I'm having the same problem as in the forum https://forum.pkp.sfu.ca/t/error-cvc-complex-type-2-4-d/62239

This error occurs when the "author" metadata is populated with multiple languages

The position of the "ORCID" schema must be above the "alt-name" schema, this is according to the instructions at http://data.crossref.org/reports/help/schema_doc/4.4.2/schema_4_4_2.html#person_name

I have tested the change in my ojs, author metadata, filled without and with multilingual, xml validation for deposit to crossref was successful