### PR TITLE
Submission and metadata languages separated from UI and form languages

### DIFF
--- a/classes/issue/IssueGalley.php
+++ b/classes/issue/IssueGalley.php
@@ -60,8 +60,8 @@ class IssueGalley extends IssueFile
     public function getGalleyLabel()
     {
         $label = $this->getLabel();
-        if ($this->getLocale() != Locale::getLocale()) {
-            $label .= ' (' . Locale::getMetadata($this->getLocale())->getDisplayName() . ')';
+        if (($locale = $this->getLocale()) && $locale !== Locale::getLocale()) {
+            $label .= ' (' . Locale::getSubmissionLocaleDisplayNames([$locale])[$locale] . ')';
         }
         return $label;
     }

--- a/classes/migration/install/JournalsMigration.php
+++ b/classes/migration/install/JournalsMigration.php
@@ -30,7 +30,7 @@ class JournalsMigration extends \PKP\migration\Migration
             $table->bigInteger('journal_id')->autoIncrement();
             $table->string('path', 32);
             $table->float('seq', 8, 2)->default(0)->comment('Used to order lists of journals');
-            $table->string('primary_locale', 14);
+            $table->string('primary_locale', 28);
             $table->smallInteger('enabled')->default(1)->comment('Controls whether or not the journal is considered "live" and will appear on the website. (Note that disabled journals may still be accessible, but only if the user knows the URL.)');
             $table->unique(['path'], 'journals_path');
             $table->bigInteger('current_issue_id')->nullable()->default(null);
@@ -45,7 +45,7 @@ class JournalsMigration extends \PKP\migration\Migration
             $table->foreign('journal_id', 'journal_settings_journal_id')->references('journal_id')->on('journals')->onDelete('cascade');
             $table->index(['journal_id'], 'journal_settings_journal_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 

--- a/classes/migration/install/OJSMigration.php
+++ b/classes/migration/install/OJSMigration.php
@@ -58,7 +58,7 @@ class OJSMigration extends \PKP\migration\Migration
             $table->foreign('section_id', 'section_settings_section_id')->references('section_id')->on('sections')->onDelete('cascade');
             $table->index(['section_id'], 'section_settings_section_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 
@@ -107,7 +107,7 @@ class OJSMigration extends \PKP\migration\Migration
             $table->foreign('issue_id', 'issue_settings_issue_id')->references('issue_id')->on('issues')->onDelete('cascade');
             $table->index(['issue_id'], 'issue_settings_issue_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 
@@ -143,7 +143,7 @@ class OJSMigration extends \PKP\migration\Migration
             $table->comment('Issue galleys are representations of the entire issue in a single file, such as a complete issue PDF.');
             $table->bigInteger('galley_id')->autoIncrement();
 
-            $table->string('locale', 14)->nullable();
+            $table->string('locale', 28)->nullable();
 
             $table->bigInteger('issue_id');
             $table->foreign('issue_id', 'issue_galleys_issue_id')->references('issue_id')->on('issues')->onDelete('cascade');
@@ -169,7 +169,7 @@ class OJSMigration extends \PKP\migration\Migration
             $table->foreign('galley_id', 'issue_galleys_settings_galley_id')->references('galley_id')->on('issue_galleys')->onDelete('cascade');
             $table->index(['galley_id'], 'issue_galley_settings_galley_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
@@ -262,7 +262,7 @@ class OJSMigration extends \PKP\migration\Migration
         Schema::create('publication_galleys', function (Blueprint $table) {
             $table->comment('Publication galleys are representations of a publication in a specific format, e.g. a PDF.');
             $table->bigInteger('galley_id')->autoIncrement();
-            $table->string('locale', 14)->nullable();
+            $table->string('locale', 28)->nullable();
 
             $table->bigInteger('publication_id');
             $table->foreign('publication_id', 'publication_galleys_publication_id')->references('publication_id')->on('publications')->onDelete('cascade');
@@ -295,7 +295,7 @@ class OJSMigration extends \PKP\migration\Migration
             $table->foreign('galley_id', 'publication_galley_settings_galley_id')->references('galley_id')->on('publication_galleys')->onDelete('cascade');
             $table->index(['galley_id'], 'publication_galley_settings_galley_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
 
@@ -337,7 +337,7 @@ class OJSMigration extends \PKP\migration\Migration
             $table->foreign('type_id', 'subscription_type_settings_type_id')->references('type_id')->on('subscription_types')->onDelete('cascade');
             $table->index(['type_id'], 'subscription_type_settings_type_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->mediumText('setting_value')->nullable();
             $table->string('setting_type', 6);

--- a/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+++ b/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I9425_SeparateUIAndSubmissionLocales
+ *
+ * @brief pkp/pkp-lib#9425 Make submission language selection and metadata forms independent from website language settings
+ */
+
+namespace APP\migration\upgrade\v3_5_0;
+
+class I9425_SeparateUIAndSubmissionLocales extends \PKP\migration\upgrade\v3_5_0\I9425_SeparateUIAndSubmissionLocales
+{
+    protected function getContextTable(): string
+    {
+        return 'journals';
+    }
+    protected function getContextSettingsTable(): string
+    {
+        return 'journal_settings';
+    }
+    protected function getContextIdColumn(): string
+    {
+        return 'journal_id';
+    }
+}

--- a/classes/publication/Repository.php
+++ b/classes/publication/Repository.php
@@ -40,9 +40,7 @@ class Repository extends \PKP\publication\Repository
     public function validate($publication, array $props, Submission $submission, Context $context): array
     {
         $errors = parent::validate($publication, $props, $submission, $context);
-
-        $allowedLocales = $context->getSupportedSubmissionLocales();
-        $primaryLocale = $submission->getData('locale');
+        $submissionLocale = $submission->getData('locale');
 
         // Ensure that the specified section exists
         $section = null;
@@ -62,21 +60,22 @@ class Repository extends \PKP\publication\Repository
         if ($section && !$submission->getData('submissionProgress')) {
             // Require abstracts for new publications if the section requires them
             if (is_null($publication) && !$section->getData('abstractsNotRequired') && empty($props['abstract'])) {
-                $errors['abstract'][$primaryLocale] = [__('author.submit.form.abstractRequired')];
+                $errors['abstract'][$submissionLocale] = [__('author.submit.form.abstractRequired')];
             }
 
             if (isset($props['abstract']) && empty($errors['abstract'])) {
                 // Require abstracts in the primary language if the section requires them
                 if (!$section->getData('abstractsNotRequired')) {
-                    if (empty($props['abstract'][$primaryLocale])) {
+                    if (empty($props['abstract'][$submissionLocale])) {
                         if (!isset($errors['abstract'])) {
                             $errors['abstract'] = [];
                         };
-                        $errors['abstract'][$primaryLocale] = [__('author.submit.form.abstractRequired')];
+                        $errors['abstract'][$submissionLocale] = [__('author.submit.form.abstractRequired')];
                     }
                 }
 
                 // Check the word count on abstracts
+                $allowedLocales = $submission->getPublicationLanguages($context->getSupportedSubmissionMetadataLocales());
                 foreach ($allowedLocales as $localeKey) {
                     if (empty($props['abstract'][$localeKey])) {
                         continue;

--- a/classes/publication/maps/Schema.php
+++ b/classes/publication/maps/Schema.php
@@ -49,7 +49,9 @@ class Schema extends \PKP\publication\maps\Schema
             );
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues(PKPSchemaService::SCHEMA_PUBLICATION, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = $this->submission->getPublicationLanguages($this->context->getSupportedSubmissionMetadataLocales());
+
+        $output = $this->schemaService->addMissingMultilingualValues(PKPSchemaService::SCHEMA_PUBLICATION, $output, $locales);
 
         ksort($output);
 

--- a/classes/submission/Repository.php
+++ b/classes/submission/Repository.php
@@ -80,7 +80,8 @@ class Repository extends \PKP\submission\Repository
             $abstracts = $publication->getData('abstract');
             if ($abstracts) {
                 $abstractErrors = [];
-                foreach ($context->getSupportedSubmissionLocales() as $localeKey) {
+                $allowedLocales = $submission->getPublicationLanguages($context->getSupportedSubmissionMetadataLocales());
+                foreach ($allowedLocales as $localeKey) {
                     $abstract = $publication->getData('abstract', $localeKey);
                     $wordCount = $abstract ? PKPString::getWordCount($abstract) : 0;
                     if ($wordCount > $section->getAbstractWordCount()) {

--- a/classes/submission/maps/Schema.php
+++ b/classes/submission/maps/Schema.php
@@ -36,7 +36,13 @@ class Schema extends \PKP\submission\maps\Schema
             );
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues($this->schemaService::SCHEMA_SUBMISSION, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = $this->context->getSupportedSubmissionMetadataLocales();
+
+        if (!in_array($primaryLocale = $submission->getData('locale'), $locales)) {
+            $locales[] = $primaryLocale;
+        }
+
+        $output = $this->schemaService->addMissingMultilingualValues($this->schemaService::SCHEMA_SUBMISSION, $output, $locales);
 
         ksort($output);
 

--- a/cypress/tests/data/10-ApplicationSetup/20-CreateContext.cy.js
+++ b/cypress/tests/data/10-ApplicationSetup/20-CreateContext.cy.js
@@ -70,8 +70,13 @@ describe('Data suite tests', function() {
 		cy.get('#appearance [role="status"]').contains('Saved');
 
 		cy.get('button[id="languages-button"]').click();
-		cy.get('input[id^=select-cell-fr_CA-submissionLocale]').click();
-		cy.contains('Locale settings saved.');
+		cy.get('input[id^="select-cell-fr_CA-formLocale"]').click();
+		cy.get('a[id^=component-grid-settings-languages-submissionlanguagegrid-addLanguageModal-button]').click();
+		cy.get('#locale-fr_CA').should('exist').click();
+		cy.get('#addLanguageForm button[name="submitFormButton"]').click();
+		cy.contains('Submission locales updated.').should('exist');
+		cy.get('input[id^="select-cell-fr_CA-submissionLocale"]').click();
+		cy.get('input[id^="select-cell-fr_CA-submissionMetadataLocale"]').should('be.checked');
 
 		cy.get('button[id="indexing-button"]').click();
 		cy.get('input[name="searchDescription-en"]').type(Cypress.env('contextDescriptions')['en'], {delay: 0});

--- a/cypress/tests/data/60-content/AmwandengaSubmission.cy.js
+++ b/cypress/tests/data/60-content/AmwandengaSubmission.cy.js
@@ -224,7 +224,7 @@ describe('Data suite: Amwandenga', function() {
 			.find('h4').contains('Keywords').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Abstract').siblings('.submissionWizard__reviewPanel__item__value').contains(submission.abstract);
-		cy.get('h3').contains('Details (French)')
+		cy.get('h3').contains('Details (French (Canada))')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Title').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided')
 			.parents('.submissionWizard__reviewPanel')
@@ -234,7 +234,7 @@ describe('Data suite: Amwandenga', function() {
 		cy.get('h3').contains('For the Editors (English)')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Comments for the Editor').siblings('.submissionWizard__reviewPanel__item__value').contains('None');
-		cy.get('h3').contains('For the Editors (French)') // FIXME: Should be French
+		cy.get('h3').contains('For the Editors (French (Canada))')
 
 		// Save for later
 		cy.get('button').contains('Save for Later').click();

--- a/cypress/tests/integration/SubmissionWizard.cy.js
+++ b/cypress/tests/integration/SubmissionWizard.cy.js
@@ -479,20 +479,20 @@ describe('Submission Wizard', function() {
         cy.get('label:contains("Abstract *")');
         cy.contains('Word Count: 0/500');
 
-        // Change submission language to French and section to Reviews
+        // Change submission language to French (Canada) and section to Reviews
         cy.contains('Submitting to the Articles section in English');
         cy.get('button:contains("Change")').click();
         cy.get('h2:contains("Change Submission Settings")')
             .parents('.modal')
             .within(() => {
-                cy.get('label:contains("French")').click();
+                cy.get('label:contains("French (Canada)")').click();
                 cy.get('label:contains("Reviews")').click();
                 cy.get('button:contains("Save")').click();
             });
 
-        // Forms load with French fields displayed instead of English
-        cy.contains('Submitting to the Reviews section in French');
-        cy.get('span.pkpFormLocales__locale:contains("French")');
+        // Forms load with French (Canada) fields displayed instead of English
+        cy.contains('Submitting to the Reviews section in French (Canada)');
+        cy.get('span.pkpFormLocales__locale:contains("French (Canada)")');
         cy.get('#titleAbstract-keywords-control-fr_CA').type('Transformation Sociale', {delay: 0});
         cy.get('li:contains("Transformation Sociale")');
         cy.get('#titleAbstract-keywords-control-fr_CA').type('{downarrow}{enter}', {delay: 0});
@@ -502,7 +502,7 @@ describe('Submission Wizard', function() {
         cy.get('label:contains("Abstract *")').should('not.exist');
         cy.get('*:contains("Word Count: 0/500")').should('not.exist');
 
-        // Show English fields alongside French fields
+        // Show English fields alongside French (Canada) fields
         cy.get('.pkpStep:contains("Submission Details") button.pkpFormLocales__locale:contains("English")').click();
         cy.get('label:contains("Title in English")');
         cy.get('label:contains("Keywords in English")');
@@ -523,7 +523,7 @@ describe('Submission Wizard', function() {
         cy.get('button:contains("Continue")').click();
         cy.get('button:contains("Continue")').click();
 
-        // Check metadata form shows in French only at first
+        // Check metadata form shows in French (Canada) only at first
         const metadata = {
             subjects: "Subjects",
             disciplines: "Disciplines",
@@ -539,7 +539,7 @@ describe('Submission Wizard', function() {
             cy.get('label:contains("' + metadata[prop] + ' in English")').should('not.be.visible');
         });
 
-        // Show English fields alongside French fields
+        // Show English fields alongside French (Canada) fields
         cy.get('.pkpStep:contains("For the Editors") button.pkpFormLocales__locale:contains("English")').click();
         Object.keys(metadata).forEach((prop) => {
             cy.get('label:contains("' + metadata[prop] + ' in English")');
@@ -551,13 +551,13 @@ describe('Submission Wizard', function() {
         // Errors in review
         cy.get('button:contains("Continue")').click();
         cy.contains('There are one or more problems');
-        cy.get('h3:contains("Details (French)")')
+        cy.get('h3:contains("Details (French (Canada))")')
             .parents('.submissionWizard__reviewPanel')
             .find('h4:contains("Title")')
             .parent()
             .contains('This field is required.');
-        cy.contains('The given name is missing in French for one or more of the contributors.');
-        cy.get('h3:contains("For the Editors (French)")')
+        cy.contains('The given name is missing in French (Canada) for one or more of the contributors.');
+        cy.get('h3:contains("For the Editors (French (Canada))")')
             .parents('.submissionWizard__reviewPanel')
             .find('h4:contains("Subjects")')
             .parent()

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -117,6 +117,7 @@
 		<migration class="APP\migration\upgrade\v3_5_0\I9475_RecoverLayoutFiles"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9462_UserUserGroups"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9552_UserGroupsMasthead"/>
+		<migration class="APP\migration\upgrade\v3_5_0\I9425_SeparateUIAndSubmissionLocales"/>
 	</upgrade>
 
 	<!-- update plugin configuration - should be done as the final upgrade task -->

--- a/pages/submission/SubmissionHandler.php
+++ b/pages/submission/SubmissionHandler.php
@@ -94,7 +94,7 @@ class SubmissionHandler extends PKPSubmissionHandler
                 'submission.wizard.submittingToSectionInLanguage',
                 [
                     'section' => $section->getLocalizedTitle(),
-                    'language' => Locale::getMetadata($submission->getData('locale'))->getDisplayName(),
+                    'language' => Locale::getSubmissionLocaleDisplayNames([$submission->getData('locale')])[$submission->getData('locale')],
                 ]
             );
         } elseif ($sectionCount) {
@@ -108,7 +108,7 @@ class SubmissionHandler extends PKPSubmissionHandler
             return __(
                 'submission.wizard.submittingInLanguage',
                 [
-                    'language' => Locale::getMetadata($submission->getData('locale'))->getDisplayName(),
+                    'language' => Locale::getSubmissionLocaleDisplayNames([$submission->getData('locale')])[$submission->getData('locale')],
                 ]
             );
         }

--- a/schemas/galley.json
+++ b/schemas/galley.json
@@ -48,7 +48,7 @@
 			"description": "The primary locale of this galley.",
 			"apiSummary": true,
 			"validation": [
-				"regex:/^([a-z]{2})((_[A-Z]{2})?)(@[a-z]{0,})?$/"
+				"regex:/^([A-Za-z]{2,4})(?<sc>[_-]([A-Za-z]{4,5}|[0-9]{4}))?([_-]([A-Za-z]{2}|[0-9]{3}))?(@[a-z]{2,30}(?&sc)?)?$/"
 			]
 		},
 		"label": {


### PR DESCRIPTION
- In Website Settings > Setup > Languages and in Administration > Hosted Journals > Settings Wizard > Journal Settings > Languages, separate Website Languages and Submission Languages settings. In the website languages are UI and Forms, and in the submission languages are submission and metadata.

- Submission metadata can be edited even if metadata isn't checked in that language in the settings.