### PR TITLE
[stable-3_2_1] pkp#pkp-lib#5565 Submission preview feature implementation

### DIFF
--- a/classes/issue/IssueAction.inc.php
+++ b/classes/issue/IssueAction.inc.php
@@ -49,6 +49,9 @@ class IssueAction {
 	 * @return bool
 	 */
 	function allowedPrePublicationAccess($journal, $submission, $user) {
+		// Don't grant access until submission reaches Copyediting stage
+		if ($submission->getData('stageId') < WORKFLOW_STAGE_ID_EDITING) return false;
+
 		if ($this->_roleAllowedPrePublicationAccess($journal, $user)) return true;
 
 		if ($user && $journal) {

--- a/locale/en_US/submission.po
+++ b/locale/en_US/submission.po
@@ -158,6 +158,9 @@ msgstr "The requested citation format could not be retrieved."
 msgid "submission.metadataDescription"
 msgstr "These specifications are based on the Dublin Core metadata set, an international standard used to describe journal content."
 
+msgid "submission.viewingPreview"
+msgstr "This is a preview and has not been published. <a href=\"{$url}\">View submission</a>"
+
 msgid "section.any"
 msgstr "Any Section"
 

--- a/pages/article/ArticleHandler.inc.php
+++ b/pages/article/ArticleHandler.inc.php
@@ -75,7 +75,12 @@ class ArticleHandler extends Handler {
 			if ($submission && $request->getContext()->getId() != $submission->getContextId()) $submission = null;
 		}
 
-		if (!$submission || $submission->getData('status') !== STATUS_PUBLISHED) {
+		import('classes.issue.IssueAction');
+		$issueAction = new IssueAction();
+		$context = $request->getContext();
+		$user = $request->getUser();
+
+		if (!$submission || ($submission->getData('status') !== STATUS_PUBLISHED && !$issueAction->allowedPrePublicationAccess($context, $submission, $user))) {
 			$request->getDispatcher()->handle404();
 		}
 
@@ -107,7 +112,7 @@ class ArticleHandler extends Handler {
 			$galleyId = $subPath;
 		}
 
-		if ($this->publication->getData('status') !== STATUS_PUBLISHED) {
+		if ($this->publication->getData('status') !== STATUS_PUBLISHED && !$issueAction->allowedPrePublicationAccess($context, $submission, $user)) {
 			$request->getDispatcher()->handle404();
 		}
 

--- a/pages/article/ArticleHandler.inc.php
+++ b/pages/article/ArticleHandler.inc.php
@@ -509,6 +509,6 @@ class ArticleHandler extends Handler {
 	 */
 	function setupTemplate($request) {
 		parent::setupTemplate($request);
-		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_READER, LOCALE_COMPONENT_PKP_SUBMISSION);
+		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_READER, LOCALE_COMPONENT_PKP_SUBMISSION, LOCALE_COMPONENT_APP_SUBMISSION);
 	}
 }

--- a/pages/workflow/WorkflowHandler.inc.php
+++ b/pages/workflow/WorkflowHandler.inc.php
@@ -119,7 +119,7 @@ class WorkflowHandler extends PKPWorkflowHandler {
 		$workflowData['assignToIssueUrl'] = $assignToIssueUrl;
 		$workflowData['issueApiUrl'] = $issueApiUrl;
 		$workflowData['sectionWordLimits'] = $sectionWordLimits;
-		$workflowData['i18n']['schedulePublication'] = __('editor.submission.schedulePublication');
+		$workflowData['i18n']['preview'] = __('common.preview');
 		$workflowData['selectIssueLabel'] = __('publication.selectIssue');
 
 		$templateMgr->assign('workflowData', $workflowData);

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -69,8 +69,15 @@
 {/if}
 <article class="obj_article_details">
 
+	{* Indicate if this is only a preview *}
+	{if $article->getData('status') !== $smarty.const.STATUS_PUBLISHED || $publication->getData('status') !== $smarty.const.STATUS_PUBLISHED}
+	<div class="cmp_notification notice">
+		{capture assign="submissionUrl"}{url page="workflow" op="access" path=$article->getId()}{/capture}
+		{translate key="submission.viewingPreview" url=$submissionUrl}
+	</div>
+
 	{* Notification that this is an old version *}
-	{if $currentPublication->getId() !== $publication->getId()}
+	{elseif $currentPublication->getId() !== $publication->getId()}
 		<div class="cmp_notification notice">
 			{capture assign="latestVersionUrl"}{url page="article" op="view" path=$article->getBestId()}{/capture}
 			{translate key="submission.outdatedVersion"
@@ -79,11 +86,9 @@
 			}
 		</div>
 	{/if}
-
 	<h1 class="page_title">
 		{$publication->getLocalizedTitle()|escape}
 	</h1>
-
 	{if $publication->getLocalizedData('subtitle')}
 		<h2 class="subtitle">
 			{$publication->getLocalizedData('subtitle')|escape}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -70,7 +70,7 @@
 <article class="obj_article_details">
 
 	{* Indicate if this is only a preview *}
-	{if $article->getData('status') !== $smarty.const.STATUS_PUBLISHED || $publication->getData('status') !== $smarty.const.STATUS_PUBLISHED}
+	{if $publication->getData('status') !== $smarty.const.STATUS_PUBLISHED}
 	<div class="cmp_notification notice">
 		{capture assign="submissionUrl"}{url page="workflow" op="access" path=$article->getId()}{/capture}
 		{translate key="submission.viewingPreview" url=$submissionUrl}

--- a/templates/workflow/workflow.tpl
+++ b/templates/workflow/workflow.tpl
@@ -154,7 +154,7 @@
 										@click="openCreateVersionPrompt"
 									></pkp-button>
 									<pkp-button
-										v-if="submission.status === getConstant('STATUS_PUBLISHED') && workingPublication.status !== getConstant('STATUS_PUBLISHED')"
+										v-if="workingPublication.status !== getConstant('STATUS_PUBLISHED')"
 										element="a"
 										:label="i18n.preview"
 										:href="workingPublication.urlPublished"

--- a/templates/workflow/workflow.tpl
+++ b/templates/workflow/workflow.tpl
@@ -60,6 +60,11 @@
 					:label="i18n.preview"
 					:href="submission.urlPublished"
 				></pkp-button>
+				<pkp-button v-if="submission.status === getConstant('STATUS_PUBLISHED') && workingPublication.status !== getConstant('STATUS_PUBLISHED')"
+					element="a"
+					:label="i18n.preview"
+					:href="workingPublication.urlPublished"
+				></pkp-button>
 				{if $canAccessEditorialHistory}
 					<pkp-button
 						label="{translate key="editor.activityLog"}"

--- a/templates/workflow/workflow.tpl
+++ b/templates/workflow/workflow.tpl
@@ -50,9 +50,14 @@
 				</span>
 			</h1>
 			<template slot="actions">
-				<pkp-button
+				<pkp-button v-if="submission.status === getConstant('STATUS_PUBLISHED')"
 					element="a"
-					:label="submission.status === getConstant('STATUS_PUBLISHED') ? i18n.view : i18n.preview"
+					:label="i18n.view"
+					:href="submission.urlPublished"
+				></pkp-button>
+				<pkp-button v-else-if="submission.status !== getConstant('STATUS_PUBLISHED') && submission.stageId >= getConstant('WORKFLOW_STAGE_ID_EDITING')"
+					element="a"
+					:label="i18n.preview"
 					:href="submission.urlPublished"
 				></pkp-button>
 				{if $canAccessEditorialHistory}

--- a/templates/workflow/workflow.tpl
+++ b/templates/workflow/workflow.tpl
@@ -130,6 +130,12 @@
 							{if $canPublish}
 								<template slot="actions">
 									<pkp-button
+										v-if="workingPublication.status !== getConstant('STATUS_PUBLISHED') && submission.stageId >= getConstant('WORKFLOW_STAGE_ID_EDITING')"
+										element="a"
+										:label="i18n.preview"
+										:href="workingPublication.urlPublished"
+									></pkp-button>
+									<pkp-button
 										v-if="workingPublication.status === getConstant('STATUS_QUEUED')"
 										ref="publish"
 										:label="submission.status === getConstant('STATUS_PUBLISHED') ? i18n.publish : i18n.schedulePublication"
@@ -152,12 +158,6 @@
 										ref="createVersion"
 										label="{translate key="publication.createVersion"}"
 										@click="openCreateVersionPrompt"
-									></pkp-button>
-									<pkp-button
-										v-if="workingPublication.status !== getConstant('STATUS_PUBLISHED')"
-										element="a"
-										:label="i18n.preview"
-										:href="workingPublication.urlPublished"
 									></pkp-button>
 								</template>
 							{/if}

--- a/templates/workflow/workflow.tpl
+++ b/templates/workflow/workflow.tpl
@@ -51,9 +51,8 @@
 			</h1>
 			<template slot="actions">
 				<pkp-button
-					v-if="submission.status === getConstant('STATUS_PUBLISHED')"
 					element="a"
-					:label="i18n.view"
+					:label="submission.status === getConstant('STATUS_PUBLISHED') ? i18n.view : i18n.preview"
 					:href="submission.urlPublished"
 				></pkp-button>
 				{if $canAccessEditorialHistory}

--- a/templates/workflow/workflow.tpl
+++ b/templates/workflow/workflow.tpl
@@ -60,11 +60,6 @@
 					:label="i18n.preview"
 					:href="submission.urlPublished"
 				></pkp-button>
-				<pkp-button v-if="submission.status === getConstant('STATUS_PUBLISHED') && workingPublication.status !== getConstant('STATUS_PUBLISHED')"
-					element="a"
-					:label="i18n.preview"
-					:href="workingPublication.urlPublished"
-				></pkp-button>
 				{if $canAccessEditorialHistory}
 					<pkp-button
 						label="{translate key="editor.activityLog"}"
@@ -157,6 +152,12 @@
 										ref="createVersion"
 										label="{translate key="publication.createVersion"}"
 										@click="openCreateVersionPrompt"
+									></pkp-button>
+									<pkp-button
+										v-if="submission.status === getConstant('STATUS_PUBLISHED') && workingPublication.status !== getConstant('STATUS_PUBLISHED')"
+										element="a"
+										:label="i18n.preview"
+										:href="workingPublication.urlPublished"
 									></pkp-button>
 								</template>
 							{/if}


### PR DESCRIPTION
Allows submission preview starting from a copyediting stage according to the initial implementation by @majaroenne. Note that this is for the stable-3_2_1 branch. 