### PR TITLE
pkp/pkp-lib#7595 Allow valid special characters in doi suffix

### DIFF
--- a/classes/plugins/PubIdPlugin.inc.php
+++ b/classes/plugins/PubIdPlugin.inc.php
@@ -213,7 +213,7 @@ abstract class PubIdPlugin extends \PKP\plugins\PKPPubIdPlugin
                 $pubIdSuffix = $this->getSetting($contextId, $suffixPatternsFieldNames[$pubObjectType]);
 
                 // %j - journal initials, remove special characters and uncapitalize
-                $pubIdSuffix = PKPString::regexp_replace('/%j/', PKPString::regexp_replace('/[^A-Za-z0-9]/', '', PKPString::strtolower($context->getAcronym($context->getPrimaryLocale()))), $pubIdSuffix);
+                $pubIdSuffix = PKPString::regexp_replace('/%j/', PKPString::regexp_replace('/[^-._;()\/:A-Za-z0-9]/', '', PKPString::strtolower($context->getAcronym($context->getPrimaryLocale()))), $pubIdSuffix);
 
                 // %x - custom identifier
                 if ($pubObject->getStoredPubId('publisher-id')) {
@@ -251,7 +251,7 @@ abstract class PubIdPlugin extends \PKP\plugins\PKPPubIdPlugin
                 break;
 
             default:
-                $pubIdSuffix = PKPString::regexp_replace('/[^A-Za-z0-9]/', '', PKPString::strtolower($context->getAcronym($context->getPrimaryLocale())));
+                $pubIdSuffix = PKPString::regexp_replace('/[^-._;()\/:A-Za-z0-9]/', '', PKPString::strtolower($context->getAcronym($context->getPrimaryLocale())));
 
                 if ($issue) {
                     $pubIdSuffix .= '.v' . $issue->getVolume() . 'i' . $issue->getNumber();

--- a/plugins/pubIds/doi/DOIPubIdPlugin.inc.php
+++ b/plugins/pubIds/doi/DOIPubIdPlugin.inc.php
@@ -447,7 +447,7 @@ class DOIPubIdPlugin extends PubIdPlugin
                 'value' => $form->publication->getData('pub-id::doi'),
                 'prefix' => $prefix,
                 'pattern' => $pattern,
-                'contextInitials' => PKPString::regexp_replace('/[^A-Za-z0-9]/', '', PKPString::strtolower($form->submissionContext->getData('acronym', $form->submissionContext->getData('primaryLocale')))) ?? '',
+                'contextInitials' => PKPString::regexp_replace('/[^-._;()\/:A-Za-z0-9]/', '', PKPString::strtolower($form->submissionContext->getData('acronym', $form->submissionContext->getData('primaryLocale')))) ?? '',
                 'separator' => '/',
                 'submissionId' => $form->publication->getData('submissionId'),
                 'assignIdLabel' => __('plugins.pubIds.doi.editor.doi.assignDoi'),


### PR DESCRIPTION
Hi!

The regex for the DOI suffix currently removes characters that are [rendered valid by Crossref](https://www.crossref.org/documentation/member-setup/constructing-your-dois/#afewrules), in particular: "hyphen, period, underscore, semicolon, parentheses, forward slash". This was introduced in / is related to pkp/pkp-lib/issues/5505 and #2620

This PR suggests an (untested!) regex based on [this post](https://www.crossref.org/blog/dois-and-matching-regular-expressions/).

Best regards!