### PR TITLE
Add coverImage to publication schema to avoid unserialize() error during v3 migration (setFileName / DAO.inc.php)

### DIFF
--- a/schemas/publication.json
+++ b/schemas/publication.json
@@ -33,6 +33,12 @@
 				"nullable"
 			]
 		},
+		"coverImage": {
+			"type": "string",
+			"validation": [
+				"nullable"
+			]
+		},
 		"pages": {
 			"type": "string",
 			"description": "The pages of the issue in which this article appears if it is published in a physical format.",


### PR DESCRIPTION
When upgrading from OJS v2.4.8-5 to OJS v3.2.1 and when running `php tools/upgrade.php upgrade`, I hit an issue during the `Installer::setFileName` process which looked like so:

```
[...]
[code: Installer Installer::setFileName]
PHP Notice:  unserialize(): Error at offset 0 of 28 bytes in /usr/share/nginx/html/ojs/lib/pkp/classes/db/DAO.inc.php on line 357
PHP Notice:  unserialize(): Error at offset 0 of 28 bytes in /usr/share/nginx/html/ojs/lib/pkp/classes/db/DAO.inc.php on line 357
PHP Notice:  unserialize(): Error at offset 0 of 28 bytes in /usr/share/nginx/html/ojs/lib/pkp/classes/db/DAO.inc.php on line 357
PHP Notice:  unserialize(): Error at offset 0 of 28 bytes in /usr/share/nginx/html/ojs/lib/pkp/classes/db/DAO.inc.php on line 357
[...]
```

Delving into why, the underlying error stems from the `coverImage` setting field on a publication being treated as an `object` when it's actually a string - dumping the value passed to unserialize at that point in the code shows it's like so:  `string(28) "cover_article_1234_en_US.png"`. 

Access happens in `lib/pkp/classes/db/DAO.inc.php:357`, which gets called by `lib/pkp/classes/db/SchemaDAO.inc.php:250`, which loads the conversion type from the schema.  In this case, because of the lack of a `coverImage` field, hence why the `unserialize()` call is erroring. 

This PR add this field into `schemas/publication.json` which allows the migration from v2 to complete to v3 without error.  This mightn't be _the_ overall solution as I'm not familiar with the internals of OJS so changes/improvements to this PR are very welcome.