### PR TITLE
pkp/pkp-lib#3585 Submodule Update ##touhidurabir/i3585_main##

### DIFF
--- a/classes/decision/Decision.inc.php
+++ b/classes/decision/Decision.inc.php
@@ -41,6 +41,7 @@ class Decision extends BaseDecision
     public const BACK_TO_REVIEW = 20;
     public const BACK_TO_COPYEDITING = 21;
     public const BACK_TO_SUBMISSION_FROM_COPYEDITING = 22;
+    public const DELETE_EMPTY_EXTERNAL_REVIEW_ROUND = 23;
 }
 
 if (!PKP_STRICT_MODE) {

--- a/classes/decision/Repository.inc.php
+++ b/classes/decision/Repository.inc.php
@@ -28,6 +28,7 @@ use PKP\decision\types\RecommendDecline;
 use PKP\decision\types\RecommendResubmit;
 use PKP\decision\types\RecommendRevisions;
 use PKP\decision\types\RequestRevisions;
+use PKP\decision\types\RemoveEmptyExternalReviewRound;
 use PKP\decision\types\Resubmit;
 use PKP\decision\types\RevertDecline;
 use PKP\decision\types\RevertInitialDecline;
@@ -62,6 +63,7 @@ class Repository extends \PKP\decision\Repository
                 new SendExternalReview(),
                 new SendToProduction(),
                 new SkipExternalReview(),
+                new RemoveEmptyExternalReviewRound(),
             ]);
             HookRegistry::call('Decision::types', [$decisionTypes]);
             $this->decisionTypes = $decisionTypes;


### PR DESCRIPTION
This PR aims to provide a way to handle pkp/pkp-lib#3585 by allowing the editor to delete/remove an empty review round when created accidentally . 