### PR TITLE
Add p.last_modified to update the last datestamp.

### DIFF
--- a/classes/oai/ojs/OAIDAO.inc.php
+++ b/classes/oai/ojs/OAIDAO.inc.php
@@ -240,7 +240,7 @@ class OAIDAO extends PKPOAIDAO
 
         return DB::table('submissions AS a')
             ->select([
-                DB::raw('GREATEST(a.last_modified, i.last_modified) AS last_modified'),
+                DB::raw('GREATEST(a.last_modified, i.last_modified, p.last_modified) AS last_modified'),
                 'a.submission_id AS submission_id',
                 'i.issue_id',
                 DB::raw('NULL AS tombstone_id'),
@@ -271,10 +271,10 @@ class OAIDAO extends PKPOAIDAO
                 return $query->where('p.section_id', '=', (int) $sectionId);
             })
             ->when($from, function ($query, $from) {
-                return $query->where('GREATEST(a.last_modified, i.last_modified)', '>=', $from);
+                return $query->where('GREATEST(a.last_modified, i.last_modified, p.last_modified)', '>=', $from);
             })
             ->when($until, function ($query, $until) {
-                return $query->where('GREATEST(a.last_modified, i.last_modified)', '<=', $until);
+                return $query->where('GREATEST(a.last_modified, i.last_modified, p.last_modified)', '<=', $until);
             })
             ->when($submissionId, function ($query, $submissionId) {
                 return $query->where('a.submission_id', '=', (int) $submissionId);


### PR DESCRIPTION
In an OJS 3.3.0-7 from where a harvest server, harvest the metadata of published articles, the harvest server doesn’t identify the updated articles in OAI-PMH because the datestamp isn’t updated to the date the article was updated.

My proposal to solve it, is to modify in the file classes/oai/ojs/OAI DAO.inc.php, adding p.last modified on the querys. With this change, the OAI already shows the datestamp with the date of the last_modified field of the publications table and vufind already identifies it as an updated article to re-harvest it.

There are more information in: https://forum.pkp.sfu.ca/t/ojs-3-3-0-7-oai-doesnt-update-the-datestamp-to-the-date-of-the-last-update-to-allow-metadata-harvest/69677

Regards