### PR TITLE
assign hideAuthor for sections in issue TOC

### DIFF
--- a/pages/issue/IssueHandler.inc.php
+++ b/pages/issue/IssueHandler.inc.php
@@ -324,6 +324,7 @@ class IssueHandler extends Handler {
 		foreach ($sections as $section) {
 			$issueSubmissionsInSection[$section->getId()] = [
 				'title' => $section->getHideTitle()?null:$section->getLocalizedTitle(),
+				'hideAuthor' => $section->getHideAuthor(),
 				'articles' => [],
 			];
 		}


### PR DESCRIPTION
This PR aims to address https://github.com/pkp/pkp-lib/issues/6310 ("Omit author names for section items from issues' table of contents" is ignored). It also address the second part of https://github.com/pkp/pkp-lib/issues/5955 (OJS should support author-less publications) but not the wider issue of author-less publications.

I have tested it on OJS 3.2.1-1 and it produces the desired result, i.e. author names no longer appear in the issue table of contents for sections where "Omit author names for section items from issues' has been ticked.

A couple of things to note:

- The author names still display on the full article details page. I think this is the intended behaviour? It would be good to have an option to also hide author names on article detail pages based on the parent section. Should that be logged as a new issue/feature request or just rolled into the https://github.com/pkp/pkp-lib/issues/5955 discussion?
- This doesn't affect the "Include this contributor in browse lists?" configuration which is set at contributor level at individual publications. However, that also appears to be broken (at least in OJS 3.2.1-1). I assume that should be logged as a new issue/pull-request?