### PR TITLE
pkp/pkp-lib#8086 test for user country before using Countries library

### DIFF
--- a/plugins/reports/subscriptions/SubscriptionReportPlugin.inc.php
+++ b/plugins/reports/subscriptions/SubscriptionReportPlugin.inc.php
@@ -140,7 +140,11 @@ class SubscriptionReportPlugin extends ReportPlugin {
 						$columns[$index] = PKPString::html2text($user->getMailingAddress());
 						break;
 					case 'country':
-						$country = $countries->getByAlpha2($user->getCountry());
+						$userCountry = $user->getCountry();
+						$country = null;
+						if ($userCountry) {
+							$country = $countries->getByAlpha2($user->getCountry());
+						}
 						$columns[$index] = $country?$country->getLocalName():'';
 						break;
 					case 'email':


### PR DESCRIPTION
adds a test to ensure that a user has set their country, otherwise just include the blank field in the report.