### PR TITLE
Make user menu wider

### DIFF
--- a/plugins/themes/default/styles/head.less
+++ b/plugins/themes/default/styles/head.less
@@ -445,7 +445,7 @@
 		}
 
 		ul {
-			width: 10em;
+			width: 13em;
 		}
 
 		// Reproduce positioning of dropdown menu from Popper.js


### PR DESCRIPTION
Russian user menu is too narrow and word **Администрирование** doesn't fit menu width. Russian translation of **Administration** is the longest. Compare this:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Administration menu</title>
    <style>
        body {
            font-family: "Montserrat",-apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen-Sans","Ubuntu","Cantarell","Helvetica Neue",sans-serif;
        }

        ul {
            list-style: none;
            width: 10em;
            margin: 0;
            padding: 0;
        }

        li {
            margin-bottom: .1rem;
            padding: 0.357rem;
            background: #def;
            font-size: .93rem;
            font-weight: 700;
        }
    </style>
</head>
<body>
    <h1>Menu items</h1>
    <p>Move mouse pointer over the menu to ask for locale.</p>
    <ul>
        <!-- grep -R 'msgid "navigation.admin"' -A 1 | sort | perl -nle 'print qq{<li title="$1">$2</li>} if m{^(.+)/.*msgstr "(.*)"}' -->
        <li title="ar_IQ">الإدارة</li>
        <li title="ca_ES">Gestió</li>
        <li title="cs_CZ">Administrace</li>
        <li title="da_DK">Administration</li>
        <li title="de_DE">Administration</li>
        <li title="el_GR">Διαχείριση</li>
        <li title="en_US">Administration</li>
        <li title="es_ES">Administración</li>
        <li title="eu_ES">Administrazioa</li>
        <li title="fa_IR">مدیریت</li>
        <li title="fi_FI">Ylläpito</li>
        <li title="fr_CA">Administration</li>
        <li title="fr_FR">Administration</li>
        <li title="gd_GB">Ball sgioba rianachd LibreOffice</li>
        <li title="gl_ES">Administración</li>
        <li title="hu_HU">Adminisztráció</li>
        <li title="hy_AM">Ադմինիստրացիա</li>
        <li title="id_ID">Administrasi</li>
        <li title="is_IS">Umsjón</li>
        <li title="it_IT">Amministrazione</li>
        <li title="ja_JP">管理</li>
        <li title="mk_MK">Администрација</li>
        <li title="nb_NO">Administrasjon</li>
        <li title="nl_NL">Beheer</li>
        <li title="pl_PL">Administracja</li>
        <li title="pt_BR">Administração</li>
        <li title="pt_PT">Administração</li>
        <li title="ro_RO">Administrare</li>
        <li title="ru_RU">Администрирование</li>
        <li title="sl_SI">Administracija</li>
        <li title="sr_RS@cyrillic">Администрација</li>
        <li title="sr_RS@latin">Administracija</li>
        <li title="sv_SE">Administration</li>
        <li title="tr_TR">Yönetim</li>
        <li title="uk_UA">Адміністрування</li>
        <li title="vi_VN">Quản trị</li>
        <li title="zh_CN">管理</li>
    </ul>
</body>
</html>
```

`13em` is quite enough.