### PR TITLE
Display site description without adding <br>

### DIFF
--- a/templates/frontend/pages/indexSite.tpl
+++ b/templates/frontend/pages/indexSite.tpl
@@ -14,7 +14,7 @@
 
 	{if $about}
 		<div class="about_site">
-			{$about|nl2br}
+			{$about}
 		</div>
 	{/if}
 


### PR DESCRIPTION
Same as #3043; but stems from https://github.com/pkp/pkp-lib/issues/5844

'About this Site' is now edited as rich text, meaning it contains HTML by default and with TinyMCE as the editor, content will be wrapped in at least `<p>` tags.  Prior to this change, the use of `|nl2br` added a `<br>` tag after every newline, resulting in extra markup/spacing as a description with multiple paragraphs has its `<p>` tags on separate lines:

```html
<p>...</p><br>
<p>...</p><br>
<p>...</p>
```

This change outputs the About information verbatim on the page, without conversion.