### PR TITLE
F4695 Added metadata field for work number 

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -398,6 +398,17 @@
 							</div>
 						</section>
 					{/if}
+
+					{{if $publication->getData('workNumber')}}
+						<section class="sub_item">
+							<h2 class="label">
+								{translate key="submission.workNumber"}
+							</h2>
+							<div class="value">
+								{$publication->getData('workNumber')|escape}
+							</div>
+						</section>
+					{/if}
 				</div>
 			{/if}
 


### PR DESCRIPTION
Added (+) and not yet (-):

[+] Add a workNumber prop to the context schema which allows it to be enabled/disabled.
[+] Add a workNumber field to the MetadataForm when it is enabled.
[-] Add this number to Crossref exports when it is enabled.
[-] Come up with clear guidance about when it should be used, such as that shown with publisher id.
[-] Show the workNumber in citations if it exists.
[+] Show the workNumber in the default theme if it exists.