### PR TITLE
Disabled selection of fonts in the default theme when the CDN is disabled

### DIFF
--- a/plugins/themes/default/DefaultThemePlugin.inc.php
+++ b/plugins/themes/default/DefaultThemePlugin.inc.php
@@ -37,8 +37,10 @@ class DefaultThemePlugin extends ThemePlugin {
 		$this->addOption('typography', 'FieldOptions', [
 			'type' => 'radio',
 			'label' => __('plugins.themes.default.option.typography.label'),
-			'description' => __('plugins.themes.default.option.typography.description'),
-			'options' => [
+			'description' => (Config::getVar('general', 'enable_cdn'))
+				? __('plugins.themes.default.option.typography.description')
+				: __('plugins.themes.default.option.typegrapht.cdn_disabled'),
+			'options' => (Config::getVar('general', 'enable_cdn')) ? [
 				[
 					'value' => 'notoSans',
 					'label' => __('plugins.themes.default.option.typography.notoSans'),
@@ -67,7 +69,7 @@ class DefaultThemePlugin extends ThemePlugin {
 					'value' => 'lora_openSans',
 					'label' => __('plugins.themes.default.option.typography.lora_openSans'),
 				],
-			],
+			] : [],
 			'default' => 'notoSans',
 		]);
 

--- a/plugins/themes/default/locale/en_US/locale.po
+++ b/plugins/themes/default/locale/en_US/locale.po
@@ -23,6 +23,9 @@ msgstr "Typography"
 msgid "plugins.themes.default.option.typography.description"
 msgstr "Choose a font combination that suits this journal."
 
+msgid "plugins.themes.default.option.typography.cdn_disabled"
+msgstr "Your OJS settings have disabled CDN. Unfortunately, custom fonts require the use of CDN. Please speak to your system administrator and get them to enable the CDN in config.inc.php"
+
 msgid "plugins.themes.default.option.typography.notoSans"
 msgstr "Noto Sans: A digital-native font designed by Google for extensive language support."
 


### PR DESCRIPTION
Currently, the default theme that OJS comes with allows changing fonts on the journal. However, it will not change if the OJS configuration does not have `enabled_cdn` set to `On`. Also, there is no documentation or warnings that let the Journal administrator know if they can or can't change the fonts. 

The change propsed replaces the Radio buttons with a warning if the CDN isn't enabled. This way Journal admins can't change the font and are left wondering why nothing changed. I have only been able to provide the English localization.

Example photo:
<img width="926" alt="Screen Shot 2020-12-08 at 3 19 44 pm" src="https://user-images.githubusercontent.com/6085575/101444115-84aa4500-396a-11eb-8e2c-078747ed0d62.png">
