### PR TITLE
pkp/pkp-lib#4240 Submodule Update ##touhidurabir/i4240_fix_main##

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -128,12 +128,11 @@ enable_beacon = On
 ; as separate Privacy Statements for each journal.
 sitewide_privacy_statement = Off
 
-; Remove all unvalidated and expired users after validation timeout.
-; A user will consider as expired if the the validation is enabled and after the days passed off
-; validation_timeout, the user has not validated. In the scenario when the require_validation has
-; turned off, user will consider expired if has not logged in once past the days of validation_timeout
-; since the day of registration.
-remove_expired_users = Off
+; The number of days a new user has to validate their account
+; A new user account will be expired and removed if this many days have passed since the user registered
+; their account, and they have not validated their account or logged in. If the user_validation_period is set to 
+; 0, unvalidated accounts will never be removed. Use this setting to automatically remove bot registrations.
+user_validation_period = 28
 
 
 ;;;;;;;;;;;;;;;;;;;;;

--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -128,6 +128,13 @@ enable_beacon = On
 ; as separate Privacy Statements for each journal.
 sitewide_privacy_statement = Off
 
+; Remove all unvalidated and expired users after validation timeout.
+; A user will consider as expired if the the validation is enabled and after the days passed off
+; validation_timeout, the user has not validated. In the scenario when the require_validation has
+; turned off, user will consider expired if has not logged in once past the days of validation_timeout
+; since the day of registration.
+remove_expired_users = Off
+
 
 ;;;;;;;;;;;;;;;;;;;;;
 ; Database Settings ;

--- a/registry/scheduledTasks.xml
+++ b/registry/scheduledTasks.xml
@@ -44,7 +44,7 @@
 		<frequency hour="0" />
 	</task>
   <task class="lib.pkp.classes.task.RemoveUnvalidatedExpiredUsers">
-    <descr>Automatically remove unvalidated and expired users .</descr>
+    <descr>Automatically remove unvalidated and expired users.</descr>
     <frequency day="1"/>
   </task>
 </scheduled_tasks>

--- a/registry/scheduledTasks.xml
+++ b/registry/scheduledTasks.xml
@@ -43,8 +43,8 @@
 		<descr>Automatically deposit any outstanding DOIs to the configured registration agency.</descr>
 		<frequency hour="0" />
 	</task>
-  <task class="lib.pkp.classes.task.RemoveUnvalidatedExpiredUsers">
-    <descr>Automatically remove unvalidated and expired users.</descr>
-    <frequency day="1"/>
-  </task>
+	<task class="lib.pkp.classes.task.RemoveUnvalidatedExpiredUsers">
+		<descr>Automatically remove unvalidated and expired users.</descr>
+		<frequency day="1"/>
+	</task>
 </scheduled_tasks>

--- a/registry/scheduledTasks.xml
+++ b/registry/scheduledTasks.xml
@@ -43,4 +43,8 @@
 		<descr>Automatically deposit any outstanding DOIs to the configured registration agency.</descr>
 		<frequency hour="0" />
 	</task>
+  <task class="lib.pkp.classes.task.RemoveUnvalidatedExpiredUsers">
+    <descr>Automatically remove unvalidated and expired users .</descr>
+    <frequency day="1"/>
+  </task>
 </scheduled_tasks>


### PR DESCRIPTION
This PR aims to resolve the issue pkp/pkp-lib#4240 by adding the feature that will allow automatic removal of unvalidated expired users . The removal process as follows : 

- User has not validated
- User has never logged in since registration
- the difference between registration and task running has passed what is set for `validation_timeout` in the config file

Also the removal process needed to be initiated from the `config` file as setting defined . 