### PR TITLE
pkp/pkp-lib#5948 tests for unpublishing an issue

### DIFF
--- a/cypress/tests/data/50-CreateIssues.spec.js
+++ b/cypress/tests/data/50-CreateIssues.spec.js
@@ -30,7 +30,7 @@ describe('Data suite tests', function() {
 		cy.wait(1000);
 		cy.get('a[id^=component-grid-issues-futureissuegrid-addIssue-button-]').click();
 		cy.wait(1000); // Avoid occasional failure due to form init taking time
-		cy.get('input[name="volume"]').type('1', {delay: 0});
+		cy.get('input[name="volume"]').type('2', {delay: 0});
 		cy.get('input[name="number"]').type('1', {delay: 0});
 		cy.get('input[name="year"]').type('2015', {delay: 0});
 		cy.get('input[id=showTitle]').click();

--- a/cypress/tests/data/50-CreateIssues.spec.js
+++ b/cypress/tests/data/50-CreateIssues.spec.js
@@ -23,6 +23,17 @@ describe('Data suite tests', function() {
 
 		cy.get('a.show_extras').click();
 		cy.contains('Publish Issue').click();
+		cy.get('input[id="sendIssueNotification"]').click();
+		cy.get('button[id^=submitFormButton]').click();
+
+		// create a future issue
+		cy.wait(1000);
+		cy.get('a[id^=component-grid-issues-futureissuegrid-addIssue-button-]').click();
+		cy.wait(1000); // Avoid occasional failure due to form init taking time
+		cy.get('input[name="volume"]').type('1', {delay: 0});
+		cy.get('input[name="number"]').type('1', {delay: 0});
+		cy.get('input[name="year"]').type('2015', {delay: 0});
+		cy.get('input[id=showTitle]').click();
 		cy.get('button[id^=submitFormButton]').click();
 	});
 })

