### PR TITLE
pkp/pkp-lib#5844 Changing site-wide about field to rich textarea. And creating a a migration to handle cases when old data has html special characters

### DIFF
--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -210,6 +210,10 @@
 		<note file="docs/release-notes/README-3.4.0" />
 	</upgrade>
 
+	<upgrade minversion="3.0.0.0" maxversion="3.3.9.9">
+		<migration class="lib.pkp.classes.migration.ConvertSiteWideAboutToRichTextArea" />
+	</upgrade>
+
 	<!-- update plugin configuration - should be done as the final upgrade task -->
 	<code function="addPluginVersions" />
 </install>

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -210,10 +210,6 @@
 		<note file="docs/release-notes/README-3.4.0" />
 	</upgrade>
 
-	<upgrade minversion="3.0.0.0" maxversion="3.3.9.9">
-		<migration class="lib.pkp.classes.migration.ConvertSiteWideAboutToRichTextArea" />
-	</upgrade>
-
 	<!-- update plugin configuration - should be done as the final upgrade task -->
 	<code function="addPluginVersions" />
 </install>


### PR DESCRIPTION
# What was made?

At Administration > Site Settings > Information tab, the About field now it's a rich text area field.

Evidences are attached at pkp/pkp-lib#5844