### PR TITLE
Hotfix/adjustment at docs read me for installation steps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,8 +91,12 @@ To install OJS:
 	 protected from direct access, such as via .htaccess rules).
 
 4. Run the Dependencies installer commands to ensure your environment properly configured.
-     Using the CLI, at OJS directory:
-      * For backend dependencies run `composer install`;
+    Using the CLI, at OJS directory:
+    > Note: We use [composer](https://getcomposer.org/) and [nodejs](https://nodejs.org/en/) to manage the dependencies.
+      * For backend dependencies run:
+        * `composer --working-dir=lib/pkp install`;
+        * `composer --working-dir=plugins/paymethod/paypal install`;
+        * `composer --working-dir=plugins/generic/citationStyleLanguage install`;
       * For frontend dependencies run `npm install && npm run build`;
 
 5. Open a web browser to http://yourdomain.com/path/to/ojs/ and

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,8 +89,13 @@ To install OJS:
 	 and make this directory writeable. It is recommended that this
 	 directory be placed in a non-web-accessible location (or otherwise
 	 protected from direct access, such as via .htaccess rules).
-	 
-4. Open a web browser to http://yourdomain.com/path/to/ojs/ and
+
+4. Run the Dependencies installer commands to ensure your environment properly configured.
+     Using the CLI, at OJS directory:
+      * For backend dependencies run `composer install`;
+      * For frontend dependencies run `npm install && npm run build`;
+
+5. Open a web browser to http://yourdomain.com/path/to/ojs/ and
 	 follow the on-screen installation instructions.
 	 
 	 Alternatively, the command-line installer can be used instead by
@@ -99,7 +104,7 @@ To install OJS:
 	 and uploaded files directories after installation, if the Apache
 	 user is different from the user running the tool.)
 
-5. Recommended additional steps post-installation:
+6. Recommended additional steps post-installation:
 
 	 * Review `config.inc.php` for additional configuration settings
 	 * Review the FAQ document for frequently asked technical and


### PR DESCRIPTION
Currently the docs/README.md file does not have, at Installation section, any item telling user to run the dependencies installation, but those instructions are available at the root README.md.

I've replicated it to docs/README.md to ensure consistency.