### PR TITLE
Display journal descriptions on site index page without adding <br>

### DIFF
--- a/templates/frontend/pages/indexSite.tpl
+++ b/templates/frontend/pages/indexSite.tpl
@@ -47,7 +47,7 @@
 							</h3>
 							{if $description}
 								<div class="description">
-									{$description|nl2br}
+									{$description}
 								</div>
 							{/if}
 							<ul class="links">


### PR DESCRIPTION
Journal descriptions are edited as rich text, meaning that they contain HTML by default and with TinyMCE as the editor, content will be wrapped in at least `<p>` tags.  Prior to this change, the use of `|nl2br` added a `<br>` tag after every newline, resulting in extra markup/spacing as a description with multiple paragraphs has its `<p>` tags on separate lines:

```html
<p>...</p><br>
<p>...</p><br>
<p>...</p>
```

This change outputs the description verbatim on the page, without conversion.

Whilst this change manifests as extra spacing between `<p>` tags, it's particularly important because the original code can create invalid HTML: `<br>` elements are injected where they shouldn't be.  I've applied this PR in our production system but an example of the issue can be seen at https://journals.calstate.edu/ if you view source on the descriptions:

```html
<ul><br>
<li class="show"><strong>Leah Penniman, MA</strong>: "Ending racism and injustice in the food system and reclaiming the inherent right to belong to the earth"</li><br>
<li class="show"><strong>Katharine Wilkinson, PhD</strong>: "Drawdown: How empowering women and girls can help stop global warming"</li><br>
```

In the HTML standard, `<br>` are [not permitted here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul) as direct children of list elements. 