### PR TITLE
Changed URL for jobs documentation

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -523,7 +523,7 @@ default_queue = "queue"
 ; sites. Instead, a worker daemon or cron job should be configured
 ; to process jobs off the application's main thread.
 ;
-; See: https://docs.pkp.sfu.ca/admin-guide/en/advanced-jobs
+; See: https://docs.pkp.sfu.ca/admin-guide/en/deploy-jobs
 ;
 job_runner = On
 


### PR DESCRIPTION
Very minor change: in the new **Job Queues Settings** section of `config.TEMPLATE.inc.php`, the URL to the documentation was throwing a 404. I substituted what I understand is the correct URL.