### PR TITLE
pkp/pkp-lib#4235 Don't output invalid chars in OAI setSpec

### DIFF
--- a/classes/article/ArticleTombstoneManager.inc.php
+++ b/classes/article/ArticleTombstoneManager.inc.php
@@ -16,6 +16,7 @@
 namespace APP\article;
 
 use APP\facades\Repo;
+use APP\oai\ojs\OAIDAO;
 use APP\submission\Submission;
 use PKP\config\Config;
 
@@ -40,7 +41,7 @@ class ArticleTombstoneManager
         $tombstoneDao->deleteByDataObjectId($article->getId());
         // insert article tombstone
         $section = $sectionDao->getById($article->getSectionId());
-        $setSpec = urlencode($journal->getPath()) . ':' . urlencode($section->getLocalizedAbbrev());
+        $setSpec = OAIDAO::setSpec($journal, $section);
         $oaiIdentifier = 'oai:' . Config::getVar('oai', 'repository_id') . ':' . 'article/' . $article->getId();
         $OAISetObjectsIds = [
             ASSOC_TYPE_JOURNAL => $journal->getId(),

--- a/classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
+++ b/classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
@@ -43,7 +43,3 @@ class I4235_OAISetSpec extends \PKP\migration\Migration
         // The old format is not recoverable since some characters might have been stripped
     }
 }
-
-if (!PKP_STRICT_MODE) {
-    class_alias('\APP\migration\upgrade\v3_4_0\I4235_OAISetSpec', '\I4235_OAISetSpec');
-}

