### PR TITLE
Extend README to add detailed requirements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ improvements or bug fixes to the software.
 
 Recommended server requirements:
 
-* PHP >= 7.3
+* PHP >= 7.3 (with php-mbstring and php-xml support [1])
 * MySQL >= 4.1 or PostgreSQL >= 9.5
 * Apache >= 1.3.2x or >= 2.0.4x or Microsoft IIS 6
 * Operating system: Any OS that supports the above software, including
@@ -169,6 +169,10 @@ interpreter installed on your server.
 
 
 ## Third-party Libraries
+
+* In non debian stacks, additional libraries and php modules could be required and need to be
+	manually installed. For a detailed list, check the docker release of your version:
+	[1]: https://github.com/pkp/docker-ojs/blob/main/versions/3_3_0-8/alpine/apache/php73/Dockerfile#L27
 
 * See [lib/pkp/lib/libraries.txt](../lib/pkp/lib/libraries.txt) for a list of third-party libraries
 	used by OJS.


### PR DESCRIPTION
The new upgrade guide refers README as the place where requirements are described:
https://github.com/pkp/pkp-docs/blob/27554643e0a83b2ab1f9eb44b367cae562590bd0/upgrade-guide/en/index.md

Over debian-like distributions (aka. ubuntu) two plugins are missed (php-mbstring and php-xml) and need to be included.
For additional features (searcher...) or in non debian-like distros, a detailed list of applications, libraries and php-moudles is required.

In the docker project we install apline (a very tiny OS) and all applications and modules need to be installed by hand, so all the requirements are explicit.
Dockerfile is very easy to read and is going to be maintained up to date with a detailed list of any requirement, so is good place to refer to avoid doing extra work.

If you prefer it be an external file in pkp/docker-ojs project or in pkp/ojs... it's also feasible.

This PR is just a proposal, so feel free to refuse, remake even refuse if you have better alternative to detail ojs's requirements.