--- a/cypress/tests/data/60-content/VkarbasizaedSubmission.spec.js
+++ b/cypress/tests/data/60-content/VkarbasizaedSubmission.spec.js
@@ -8,18 +8,22 @@
  */
 
 describe('Data suite tests', function() {
+	var familyName = 'Karbasizaed';
+	var submissionTitle = 'Antimicrobial, heavy metal resistance and plasmid profile of coliforms isolated from nosocomial infections in a hospital in Isfahan, Iran';
+	var issueTitle = 'Vol. 1 No. 1 (2015)';
+
 	it('Create a submission', function() {
 		cy.register({
 			'username': 'vkarbasizaed',
 			'givenName': 'Vajiheh',
-			'familyName': 'Karbasizaed',
+			'familyName': familyName,
 			'affiliation': 'University of Tehran',
 			'country': 'Iran, Islamic Republic of',
 		});
 
 		cy.createSubmission({
 			'section': 'Articles',
-			'title': 'Antimicrobial, heavy metal resistance and plasmid profile of coliforms isolated from nosocomial infections in a hospital in Isfahan, Iran',
+			'title': submissionTitle,
 			'abstract': 'The antimicrobial, heavy metal resistance patterns and plasmid profiles of Coliforms (Enterobacteriacea) isolated from nosocomial infections and healthy human faeces were compared. Fifteen of the 25 isolates from nosocomial infections were identified as Escherichia coli, and remaining as Kelebsiella pneumoniae. Seventy two percent of the strains isolated from nosocomial infections possess multiple resistance to antibiotics compared to 45% of strains from healthy human faeces. The difference between minimal inhibitory concentration (MIC) values of strains from clinical cases and from faeces for four heavy metals (Hg, Cu, Pb, Cd) was not significant. However most strains isolated from hospital were more tolerant to heavy metal than those from healthy persons. There was no consistent relationship between plasmid profile group and antimicrobial resistance pattern, although a conjugative plasmid (>56.4 kb) encoding resistance to heavy metals and antibiotics was recovered from eight of the strains isolated from nosocomial infections. The results indicate multidrug-resistance coliforms as a potential cause of nosocomial infection in this region.',
 		});
 
@@ -53,10 +57,151 @@ describe('Data suite tests', function() {
 		cy.get('button').contains('Continue').click();
 		cy.get('button').contains('Continue').click();
 		cy.get('button').contains('Complete').click();
+	});
 
+	it('Schedule for publication', function() {
+		cy.login('dbarnes');
+		// schedule for the publication in the future issue
+		cy.visit('index.php/publicknowledge/submissions');
+		cy.get('button[id="active-button"]').click();
+		cy.contains('View ' + familyName).click({force: true});
+		cy.get('button[id="publication-button"]').click();
+		cy.get('div#publication button:contains("Schedule For Publication")').click();
+		cy.get('select[id="assignToIssue-issueId-control"]').select(issueTitle);
+		cy.get('div[id^="assign-"] button:contains("Save")').click();
+		cy.get('div:contains("All publication requirements have been met. This will be published when ' + issueTitle + ' is published. Are you sure you want to schedule this for publication?")');
+		cy.get('div.pkpWorkflow__publishModal button:contains("Schedule For Publication")').click();
+		// check status = 5 (scheduled)
+		cy.reload() // to be able to get the header
+		// check submission status
+		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Scheduled");
+		// check publication status
+		cy.get('button[id="publication-button"]').click();
+		cy.get('span').should('have.class', 'pkpPublication__status').contains("Scheduled");
+		// the button "Unschedule" exists
+		// the buttons "Create New Version" (connected with submission) and "Unpublish" (connected with publication) does not exist
+		cy.get('div#publication button:contains("Unschedule")');
+		cy.get('div#publication button:contains("Create New Version")').should('not.exist');
+		cy.get('div#publication button:contains("Unpublish")').should('not.exist');
 
+		// isInTOC:
+		cy.visit('index.php/publicknowledge/manageIssues#future');
+		cy.get('a:contains("' + issueTitle + '")').click();
+		cy.get('div[id^="component-grid-toc-tocgrid-"] span:contains("' + submissionTitle + '")');
+		// go to issues management page to go around closing the TOC window
+		cy.visit('index.php/publicknowledge/manageIssues');
+	});
+
+	it('Publish the issue', function() {
+		cy.login('dbarnes');
+		cy.visit('index.php/publicknowledge/manageIssues#future');
+		cy.get('span:contains("' + issueTitle + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + issueTitle + '")').next().contains('a', 'Publish Issue').click();
+		cy.get('input[id="sendIssueNotification"]').click();
+		cy.get('button[id^=submitFormButton]').click();
+		// check status = 3 (published)
+		cy.visit('index.php/publicknowledge/submissions');
+		cy.get('button[id="active-button"]').click();
+		cy.contains('View ' + familyName).click({force: true});
+		// check submission status
+		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Published");
+		// check publication status
+		cy.get('button[id="publication-button"]').click();
+		cy.get('span').should('have.class', 'pkpPublication__status').contains("Published");
+		cy.contains('This version has been published and can not be edited.');
+		// the button "Unpublish" (connected with the publication)
+		// and the button "Create New Version" (connected with submission) exist
+		cy.get('div#publication button:contains("Unpublish")');
+		cy.get('div#publication button:contains("Create New Version")');
+	});
+
+	it('Unpublish the issue', function() {
+		cy.login('dbarnes');
+		cy.visit('index.php/publicknowledge/manageIssues#back');
+		cy.get('span:contains("' + issueTitle + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + issueTitle + '")').next().contains('a', 'Unpublish Issue').click();
+		cy.get('button:contains("OK")').click();
+		// check status = 5 (scheduled)
+		cy.visit('index.php/publicknowledge/submissions');
+		cy.get('button[id="active-button"]').click();
+		cy.contains('View ' + familyName).click({force: true});
+		// check submission status
+		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Scheduled");
+		// check publication status
+		cy.get('button[id="publication-button"]').click();
+		cy.get('span').should('have.class', 'pkpPublication__status').contains("Scheduled");
+		// the button "Unschedule" exists
+		// the buttons "Create New Version" (connected with submission) and "Unpublish" (connected with publication) does not exist
+		cy.get('div#publication button:contains("Unschedule")');
+		cy.get('div#publication button:contains("Create New Version")').should('not.exist');
+		cy.get('div#publication button:contains("Unpublish")').should('not.exist');
+	});
+
+	it('Republish the issue', function() {
+		cy.login('dbarnes');
+		cy.visit('index.php/publicknowledge/manageIssues#future');
+		cy.get('span:contains("' + issueTitle + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + issueTitle + '")').next().contains('a', 'Publish Issue').click();
+		cy.get('input[id="sendIssueNotification"]').click();
+		cy.get('button[id^=submitFormButton]').click();
+		// check status = 3
+		cy.visit('index.php/publicknowledge/submissions');
+		cy.get('button[id="active-button"]').click();
+		cy.contains('View ' + familyName).click({force: true});
+		// check submission status
+		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Published");
+		// check publication status
+		cy.get('button[id="publication-button"]').click();
+		cy.get('span').should('have.class', 'pkpPublication__status').contains("Published");
+		cy.contains('This version has been published and can not be edited.');
+		// the button "Unpublish" (connected with the publication)
+		// and the button "Create New Version" (connected with submission) exist
+		cy.get('div#publication button:contains("Unpublish")');
+		cy.get('div#publication button:contains("Create New Version")');
+	});
+
+	it('Remove submisison from TOC', function() {
+		cy.login('dbarnes');
+		cy.visit('index.php/publicknowledge/manageIssues#back');
+		cy.get('span:contains("' + issueTitle + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + issueTitle + '")').next().contains('a', 'Edit').click();
+		cy.get('span:contains("' + submissionTitle + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + submissionTitle + '")').next().contains('a', 'Remove').click();
+		cy.get('div:contains("Are you sure you wish to remove this article from the issue? The article will be available for scheduling in another issue.")');
+		cy.get('button:contains("OK")').click();
+		cy.get('span:contains("' + submissionTitle + '")').should('not.exist');
+		// check status = 1
+		cy.visit('index.php/publicknowledge/submissions');
+		cy.get('button[id="active-button"]').click();
+		cy.contains('View ' + familyName).click({force: true});
+		// check submission status
+		cy.get('span').should('not.have.class', 'pkpWorkflow__identificationStatus');
+		// check publication status
+		cy.get('button[id="publication-button"]').click();
+		cy.get('span').should('have.class', 'pkpPublication__status').contains("Unscheduled");
+		// the button "Schedule For Publication" exists
+		cy.get('div#publication button:contains("Schedule For Publication")');
+	});
+
+	it('Return back to the original state', function() {
+		cy.login('dbarnes');
 		// Publish in current issue
-		cy.publish('1', 'Vol. 1 No. 2 (2014)');
+		cy.visit('index.php/publicknowledge/submissions');
+		cy.get('button[id="active-button"]').click();
+		cy.contains('View ' +familyName).click({force: true});
+		cy.get('button[id="publication-button"]').click();
+		cy.get('button[id="issue-button"]').click();
+		cy.get('span:contains("This has not been scheduled for publication in an issue.")').next().click()
+		cy.get('select[id="assignToIssue-issueId-control"]').select('Vol. 1 No. 2 (2014)');
+		cy.get('div[id^="assign-"] button:contains("Save")').click();
+		cy.get('div[id^="publish-"] button:contains("Publish")').click();
 		cy.isInIssue('Antimicrobial, heavy metal resistance', 'Vol. 1 No. 2 (2014)');
+		// unpublish the future issue
+		cy.visit('index.php/publicknowledge/manageIssues#back');
+		cy.get('span:contains("' + issueTitle + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + issueTitle + '")').next().contains('a', 'Unpublish Issue').click();
+		cy.get('button:contains("OK")').click();
+		cy.visit('index.php/publicknowledge/manageIssues#future');
+		cy.get('span:contains("' + issueTitle + '")');
 	});
 });

--- a/cypress/tests/data/60-content/VkarbasizaedSubmission.spec.js
+++ b/cypress/tests/data/60-content/VkarbasizaedSubmission.spec.js
@@ -8,27 +8,35 @@
  */
 
 describe('Data suite tests', function() {
-	var familyName = 'Karbasizaed';
-	var submissionTitle = 'Antimicrobial, heavy metal resistance and plasmid profile of coliforms isolated from nosocomial infections in a hospital in Isfahan, Iran';
-	var issueTitle = 'Vol. 1 No. 1 (2015)';
+	var issueTitle = 'Vol. 2 No. 1 (2015)';
+	let submission;
+	let author;
+
+	before(function() {
+		submission = {
+			section: 'Articles',
+			prefix: '',
+			title: 'Antimicrobial, heavy metal resistance and plasmid profile of coliforms isolated from nosocomial infections in a hospital in Isfahan, Iran',
+			subtitle: '',
+			abstract: 'The antimicrobial, heavy metal resistance patterns and plasmid profiles of Coliforms (Enterobacteriacea) isolated from nosocomial infections and healthy human faeces were compared. Fifteen of the 25 isolates from nosocomial infections were identified as Escherichia coli, and remaining as Kelebsiella pneumoniae. Seventy two percent of the strains isolated from nosocomial infections possess multiple resistance to antibiotics compared to 45% of strains from healthy human faeces. The difference between minimal inhibitory concentration (MIC) values of strains from clinical cases and from faeces for four heavy metals (Hg, Cu, Pb, Cd) was not significant. However most strains isolated from hospital were more tolerant to heavy metal than those from healthy persons. There was no consistent relationship between plasmid profile group and antimicrobial resistance pattern, although a conjugative plasmid (>56.4 kb) encoding resistance to heavy metals and antibiotics was recovered from eight of the strains isolated from nosocomial infections. The results indicate multidrug-resistance coliforms as a potential cause of nosocomial infection in this region.',
+		}
+
+		author = {
+			username: 'vkarbasizaed',
+			givenName: 'Vajiheh',
+			familyName: 'Karbasizaed',
+			affiliation: 'University of Tehran',
+			country: 'Iran, Islamic Republic of',
+		}
+	});
 
 	it('Create a submission', function() {
-		cy.register({
-			'username': 'vkarbasizaed',
-			'givenName': 'Vajiheh',
-			'familyName': familyName,
-			'affiliation': 'University of Tehran',
-			'country': 'Iran, Islamic Republic of',
-		});
+		cy.register(author);
 
-		cy.createSubmission({
-			'section': 'Articles',
-			'title': submissionTitle,
-			'abstract': 'The antimicrobial, heavy metal resistance patterns and plasmid profiles of Coliforms (Enterobacteriacea) isolated from nosocomial infections and healthy human faeces were compared. Fifteen of the 25 isolates from nosocomial infections were identified as Escherichia coli, and remaining as Kelebsiella pneumoniae. Seventy two percent of the strains isolated from nosocomial infections possess multiple resistance to antibiotics compared to 45% of strains from healthy human faeces. The difference between minimal inhibitory concentration (MIC) values of strains from clinical cases and from faeces for four heavy metals (Hg, Cu, Pb, Cd) was not significant. However most strains isolated from hospital were more tolerant to heavy metal than those from healthy persons. There was no consistent relationship between plasmid profile group and antimicrobial resistance pattern, although a conjugative plasmid (>56.4 kb) encoding resistance to heavy metals and antibiotics was recovered from eight of the strains isolated from nosocomial infections. The results indicate multidrug-resistance coliforms as a potential cause of nosocomial infection in this region.',
-		});
+		cy.createSubmission(submission);
 
 		cy.logout();
-		cy.findSubmissionAsEditor('dbarnes', null, 'Karbasizaed');
+		cy.findSubmissionAsEditor('dbarnes', null, author.familyName);
 		cy.sendToReview();
 		cy.assignReviewer('Julie Janssen');
 		cy.assignReviewer('Paul Hudson');
@@ -64,32 +72,30 @@ describe('Data suite tests', function() {
 		// schedule for the publication in the future issue
 		cy.visit('index.php/publicknowledge/submissions');
 		cy.get('button[id="active-button"]').click();
-		cy.contains('View ' + familyName).click({force: true});
+		cy.get('#active .listPanel__itemTitle:contains("' + author.familyName + '")').parent().next().contains('a', 'View').click();
 		cy.get('button[id="publication-button"]').click();
-		cy.get('div#publication button:contains("Schedule For Publication")').click();
+		cy.get('#publication button:contains("Schedule For Publication")').click();
 		cy.get('select[id="assignToIssue-issueId-control"]').select(issueTitle);
 		cy.get('div[id^="assign-"] button:contains("Save")').click();
 		cy.get('div:contains("All publication requirements have been met. This will be published when ' + issueTitle + ' is published. Are you sure you want to schedule this for publication?")');
-		cy.get('div.pkpWorkflow__publishModal button:contains("Schedule For Publication")').click();
+		cy.get('.pkpWorkflow__publishModal button:contains("Schedule For Publication")').click();
+
 		// check status = 5 (scheduled)
-		cy.reload() // to be able to get the header
+		cy.wait(1000); // to be able to get the header
 		// check submission status
-		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Scheduled");
+		cy.get('.pkpWorkflow__header:contains("Scheduled")');
 		// check publication status
-		cy.get('button[id="publication-button"]').click();
-		cy.get('span').should('have.class', 'pkpPublication__status').contains("Scheduled");
+		cy.get('.pkpPublication__header:contains("Scheduled")');
 		// the button "Unschedule" exists
 		// the buttons "Create New Version" (connected with submission) and "Unpublish" (connected with publication) does not exist
-		cy.get('div#publication button:contains("Unschedule")');
-		cy.get('div#publication button:contains("Create New Version")').should('not.exist');
-		cy.get('div#publication button:contains("Unpublish")').should('not.exist');
+		cy.get('#publication button:contains("Unschedule")');
+		cy.get('#publication button:contains("Create New Version")').should('not.exist');
+		cy.get('#publication button:contains("Unpublish")').should('not.exist');
 
 		// isInTOC:
 		cy.visit('index.php/publicknowledge/manageIssues#future');
 		cy.get('a:contains("' + issueTitle + '")').click();
-		cy.get('div[id^="component-grid-toc-tocgrid-"] span:contains("' + submissionTitle + '")');
-		// go to issues management page to go around closing the TOC window
-		cy.visit('index.php/publicknowledge/manageIssues');
+		cy.get('div[id^="component-grid-toc-tocgrid-"] span:contains("' + submission.title + '")');
 	});
 
 	it('Publish the issue', function() {
@@ -101,18 +107,17 @@ describe('Data suite tests', function() {
 		cy.get('button[id^=submitFormButton]').click();
 		// check status = 3 (published)
 		cy.visit('index.php/publicknowledge/submissions');
-		cy.get('button[id="active-button"]').click();
-		cy.contains('View ' + familyName).click({force: true});
+		cy.get('button[id="archive-button"]').click();
+		cy.get('#archive .listPanel__itemTitle:contains("' + author.familyName + '")').parent().next().contains('a', 'View').click();
 		// check submission status
-		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Published");
+		cy.get('.pkpWorkflow__header:contains("Published")');
 		// check publication status
-		cy.get('button[id="publication-button"]').click();
-		cy.get('span').should('have.class', 'pkpPublication__status').contains("Published");
+		cy.get('.pkpPublication__header:contains("Published")');
 		cy.contains('This version has been published and can not be edited.');
 		// the button "Unpublish" (connected with the publication)
 		// and the button "Create New Version" (connected with submission) exist
-		cy.get('div#publication button:contains("Unpublish")');
-		cy.get('div#publication button:contains("Create New Version")');
+		cy.get('#publication button:contains("Unpublish")');
+		cy.get('#publication button:contains("Create New Version")');
 	});
 
 	it('Unpublish the issue', function() {
@@ -123,18 +128,17 @@ describe('Data suite tests', function() {
 		cy.get('button:contains("OK")').click();
 		// check status = 5 (scheduled)
 		cy.visit('index.php/publicknowledge/submissions');
-		cy.get('button[id="active-button"]').click();
-		cy.contains('View ' + familyName).click({force: true});
+		cy.get('button[id="archive-button"]').click();
+		cy.get('#archive .listPanel__itemTitle:contains("' + author.familyName + '")').parent().next().contains('a', 'View').click();
 		// check submission status
-		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Scheduled");
+		cy.get('.pkpWorkflow__header:contains("Scheduled")');
 		// check publication status
-		cy.get('button[id="publication-button"]').click();
-		cy.get('span').should('have.class', 'pkpPublication__status').contains("Scheduled");
+		cy.get('.pkpPublication__header:contains("Scheduled")');
 		// the button "Unschedule" exists
 		// the buttons "Create New Version" (connected with submission) and "Unpublish" (connected with publication) does not exist
-		cy.get('div#publication button:contains("Unschedule")');
-		cy.get('div#publication button:contains("Create New Version")').should('not.exist');
-		cy.get('div#publication button:contains("Unpublish")').should('not.exist');
+		cy.get('#publication button:contains("Unschedule")');
+		cy.get('#publication button:contains("Create New Version")').should('not.exist');
+		cy.get('#publication button:contains("Unpublish")').should('not.exist');
 	});
 
 	it('Republish the issue', function() {
@@ -146,18 +150,17 @@ describe('Data suite tests', function() {
 		cy.get('button[id^=submitFormButton]').click();
 		// check status = 3
 		cy.visit('index.php/publicknowledge/submissions');
-		cy.get('button[id="active-button"]').click();
-		cy.contains('View ' + familyName).click({force: true});
+		cy.get('button[id="archive-button"]').click();
+		cy.get('#archive .listPanel__itemTitle:contains("' + author.familyName + '")').parent().next().contains('a', 'View').click();
 		// check submission status
-		cy.get('span').should('have.class', 'pkpWorkflow__identificationStatus').contains("Published");
+		cy.get('.pkpWorkflow__header:contains("Published")');
 		// check publication status
-		cy.get('button[id="publication-button"]').click();
-		cy.get('span').should('have.class', 'pkpPublication__status').contains("Published");
+		cy.get('.pkpPublication__header:contains("Published")');
 		cy.contains('This version has been published and can not be edited.');
 		// the button "Unpublish" (connected with the publication)
 		// and the button "Create New Version" (connected with submission) exist
-		cy.get('div#publication button:contains("Unpublish")');
-		cy.get('div#publication button:contains("Create New Version")');
+		cy.get('#publication button:contains("Unpublish")');
+		cy.get('#publication button:contains("Create New Version")');
 	});
 
 	it('Remove submisison from TOC', function() {
@@ -165,22 +168,21 @@ describe('Data suite tests', function() {
 		cy.visit('index.php/publicknowledge/manageIssues#back');
 		cy.get('span:contains("' + issueTitle + '")').prev('a.show_extras').click();
 		cy.get('tr:contains("' + issueTitle + '")').next().contains('a', 'Edit').click();
-		cy.get('span:contains("' + submissionTitle + '")').prev('a.show_extras').click();
-		cy.get('tr:contains("' + submissionTitle + '")').next().contains('a', 'Remove').click();
+		cy.get('span:contains("' + submission.title + '")').prev('a.show_extras').click();
+		cy.get('tr:contains("' + submission.title + '")').next().contains('a', 'Remove').click();
 		cy.get('div:contains("Are you sure you wish to remove this article from the issue? The article will be available for scheduling in another issue.")');
 		cy.get('button:contains("OK")').click();
-		cy.get('span:contains("' + submissionTitle + '")').should('not.exist');
+		cy.get('span:contains("' + submission.title + '")').should('not.exist');
 		// check status = 1
 		cy.visit('index.php/publicknowledge/submissions');
 		cy.get('button[id="active-button"]').click();
-		cy.contains('View ' + familyName).click({force: true});
+		cy.get('#active .listPanel__itemTitle:contains("' + author.familyName + '")').parent().next().contains('a', 'View').click();
 		// check submission status
 		cy.get('span').should('not.have.class', 'pkpWorkflow__identificationStatus');
 		// check publication status
-		cy.get('button[id="publication-button"]').click();
-		cy.get('span').should('have.class', 'pkpPublication__status').contains("Unscheduled");
+		cy.get('.pkpPublication__header:contains("Unscheduled")');
 		// the button "Schedule For Publication" exists
-		cy.get('div#publication button:contains("Schedule For Publication")');
+		cy.get('#publication button:contains("Schedule For Publication")');
 	});
 
 	it('Return back to the original state', function() {
@@ -188,10 +190,10 @@ describe('Data suite tests', function() {
 		// Publish in current issue
 		cy.visit('index.php/publicknowledge/submissions');
 		cy.get('button[id="active-button"]').click();
-		cy.contains('View ' +familyName).click({force: true});
+		cy.get('#active .listPanel__itemTitle:contains("' + author.familyName + '")').parent().next().contains('a', 'View').click();
 		cy.get('button[id="publication-button"]').click();
 		cy.get('button[id="issue-button"]').click();
-		cy.get('span:contains("This has not been scheduled for publication in an issue.")').next().click()
+		cy.get('button:contains("Change Issue")').click();
 		cy.get('select[id="assignToIssue-issueId-control"]').select('Vol. 1 No. 2 (2014)');
 		cy.get('div[id^="assign-"] button:contains("Save")').click();
 		cy.get('div[id^="publish-"] button:contains("Publish")').click();


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/5948

- In 50-CreateIssues.spec.js I created a new, future issue -- It is needed for these tests, but maybe also for some similar in the future? If not I can create that issue only for these tests and remove it afterwards.
- I used VkarbasizaedSubmission.spec.js for these tests -- it is one of the straight forward published test submissions -- in order not to create a totally new one. OK so?
- The tests cover: schedule for publication in the future issue -> publish issue -> unpublish issue -> republish issue -> remove from TOC. Thus the two required options from the issue description ("1) ...when issue is unpublished. and 2) ...when an issue is published, unpublished and the republished.") are in a way put together. OK so?
- the issue TOC test is after the "schedule for publication" and automatically in "remove from TOC" and thus automatically after "republish issue". I believe this is enough, but, if necessary I can integrate that test also after each of publish issue -> unpublish issue?
- To check the submission and publication state there are a few option in the UI: For submission: the badge in the header of the submission backend page (span#pkpWorkflow__identificationStatus), but also the button "Create New Version". For publication: the status text on the publication tab (span#pkpPublication__status), but also the button "Unpublish". These all are checked in these tests. If too much I can remove?

Hmmmm... I believe that is all I wanted to mention... :thinking: :-)