### PR TITLE
Fix upgrade error in I17014_DoiMigration.inc.php

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I7014_DoiMigration.inc.php
+++ b/classes/migration/upgrade/v3_4_0/I7014_DoiMigration.inc.php
@@ -756,7 +756,7 @@ class I7014_DoiMigration extends Migration
                     $this->_updateDoi($item->doi_id, $item->context_id, $item->setting_value);
                 }
             }
-        }, 'publication_id');
+        }, 'p.publication_id','publication_id');
 
         // Remove pub-id::doi settings entry
         DB::table('publication_settings')


### PR DESCRIPTION
**Problem**
When upgrading from ojs version 3.3.0.7 to the current main branch 3.4, we ran across the following error when running `upgrade.php` :

>2022-03-02 11:04:32 [downgrade for "PKP\migration\upgrade\v3_4_0\I7167_RemoveDuplicatedUserSettingsAndDep recatedFields" unsupported: Downgrade unsupported due to removed data] ERROR: Upgrade failed: DB: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'publication_id' in where clause is ambiguous (SQL: select `s`.`context_id`, `p`.`publication_id`, `p`.`doi_id`, `pss`.`setting_name`, `pss`.`setting_value` from `submissions` as `s` left join `publications` as `p` on `p`.`subm ission_id` = `s`.`submission_id` left join `publication_settings` as `pss` on `pss`.`publication_id` = `p `.`publication_id` where `pss`.`setting_name` = pub-id::doi and `publication_id` > 2433 order by `publication_id` asc limit 1000)

**Solution**
We tracked the source to the following file: 
`classes/migration/upgrade/v3_4_0/I7014_DoiMigration.inc.php` and fixed the php code which generates the above query by properly specifiying the column name and alias; argument 3 and 4 of the `chunkById()` method. After doing so, `upgrade.php` finished without aborting.

Could be related to: Commit https://github.com/pkp/ojs/commit/81664e142122e18afc5333eb9602d3e1ea48b2a3 ; Issue https://github.com/pkp/pkp-lib/issues/7014 (@ewhanson)

Thanks in advance, hope this is helpful!
