### PR TITLE
Display orcid and  green icon only for validated orcid ids.

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -117,7 +117,7 @@
 									{/if}
 								</span>
 							{/if}
-							{if $author->getData('orcid')}
+                            {if $author->getData('orcid') && $author->getData('orcidAccessToken')}
 								<span class="orcid">
 									{$orcidIcon}
 									<a href="{$author->getData('orcid')|escape}" target="_blank">


### PR DESCRIPTION
PS discovered this issue.

Orcid id alongside  green orcid id should be displayed for only authenticated author ids.
