### PR TITLE
pkp/pkp-lib#5193 Aria-live should be more assertive in how to cite component

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -346,7 +346,7 @@
 							{translate key="submission.howToCite"}
 						</h2>
 						<div class="value">
-							<div id="citationOutput" role="region" aria-live="polite">
+							<div id="citationOutput" role="region" aria-live="assertive">
 								{$citation}
 							</div>
 							<div class="citation_formats">


### PR DESCRIPTION
This PR fixes the aria-live parameter from `polite` to `assertive` in how to cite component in the article landing page.