### PR TITLE
Adding DOI field to MarcXML OAI output

### DIFF
--- a/plugins/oaiMetadataFormats/marcxml/templates/record.tpl
+++ b/plugins/oaiMetadataFormats/marcxml/templates/record.tpl
@@ -17,14 +17,21 @@
 	{/if}
 	{if $journal->getData('onlineIssn')}
 		<datafield tag="022" ind1="#" ind2="#">
-			<subfield code="$a">{$journal->getData('onlineIssn')|escape}</subfield>
+			<subfield code="a">{$journal->getData('onlineIssn')|escape}</subfield>
 		</datafield>
 	{/if}
 	{if $journal->getData('printIssn')}
 		<datafield tag="022" ind1="#" ind2="#">
-			<subfield code="$a">{$journal->getData('printIssn')|escape}</subfield>
+			<subfield code="a">{$journal->getData('printIssn')|escape}</subfield>
 		</datafield>
 	{/if}
+	{if $article->getStoredPubId('doi')}
+	<datafield tag="024" ind1="7" ind2="#">
+		<subfield code="a">{$article->getStoredPubId('doi')|escape}</subfield>
+		<subfield code="2">doi</subfield>
+	</datafield>
+	{/if}
+
 	<datafield tag="042" ind1=" " ind2=" ">
 		<subfield code="a">dc</subfield>
 	</datafield>


### PR DESCRIPTION
We realized in our team that the MARC-XML of the OAI-API did not return the article's DOI. Hence, here is the fix.

Also there were two wrongly named subfields that were fixed.

All kudos to @j4lib.