--- a/classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
+++ b/classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I4235_OAISetSpec
+ */
+
+namespace APP\migration\upgrade\v3_4_0;
+
+use Illuminate\Support\Facades\DB;
+use PKP\oai\OAIUtils;
+
+class I4235_OAISetSpec extends \PKP\migration\Migration
+{
+    /**
+     * Run the migration.
+     */
+    public function up(): void
+    {
+        // pkp/pkp-lib/issues/4235 Improve OAI-PMH set spec compliance
+        // Convert stored setSpec strings to valid format
+        $setSpecs = DB::table('data_object_tombstones')->select('set_spec')->get()->toArray();
+        foreach ($setSpecs as $row) {
+            $a = preg_split('/:/', $row->set_spec);
+            if (count($a) == 2) {
+                [$journalSpec, $sectionSpec] = $a;
+                $new = OAIUtils::toValidSetSpec(urldecode($journalSpec)) . ':' . OAIUtils::toValidSetSpec(urldecode($sectionSpec));
+                DB::table('data_object_tombstones')->where('set_spec', $row->set_spec)->update(['set_spec' => $new]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the downgrades
+     */
+    public function down(): void
+    {
+        // The old format is not recoverable since some characters might have been stripped
+    }
+}
+
+if (!PKP_STRICT_MODE) {
+    class_alias('\APP\migration\upgrade\v3_4_0\I4235_OAISetSpec', '\I4235_OAISetSpec');
+}

--- a/classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
+++ b/classes/migration/upgrade/v3_4_0/I4235_OAISetSpec.inc.php
@@ -24,7 +24,7 @@ class I4235_OAISetSpec extends \PKP\migration\Migration
     {
         // pkp/pkp-lib/issues/4235 Improve OAI-PMH set spec compliance
         // Convert stored setSpec strings to valid format
-        $setSpecs = DB::table('data_object_tombstones')->select('set_spec')->get()->toArray();
+        $setSpecs = DB::table('data_object_tombstones')->select('set_spec')->distinct()->get()->toArray();
         foreach ($setSpecs as $row) {
             $a = preg_split('/:/', $row->set_spec);
             if (count($a) == 2) {

--- a/classes/oai/ojs/JournalOAI.inc.php
+++ b/classes/oai/ojs/JournalOAI.inc.php
@@ -19,14 +19,13 @@
 
 namespace APP\oai\ojs;
 
+use APP\core\Application;
+use PKP\db\DAORegistry;
 use PKP\oai\OAI;
 use PKP\oai\OAIRepository;
 use PKP\oai\OAIResumptionToken;
-use PKP\db\DAORegistry;
-use PKP\plugins\HookRegistry;
 
-use APP\oai\ojs\OAIDAO;
-use APP\core\Application;
+use PKP\plugins\HookRegistry;
 
 class JournalOAI extends OAI
 {
@@ -109,12 +108,9 @@ class JournalOAI extends OAI
         $tmpArray = preg_split('/:/', $setSpec);
         if (count($tmpArray) == 1) {
             [$journalSpec] = $tmpArray;
-            $journalSpec = urldecode($journalSpec);
             $sectionSpec = null;
         } elseif (count($tmpArray) == 2) {
             [$journalSpec, $sectionSpec] = $tmpArray;
-            $journalSpec = urldecode($journalSpec);
-            $sectionSpec = urldecode($sectionSpec);
         } else {
             return [0, 0];
         }

--- a/classes/oai/ojs/OAIDAO.inc.php
+++ b/classes/oai/ojs/OAIDAO.inc.php
@@ -173,13 +173,14 @@ class OAIDAO extends PKPOAIDAO
         }
 
         $journalId = $journal->getId();
-        $sectionId = 0;
+        $sectionId = null;
 
         if (isset($sectionSpec)) {
+            $sectionId = 0;
             $sectionIterator = $this->sectionDao->getByJournalId($journalId);
 
             while ($section = $sectionIterator->next()) {
-                if ($sectionSpec == $this->toValidSetSpec($section->getLocalizedAbbrev())) {
+                if ($sectionSpec == OAIUtils::toValidSetSpec($section->getLocalizedAbbrev())) {
                     $sectionId = $section->getId();
                     break;
                 }

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -216,6 +216,10 @@
 		<data file="dbscripts/xml/upgrade/3.4.0_preupdate_email_templates.xml" />
 		<note file="docs/release-notes/README-3.4.0" />
 	</upgrade>
+        
+	<upgrade minversion="3.0.0.0" maxversion="3.4.9.9">
+		<migration class="APP\migration\upgrade\v3_4_0\I4235_OAISetSpec" />
+ 	</upgrade>
 
 	<!-- update plugin configuration - should be done as the final upgrade task -->
 	<code function="addPluginVersions" />

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -215,11 +215,8 @@
 		<migration class="APP\migration\upgrade\v3_4_0\I6807_SetLastModified" />
 		<data file="dbscripts/xml/upgrade/3.4.0_preupdate_email_templates.xml" />
 		<note file="docs/release-notes/README-3.4.0" />
-	</upgrade>
-        
-	<upgrade minversion="3.0.0.0" maxversion="3.4.9.9">
 		<migration class="APP\migration\upgrade\v3_4_0\I4235_OAISetSpec" />
- 	</upgrade>
+	</upgrade>
 
 	<!-- update plugin configuration - should be done as the final upgrade task -->
 	<code function="addPluginVersions" />


### PR DESCRIPTION
Issue: https://github.com/pkp/pkp-lib/issues/4235
Depends on corresponding PR in pkp-lib https://github.com/pkp/pkp-lib/pull/7345

Valid characters in setSpec [1] are URI unreserved characters [2]
(`a-z`, `A-Z`, `0-9`, `-_.!~*'()`) Currently, OJS creates the setSpec
string by running `urlencode` on journal path and section abbreviation.
This produces invalid character, e.g. `%`, and the OAI-PMH feed fails
to be harvested by clients with strict validation.

This change assumes that journal path is validated to be ASCII
alphanumeric, '-' and '_' elsewhere.

Section abbreviation can be a user supplied containing any Unicode character.
Make it into a valid setSpec string by
- transliterating all non-Latin characters
- stripping all diacritics
- dropping any remaining invalid characters

This will of course not produce a meaningful result for many languages
but it will be a valid setSpec string.

Examples:
"innehåll" -> "innehall"
"Ελληνικά" -> "Ellenika"
"ひらがな" -> "hiragana"

Depends on php-intl extension (which I had to install to get OJS running so should be available?)

[1] https://www.openarchives.org/OAI/2.0/openarchivesprotocol.htm#Set
[2] http://www.ietf.org/rfc/rfc2396.txt