### PR TITLE
pkp/pkp-lib#8481 Consider not migrated assoc and metric types when copying orphaned metrics into the temporary table

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I6782_OrphanedMetrics.php
+++ b/classes/migration/upgrade/v3_4_0/I6782_OrphanedMetrics.php
@@ -8,7 +8,9 @@
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class I6782_OrphanedMetrics
- * @brief Migrate metrics data from objects that do not exist any more into the temporary table.
+ * @brief Migrate metrics data from objects that do not exist any more and from assoc types that are not considered in the upgrade into the temporary table.
+ * These entries will be copied back and stay in the table metrics_old, s. I6782_CleanOldMetrics.
+ * Consider only metric_type ojs::counter here, because these entries will be removed during the upgrade.
  */
 
 namespace APP\migration\upgrade\v3_4_0;
@@ -21,6 +23,11 @@ class I6782_OrphanedMetrics extends \PKP\migration\upgrade\v3_4_0\I6782_Orphaned
     private const ASSOC_TYPE_CONTEXT = 0x0000100;
     private const ASSOC_TYPE_ISSUE = 0x0000103;
     private const ASSOC_TYPE_ISSUE_GALLEY = 0x0000105;
+
+    protected function getMetricType(): string
+    {
+        return 'ojs::counter';
+    }
 
     protected function getContextAssocType(): int
     {
@@ -47,6 +54,18 @@ class I6782_OrphanedMetrics extends \PKP\migration\upgrade\v3_4_0\I6782_Orphaned
         return 'galley_id';
     }
 
+    protected function getAssocTypesToMigrate(): array
+    {
+        return array_merge(
+            [
+                self::ASSOC_TYPE_CONTEXT,
+                self::ASSOC_TYPE_ISSUE,
+                self::ASSOC_TYPE_ISSUE_GALLEY,
+            ],
+            parent::getAssocTypesToMigrate()
+        );
+    }
+
     /**
      * Run the migration.
      *
@@ -61,13 +80,13 @@ class I6782_OrphanedMetrics extends \PKP\migration\upgrade\v3_4_0\I6782_Orphaned
         // Metrics issue IDs
         // as m.assoc_id
         $orphanedIds = DB::table('metrics AS m')->leftJoin('issues AS i', 'm.assoc_id', '=', 'i.issue_id')->where('m.assoc_type', '=', self::ASSOC_TYPE_ISSUE)->whereNull('i.issue_id')->distinct()->pluck('m.assoc_id');
-        $orphandedIssues = DB::table('metrics')->select($metricsColumns)->where('assoc_type', '=', self::ASSOC_TYPE_ISSUE)->whereIn('assoc_id', $orphanedIds);
+        $orphandedIssues = DB::table('metrics')->select($metricsColumns)->where('assoc_type', '=', self::ASSOC_TYPE_ISSUE)->whereIn('assoc_id', $orphanedIds)->where('metric_type', '=', $this->getMetricType());
         DB::table('metrics_tmp')->insertUsing($metricsColumns, $orphandedIssues);
         DB::table('metrics')->where('assoc_type', '=', self::ASSOC_TYPE_ISSUE)->whereIn('assoc_id', $orphanedIds)->delete();
 
         // Clean orphaned metrics issue galley IDs
         $orphanedIds = DB::table('metrics AS m')->leftJoin('issue_galleys AS ig', 'm.assoc_id', '=', 'ig.galley_id')->where('m.assoc_type', '=', self::ASSOC_TYPE_ISSUE_GALLEY)->whereNull('ig.galley_id')->distinct()->pluck('m.assoc_id');
-        $orphandedIssuesGalleys = DB::table('metrics')->select($metricsColumns)->where('assoc_type', '=', self::ASSOC_TYPE_ISSUE_GALLEY)->whereIn('assoc_id', $orphanedIds);
+        $orphandedIssuesGalleys = DB::table('metrics')->select($metricsColumns)->where('assoc_type', '=', self::ASSOC_TYPE_ISSUE_GALLEY)->whereIn('assoc_id', $orphanedIds)->where('metric_type', '=', $this->getMetricType());
         DB::table('metrics_tmp')->insertUsing($metricsColumns, $orphandedIssuesGalleys);
         DB::table('metrics')->where('assoc_type', '=', self::ASSOC_TYPE_ISSUE_GALLEY)->whereIn('assoc_id', $orphanedIds)->delete();
     }


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/8481