### PR TITLE
Implements font-display attribute into default theme fonts files

### DIFF
--- a/plugins/themes/default/styles/fonts/lato.less
+++ b/plugins/themes/default/styles/fonts/lato.less
@@ -20,6 +20,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-regular.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-regular.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-regular.svg#Lato') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* lato-italic - latin-ext_latin */
@@ -34,6 +35,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-italic.svg#Lato') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* lato-900 - latin-ext_latin */
@@ -48,6 +50,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-900.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-900.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-900.svg#Lato') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* lato-900italic - latin-ext_latin */
@@ -62,4 +65,5 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-900italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-900italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lato-v17-latin-ext_latin-900italic.svg#Lato') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }

--- a/plugins/themes/default/styles/fonts/lora.less
+++ b/plugins/themes/default/styles/fonts/lora.less
@@ -20,6 +20,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.svg#Lora') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* lora-700 - vietnamese_latin-ext_latin_cyrillic-ext_cyrillic */
@@ -34,6 +35,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.svg#Lora') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* lora-italic - vietnamese_latin-ext_latin_cyrillic-ext_cyrillic */
@@ -48,6 +50,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-italic.svg#Lora') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* lora-700italic - vietnamese_latin-ext_latin_cyrillic-ext_cyrillic */
@@ -62,4 +65,5 @@
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/lora-v16-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700italic.svg#Lora') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }

--- a/plugins/themes/default/styles/fonts/notoSerif.less
+++ b/plugins/themes/default/styles/fonts/notoSerif.less
@@ -20,6 +20,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.svg#NotoSerif') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* noto-serif-italic - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
@@ -34,6 +35,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-italic.svg#NotoSerif') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* noto-serif-700 - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
@@ -48,6 +50,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.svg#NotoSerif') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* noto-serif-700italic - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
@@ -62,4 +65,5 @@
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/noto-serif-v9-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700italic.svg#NotoSerif') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }

--- a/plugins/themes/default/styles/fonts/openSans.less
+++ b/plugins/themes/default/styles/fonts/openSans.less
@@ -20,6 +20,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.svg#OpenSans') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* open-sans-italic - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
@@ -34,6 +35,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-italic.svg#OpenSans') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* open-sans-700 - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
@@ -48,6 +50,7 @@
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.svg#OpenSans') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }
 
 /* open-sans-700italic - vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic */
@@ -62,4 +65,5 @@
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700italic.woff') format('woff'), /* Modern Browsers */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700italic.ttf') format('truetype'), /* Safari, Android, iOS */
        url('@{baseUrl}/plugins/themes/default/fonts/open-sans-v18-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700italic.svg#OpenSans') format('svg'); /* Legacy iOS */
+	font-display: swap;
 }


### PR DESCRIPTION
In this [PR - 8244](https://github.com/pkp/pkp-lib/pull/8244) made for [pkp-lib](https://github.com/pkp/pkp-lib), the "font-display" attribute was added to fix a small problem that the OJS software faces, the fact that the text is not being displayed until the font files are loaded.

As this [PR](https://github.com/pkp/pkp-lib/pull/8244) progressed, an [issue was created](https://github.com/pkp/pkp-lib/issues/8246), to solve the problem and requested the same implementation made in pkp-lib, for OJS, in the default theme font files.

So we added the `font-display` attribute in the theme font files [as requested](https://github.com/pkp/pkp-lib/pull/8244#issuecomment-1243466344).

**Reference on this issue involving font loading:** https://web.dev/font-display/?utm_source=lighthouse&utm_medium=lr