### PR TITLE
Allow journals to disable author biography

### DIFF
--- a/classes/components/forms/context/AppearanceSetupForm.inc.php
+++ b/classes/components/forms/context/AppearanceSetupForm.inc.php
@@ -14,6 +14,7 @@
  */
 namespace APP\components\forms\context;
 use \PKP\components\forms\context\PKPAppearanceSetupForm;
+use \PKP\components\forms\FieldOptions;
 use \PKP\components\forms\FieldUploadImage;
 
 class AppearanceSetupForm extends PKPAppearanceSetupForm {
@@ -34,5 +35,17 @@ class AppearanceSetupForm extends PKPAppearanceSetupForm {
 					'url' => $temporaryFileApiUrl,
 				],
 			]), [FIELD_POSITION_AFTER, 'pageHeaderLogoImage']);
+		$this->addField(new FieldOptions('hideAuthorBiography', [
+				'label' => __('manager.setup.hideAuthorBiography'),
+				'type' => 'checkbox',
+				'value' => $context->getData('hideAuthorBiography'),
+				'options' => [
+					[
+						'value' => true,
+						'label' => __('manager.setup.hideAuthorBiography.description')
+					]
+				],
+				'default' => false,
+			]));
 	}
 }

--- a/locale/en_US/manager.po
+++ b/locale/en_US/manager.po
@@ -1714,3 +1714,9 @@ msgstr "Abstracts"
 
 msgid "stats.publications.galleys"
 msgstr "Files"
+
+msgid "manager.setup.hideAuthorBiography"
+msgstr "Author Biography"
+
+msgid "manager.setup.hideAuthorBiography.description"
+msgstr "Hide Author Biography"

--- a/schemas/context.json
+++ b/schemas/context.json
@@ -84,6 +84,12 @@
 				"nullable"
 			]
 		},
+		"hideAuthorBiography": {
+			"type": "boolean",
+			"validation" : [
+				"nullable"
+			]
+		},
 		"journalThumbnail": {
 			"type": "object",
 			"multilingual": true,

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -185,7 +185,7 @@
 					{assign var="hasBiographies" value=$hasBiographies+1}
 				{/if}
 			{/foreach}
-			{if $hasBiographies}
+			{if !$currentContext->getData('hideAuthorBiography') && $hasBiographies}
 				<section class="item author_bios">
 					<h2 class="label">
 						{if $hasBiographies > 1}


### PR DESCRIPTION
There were some journals that wanted to have the option to disable the Author Biography section.

We added the option to Website -> Appearance -> Setup.

It appears that there are others that would like this option (https://forum.pkp.sfu.ca/t/switch-off-author-biography-on-article-page/52724).

Please feel free to give feedback or edit this.