### PR TITLE
pkp/pkp-lib#8448 use original file name when downloading issue galley

### DIFF
--- a/classes/file/IssueFileManager.php
+++ b/classes/file/IssueFileManager.php
@@ -137,7 +137,7 @@ class IssueFileManager extends FileManager
             $fileType = $issueFile->getFileType();
             $filePath = $this->getFilesDir() . $this->contentTypeToPath($issueFile->getContentType()) . '/' . $issueFile->getServerFileName();
 
-            return parent::downloadByPath($filePath, $fileType, $inline);
+            return parent::downloadByPath($filePath, $fileType, $inline, $issueFile->getOriginalFileName());
         } else {
             return false;
         }


### PR DESCRIPTION
Adds explicit argument to parent method call.