### PR TITLE
Improve invalid response error handling and wording for Crossref plugin

### DIFF
--- a/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
+++ b/plugins/importexport/crossref/CrossRefExportPlugin.inc.php
@@ -121,6 +121,7 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 			'POST',
 			$this->isTestMode($context) ? CROSSREF_API_STATUS_URL_DEV : CROSSREF_API_STATUS_URL,
 			[
+				'http_errors' => False,
 				'form_params' => [
 					'doi_batch_id' => $request->getUserVar('batchId'),
 					'type' => 'result',
@@ -131,7 +132,10 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 		);
 
 		if ($response->getStatusCode() != 200) {
-			return __('plugins.importexport.common.register.error.mdsError', array('param' => 'No response from server.'));
+			return __(
+				'plugins.importexport.common.register.error.mdsError',
+				array('param' => !empty($response->getBody()) ? (string) $response->getBody() : 'Empty response from Crossref server')
+			);
 		}
 		return (string) $response->getBody();
 	}
@@ -298,7 +302,7 @@ class CrossRefExportPlugin extends DOIPubIdExportPlugin {
 			);
 		} catch (GuzzleHttp\Exception\RequestException $e) {
 			if ($e->getResponse()->getStatusCode() != CROSSREF_API_DEPOSIT_ERROR_FROM_CROSSREF) {
-				return [['plugins.importexport.common.register.error.mdsError', 'No response from server.']];
+				return [['plugins.importexport.common.register.error.mdsError', !empty($e->getResponse()->getBody()) ? (string) $e->getResponse()->getBody() : 'Empty response from Crossref server']];
 			}
 
 			$response = $e->getResponse();


### PR DESCRIPTION
At present, https://api.crossref.org/servlet/submissionDownload appears to be having a technical problem, resulting in 404 responses (I'm working through this with the Crossref team separately).

However, this situation highlights an issue in the OJS plugin -- Guzzle's HTTP client [throws](https://docs.guzzlephp.org/en/stable/request-options.html#http-errors) an unhandled exception when it encounters anything that's not a valid response status. 

This means that OJS/PHP currently returns a 500 Internal Server. This in turn doesn't respond with a valid JSON response
when trying to view the status for a "failed" export (e.g. a HTTP request to a URL like:

    /$$$call$$$/grid/settings/plugins/settings-plugin-grid/manage?plugin=CrossRefExportPlugin&category=importexport&verb=statusMessage&batchId=123456789&articleId=9999

which leads to a frontend error `Failed Ajax request or invalid JSON returned.`

This PR configures Guzzle to not throw an exception for status message retrieval so that the existing non-200 code can operate. Additionally, the actual server error response body is sent onto the user in OJS to help explain the situation -- the original error of "No response from server" is both unclear and ambiguous as to which server is involved.  This latter error message is reworded to clarify the Crossref server is the one returning an empty or invalid response.

This same set of changes is also applied to the deposit HTTP calls as well, to better report errors if that call fails.