### PR TITLE
pkp/pkp-lib#6625 Fix tombstones when issue is published/unpublished

### DIFF
--- a/controllers/grid/toc/TocGridHandler.inc.php
+++ b/controllers/grid/toc/TocGridHandler.inc.php
@@ -222,12 +222,7 @@ class TocGridHandler extends CategoryGridHandler {
 		$journal = $request->getJournal();
 		$submission = Services::get('submission')->get((int) $request->getUserVar('articleId'));
 		$issue = $this->getAuthorizedContextObject(ASSOC_TYPE_ISSUE);
-		import('classes.article.ArticleTombstoneManager');
-		$articleTombstoneManager = new ArticleTombstoneManager();
 		if ($submission && $request->checkCSRF()) {
-			if ($issue->getPublished() && $submission->getCurrentPublication()->getData('issueId') == $issue->getId()) {
-				$articleTombstoneManager->insertArticleTombstone($submission, $journal);
-			}
 			foreach ((array) $submission->getData('publications') as $publication) {
 				if ($publication->getData('issueId') === (int) $issue->getId()
 						&& in_array($publication->getData('status'), [STATUS_SCHEDULED, STATUS_PUBLISHED])) {


### PR DESCRIPTION
These changes centralize all of the tombstone handling into the `SubmissionService::updateStatus()` method. This should always be the method to update a submission's status, as it checks all assigned publications to determine whether it is published, scheduled or queued.