### PR TITLE
pkp/pkp-lib#6784 fix crossref error when there is no family name

### DIFF
--- a/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
@@ -119,7 +119,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 			$givenNames = $author->getGivenName(null);
 
 			// Check if both givenName and familyName is set for the submission language.
-			if (isset($familyNames[$locale]) && isset($givenNames[$locale])) {
+			if (!empty($familyNames[$locale]) && !empty($givenNames[$locale])) {
 				$personNameNode->setAttribute('language', PKPLocale::getIso1FromLocale($locale));
 				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'given_name', htmlspecialchars(ucfirst($givenNames[$locale]), ENT_COMPAT, 'UTF-8')));
 				$personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'surname', htmlspecialchars(ucfirst($familyNames[$locale]), ENT_COMPAT, 'UTF-8')));


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/6784