### PR TITLE
pkp/pkp-lib#6828 Fixed the section ordering when a new section is added later into an already sorted TOC.

### DIFF
--- a/controllers/grid/toc/TocGridHandler.inc.php
+++ b/controllers/grid/toc/TocGridHandler.inc.php
@@ -187,7 +187,11 @@ class TocGridHandler extends CategoryGridHandler {
 		if (!$sectionDao->customSectionOrderingExists($issue->getId())) {
 			$sectionDao->setDefaultCustomSectionOrders($issue->getId());
 		}
-		$sectionDao->updateCustomSectionOrder($issue->getId(), $sectionId, $newSequence);
+		if ($sectionDao->getCustomSectionOrder($issue->getId(), $sectionId)) {
+			$sectionDao->updateCustomSectionOrder($issue->getId(), $sectionId, $newSequence);
+		} else {
+			$sectionDao->insertCustomSectionOrder($issue->getId(), $sectionId, $newSequence);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Back porting fix from /main