### PR TITLE
pkp/pkp-lib#5196 CSS Pseudo selectors creating a duplicated link announcement on screenreaders

### DIFF
--- a/plugins/themes/default/styles/objects/article_details.less
+++ b/plugins/themes/default/styles/objects/article_details.less
@@ -130,9 +130,9 @@
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: start;
-		
+
 		li {
-			margin-inline-end: 0.25rem
+			margin-inline-end: 0.25rem;
 		}
 	}
 

--- a/plugins/themes/default/styles/objects/article_details.less
+++ b/plugins/themes/default/styles/objects/article_details.less
@@ -132,7 +132,7 @@
 		justify-content: start;
 		
 		li {
-			margin-right: 0.2em;
+			margin-inline-end: 0.25rem
 		}
 	}
 

--- a/plugins/themes/default/styles/objects/article_details.less
+++ b/plugins/themes/default/styles/objects/article_details.less
@@ -132,7 +132,7 @@
 		justify-content: start;
 
 		li {
-			margin-inline-end: 0.25rem;
+			margin-inline-end: 1rem;
 		}
 	}
 

--- a/plugins/themes/default/styles/objects/article_details.less
+++ b/plugins/themes/default/styles/objects/article_details.less
@@ -127,9 +127,12 @@
 
 	.galleys_links {
 		&:extend(.pkp_unstyled_list);
-
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: start;
+		
 		li {
-			display: inline-block;
+			margin-right: 0.2em;
 		}
 	}
 

--- a/plugins/themes/default/styles/objects/article_summary.less
+++ b/plugins/themes/default/styles/objects/article_summary.less
@@ -58,10 +58,12 @@
 	.galleys_links {
 		&:extend(.pkp_unstyled_list);
 		margin-top: @base;
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: start;
 
 		li {
-			display: inline-block;
-			margin-right: 1em;
+			margin-inline-end: 1.25rem;
 
 			&:last-child {
 				margin-right: 0;

--- a/plugins/themes/default/styles/objects/article_summary.less
+++ b/plugins/themes/default/styles/objects/article_summary.less
@@ -63,10 +63,10 @@
 		justify-content: start;
 
 		li {
-			margin-inline-end: 1.25rem;
+			margin-inline-end: 1rem;
 
 			&:last-child {
-				margin-right: 0;
+				margin-inline-end: 0;
 			}
 		}
 	}

--- a/plugins/themes/default/styles/objects/issue_toc.less
+++ b/plugins/themes/default/styles/objects/issue_toc.less
@@ -77,10 +77,10 @@
 		justify-content: start;
 
 		li {
-			margin-inline-end: 1.25rem;
+			margin-inline-end: 1rem;
 
 			&:last-child {
-				margin-right: 0;
+				margin-inline-end: 0;
 			}
 		}
 	}

--- a/plugins/themes/default/styles/objects/issue_toc.less
+++ b/plugins/themes/default/styles/objects/issue_toc.less
@@ -72,10 +72,12 @@
 	.galleys_links {
 		&:extend(.pkp_unstyled_list);
 		margin-top: @base;
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: start;
 
 		li {
-			display: inline-block;
-			margin-right: 1em;
+			margin-inline-end: 1.25rem;
 
 			&:last-child {
 				margin-right: 0;


### PR DESCRIPTION
Fix the duplicated announcement of link galleys by screenreaders removing the extra space between closing / opening list item tags, i.e.: `</li><li>`. The required visual gap is fixed via CSS/LESS.