### PR TITLE
pkp/pkp-lib#5195 Remove current issue link from the cover image 

### DIFF
--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -41,10 +41,12 @@
 		{* Issue cover image *}
 		{assign var=issueCover value=$issue->getLocalizedCoverImageUrl()}
 		{if $issueCover}
-			{capture assign="defaultAltText"}
-				{translate key="issue.viewIssueIdentification" identification=$issue->getIssueIdentification()|escape}
-			{/capture}
-			<img src="{$issueCover|escape}" alt="{$issue->getLocalizedCoverImageAltText()|escape|default:$defaultAltText}">
+			<div class="cover">
+				{capture assign="defaultAltText"}
+					{translate key="issue.viewIssueIdentification" identification=$issue->getIssueIdentification()|escape}
+				{/capture}
+				<img src="{$issueCover|escape}" alt="{$issue->getLocalizedCoverImageAltText()|escape|default:$defaultAltText}">
+			</div>
 		{/if}
 
 		{* Description *}

--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -41,12 +41,10 @@
 		{* Issue cover image *}
 		{assign var=issueCover value=$issue->getLocalizedCoverImageUrl()}
 		{if $issueCover}
-			<a class="cover" href="{url op="view" page="issue" path=$issue->getBestIssueId()}">
-				{capture assign="defaultAltText"}
-					{translate key="issue.viewIssueIdentification" identification=$issue->getIssueIdentification()|escape}
-				{/capture}
-				<img src="{$issueCover|escape}" alt="{$issue->getLocalizedCoverImageAltText()|escape|default:$defaultAltText}">
-			</a>
+			{capture assign="defaultAltText"}
+				{translate key="issue.viewIssueIdentification" identification=$issue->getIssueIdentification()|escape}
+			{/capture}
+			<img src="{$issueCover|escape}" alt="{$issue->getLocalizedCoverImageAltText()|escape|default:$defaultAltText}">
 		{/if}
 
 		{* Description *}


### PR DESCRIPTION
This PR removes the link on the issue cover image from the _index_ and _issue_ pages : https://github.com/pkp/pkp-lib/issues/5195