### PR TITLE
set urlPath when importing galleys via NativeXML

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlArticleGalleyFilter.inc.php
+++ b/plugins/importexport/native/filter/NativeXmlArticleGalleyFilter.inc.php
@@ -74,6 +74,7 @@ class NativeXmlArticleGalleyFilter extends NativeXmlRepresentationFilter {
 			if ($newSubmissionFileId) $addSubmissionFile = true;
 		}
 		$representation = parent::handleElement($node);
+		$representation->setData('urlPath', $node->getAttribute('url_path'));
 
 		for ($n = $node->firstChild; $n !== null; $n=$n->nextSibling) if (is_a($n, 'DOMElement')) switch($n->tagName) {
 			case 'name':


### PR DESCRIPTION
This pull request aims to fix bug reported https://github.com/pkp/pkp-lib/issues/6501 ("Galley url_path not imported in Native XML Import/Export")

I have tested it on OJS 3.2.1-1 and it produces the desired result, i.e. imported galleys now have the url_path specified in the article_galley element in the xml.

Feedback very welcome. Thanks