### PR TITLE
pkp/pkp-lib#7272 Simultaneously Displaying Multilingual Metadata on the Article Landing Page

### DIFF
--- a/pages/article/ArticleHandler.php
+++ b/pages/article/ArticleHandler.php
@@ -683,7 +683,7 @@ class ArticleHandler extends Handler
             'switcher' => $switcher,
             'data' => collect($data)
                 ->map(
-                    fn ($value): string => collect(Arr::wrap($value))
+                    fn ($val): string => collect(Arr::wrap($val))
                         ->when($filters, fn ($value) => $value->map(fn ($v) => $this->smartyUseFilters($templateMgr, $v, $filters)))
                         ->when($separator, fn ($value): string => $value->join($separator), fn ($value): string => $value->first())
                 )

--- a/plugins/themes/default/DefaultThemePlugin.php
+++ b/plugins/themes/default/DefaultThemePlugin.php
@@ -124,6 +124,30 @@ class DefaultThemePlugin extends \PKP\plugins\ThemePlugin
             'default' => 'none',
         ]);
 
+        $this->addOption('showMultilingualMetadata', 'FieldOptions', [
+            'label' => __('plugins.themes.default.option.metadata.label'),
+            'description' => __('plugins.themes.default.option.metadata.description'),
+            'options' => [
+                [
+                    'value' => 'title',
+                    'label' => __('submission.title'),
+                ],
+                [
+                    'value' => 'abstract',
+                    'label' => __('common.abstract'),
+                ],
+                [
+                    'value' => 'keywords',
+                    'label' => __('common.keywords'),
+                ],
+                [
+                    'value' => 'author',
+                    'label' => __('default.groups.name.author'),
+                ],
+            ],
+            'default' => [],
+        ]);
+
 
         // Load primary stylesheet
         $this->addStyle('stylesheet', 'styles/index.less');

--- a/plugins/themes/default/js/main.js
+++ b/plugins/themes/default/js/main.js
@@ -114,3 +114,198 @@
 	});
 
 })(jQuery);
+
+/**
+ * Create language buttons to show multilingual metadata
+ * [data-pkp-switcher-data]: Publication data for the switchers to control
+ * [data-pkp-switcher]: Switchers' containers
+ */
+(() => {
+	function createSwitcher(listbox, data, localeOrder, localeNames, accessibility) {
+		// Get all locales for the switcher from the data
+		const locales = Object.keys(Object.assign({}, ...Object.values(data)));
+		// The initially selected locale
+		let selectedLocale = null;
+		// Create and sort to alphabetical order
+		const buttons = localeOrder
+			.map((locale) => {
+				if (locales.indexOf(locale) === -1) {
+					return null;
+				}
+				if (!selectedLocale) {
+					selectedLocale = locale;
+				}
+
+				const isSelectedLocale = locale === selectedLocale;
+				const button = document.createElement('button');
+
+				button.type = 'button';
+				button.classList.add('pkpBadge', 'pkpBadge--button');
+				button.value = locale;
+				// For safari losing button focus; Tabindex maintains it
+				button.tabIndex = '0';
+				if (!isSelectedLocale) {
+					button.classList.add('pkp_screen_reader');
+				}
+
+				// Text content
+				/// SR
+				const srText = document.createElement('span');
+				srText.classList.add('pkp_screen_reader');
+				srText.textContent = accessibility.localeNames[locale];
+				button.appendChild(srText);
+				// Visual
+				const text = document.createElement('span');
+				text.ariaHidden = 'true';
+				text.textContent = localeNames[locale];
+				button.appendChild(text);
+
+				return button;
+			})
+			.filter((btn) => btn)
+			.sort((a, b) => a.value.localeCompare(b.value));
+
+		// If only one button, set it disabled
+		if (buttons.length === 1) {
+			buttons[0].ariaDisabled = 'true';
+		}
+
+		buttons.forEach((btn) => {
+			const option = document.createElement('li');
+			option.role = 'option';
+			option.ariaSelected = `${btn.value === selectedLocale}`;
+			option.appendChild(btn);
+			// Listbox: Ul element
+			listbox.appendChild(option);
+		});
+
+		return buttons;
+	}
+
+	/**
+	 * Sync data in elements to match the selected locale 
+	 */
+	function syncDataElContents(locale, propsData, accessibility) {
+		for (prop in propsData.data) {
+			propsData.dataEls[prop].lang = accessibility.langAttrs[locale];
+			propsData.dataEls[prop].innerHTML = propsData.data[prop][locale] ?? '';
+		}
+	}
+
+	/**
+	 * Toggle 'visually hidden' of the buttons; Current selected is always visual
+	 * pkp_screen_reader: button visibility hidden
+	 */
+	function setVisibility(buttons, currentSelected, visible) {
+		buttons.forEach((btn) => {
+			if (visible) {
+				btn.classList.remove('pkp_screen_reader');
+			} else if (btn !== currentSelected.btn) {
+				btn.classList.add('pkp_screen_reader');
+			}
+		});
+	}
+
+	function setSwitcher(propsData, switcherContainer, localeOrder, localeNames, accessibility) {
+		// Create buttons and append them to the switcher container
+		const listbox = switcherContainer.querySelector('[role="listbox"]');
+		const buttons = createSwitcher(listbox, propsData.data, localeOrder, localeNames, accessibility);
+		const currentSelected = {btn: switcherContainer.querySelector('.pkpBadge--button:not(.pkp_screen_reader')};
+
+		// Sync contents in data elements to match the selected locale (currentSelected.btn.value)
+		syncDataElContents(currentSelected.btn.value, propsData, accessibility);
+
+		// Do not add listeners if just one button, it is disabled
+		if (buttons.length < 2) {
+			return;
+		}
+
+		const isButtonsHidden = () => buttons.some(b => b.classList.contains('pkp_screen_reader'));
+
+		// New button switches language and syncs data contents
+		switcherContainer.addEventListener('click', (evt) => {
+			// Choices are li > button > span
+			const newSelectedBtn = evt.target.classList.contains('pkpBadge--button')
+				? evt.target
+				: (evt.target.querySelector('.pkpBadge--button') ?? evt.target.closest('.pkpBadge--button'));
+			if (buttons.some(b => b === newSelectedBtn)) {
+				// Set visibility
+				setVisibility(buttons, currentSelected, true);
+				if (newSelectedBtn !== currentSelected.btn) {
+					// Sync contents
+					syncDataElContents(newSelectedBtn.value, propsData, accessibility);
+					// Listbox option: Aria
+					currentSelected.btn.parentElement.ariaSelected = 'false';
+					newSelectedBtn.parentElement.ariaSelected = 'true';
+					// Update current button
+					currentSelected.btn = newSelectedBtn;
+				}
+				// Reset focus to current selected
+				currentSelected.btn.focus();
+			}
+		});
+
+		// Visually hide buttons when focus out
+		switcherContainer.addEventListener('focusout', (evt) => {
+			if (evt.target !== evt.currentTarget && evt.relatedTarget?.closest('[data-pkp-switcher]') !== switcherContainer) {
+				setVisibility(buttons, currentSelected, false);
+			}
+		});
+
+		// For tabbed browsing: Show all visually hidden buttons when one of the buttons receives focus
+		switcherContainer.addEventListener('focusin', (evt) => {
+			if (isButtonsHidden() && buttons.find(b => b === evt.target)) {
+				setVisibility(buttons, currentSelected, true);
+				// Reset focus to current selected
+				currentSelected.btn.focus();
+			}
+		});
+
+		// Arrow keys left and right cycles button focus when all buttons are visible. Set focused button.
+		switcherContainer.addEventListener('keydown', (evt) => {
+			if (evt.key === 'ArrowRight' || evt.key === 'ArrowLeft') {
+				const i = buttons.findIndex(b => b === evt.target);
+				if (i !== -1 && !isButtonsHidden()) {
+					const focusedBtn = (evt.key === 'ArrowRight')
+						? (buttons[i + 1] ?? buttons[0])
+						: (buttons[i - 1] ?? buttons[buttons.length - 1]);
+					focusedBtn.focus();
+				}
+			}
+		});
+	}
+
+	/**
+	 * Set all multilingual data and elements for the switchers
+	 */
+	function setSwitchersData(dataEls, pubLocaleData) {
+		const propsData = {};
+		dataEls.forEach((dataEl) => {
+			const propName = dataEl.getAttribute('data-pkp-switcher-data');
+			const switcherName = pubLocaleData[propName].switcher;
+			if (!propsData[switcherName]) {
+				propsData[switcherName] = {data: [], dataEls: []};
+			}
+			propsData[switcherName].data[propName] = pubLocaleData[propName].data;
+			propsData[switcherName].dataEls[propName] = dataEl;
+		});
+		return propsData;
+	}
+
+	(() => {
+		const switcherContainers = document.querySelectorAll('[data-pkp-switcher]');
+
+		if (!switcherContainers.length) return;
+
+		const pubLocaleData = JSON.parse(pubLocaleDataJson);
+		const switchersDataEls = document.querySelectorAll('[data-pkp-switcher-data]');
+		const switchersData = setSwitchersData(switchersDataEls, pubLocaleData);
+		// Create and set switchers, and sync data on the page
+		switcherContainers.forEach((switcherContainer) => {
+			const switcherName = switcherContainer.getAttribute('data-pkp-switcher');
+			if (switchersData[switcherName]) {
+				setSwitcher(switchersData[switcherName], switcherContainer, pubLocaleData.localeOrder, pubLocaleData.localeNames, pubLocaleData.accessibility);
+			}
+		});
+	})();
+})();

--- a/plugins/themes/default/locale/en/locale.po
+++ b/plugins/themes/default/locale/en/locale.po
@@ -98,3 +98,24 @@ msgstr "Next slide"
 
 msgid "plugins.themes.default.prevSlide"
 msgstr "Previous slide"
+
+msgid "plugins.themes.default.option.metadata.label"
+msgstr "Show article metadata on the article landing page"
+
+msgid "plugins.themes.default.option.metadata.description"
+msgstr "Select the article metadata to show in other languages."
+
+msgid "plugins.themes.default.languageSwitcher.ariaDescription.select"
+msgstr "Select language"
+
+msgid "plugins.themes.default.languageSwitcher.ariaDescription.titles"
+msgstr "The article title and subtitle languages"
+
+msgid "plugins.themes.default.languageSwitcher.ariaDescription.author"
+msgstr "The author's affiliation languages"
+
+msgid "plugins.themes.default.languageSwitcher.ariaDescription.keywords"
+msgstr "The keywords languages"
+
+msgid "plugins.themes.default.languageSwitcher.ariaDescription.abstract"
+msgstr "The abstract languages"

--- a/plugins/themes/default/styles/objects/article_details.less
+++ b/plugins/themes/default/styles/objects/article_details.less
@@ -10,15 +10,17 @@
  */
 .obj_article_details {
 
-	> .page_title {
-		margin: 0;
-	}
-
-	> .subtitle {
-		margin: 0;
-		font-size: @font-base;
-		line-height: @line-lead;
-		font-weight: @normal;
+	.page_titles {
+		.page_title {
+			margin: 0;
+		}
+	
+		.subtitle {
+			margin: 0;
+			font-size: @font-base;
+			line-height: @line-lead;
+			font-weight: @normal;
+		}
 	}
 
 	.row {
@@ -61,9 +63,14 @@
 				font-weight: @bold;
 			}
 
-			&.doi .label,
-			&.keywords .label {
+			&.doi .label {
 				display: inline;
+				font-size: @font-base;
+			}
+
+			&.keywords .label,
+			&.abstract .label {
+				display: inline-block;
 				font-size: @font-base;
 			}
 		}
@@ -86,7 +93,7 @@
 
 		.name {
 			font-weight: bold;
-			display: block;
+			display: inline-block;
 		}
 
 		.userGroup {
@@ -289,6 +296,76 @@
 		}
 	}
 
+	/**
+	 * Language switcher
+	*/
+	[data-pkp-switcher] {
+		.pkpBadge {
+			padding: 0.25em 1em;
+			font-size: @font-tiny;
+			font-weight: @normal;
+			line-height: 1.5em;
+			border: 1px solid @bg-border-color-light;
+			border-radius: 1.2em;
+			color: @text;
+		}
+	
+		.pkpBadge--button {
+			background: inherit;
+			text-decoration: none;
+			cursor: pointer;
+		
+			&:hover {
+				border-color: @text;
+				outline: 0;
+			}
+		}
+		// Button
+		[aria-disabled="true"],
+		[aria-disabled="true"]:hover {
+			color: #fff;
+			background: @bg-dark;
+			border-color: @bg-dark;
+			cursor: not-allowed;
+		}
+
+		display: inline-block;
+
+		* {
+			display: inline-block;
+		}
+
+		[role="listbox"],
+		[role="option"] {
+			padding: 0;
+			margin: 0;
+		}
+
+		[aria-selected="true"] .pkpBadge--button {
+			font-weight: @bold;
+		}
+
+		.pkpBadge--button:not(.pkp_screen_reader) {
+			animation: fadeIn 0.7s ease-in-out;
+
+			@keyframes fadeIn {
+				0% {
+					display: none;
+					opacity: 0;
+				}
+			
+				1% {
+					display: inline-block;
+					opacity: 0;
+				}
+			
+				100% {
+					opacity: 1;
+				}
+			}
+		}
+	}
+
 	@media(min-width: @screen-phone) {
 
 		.entry_details {
@@ -323,8 +400,7 @@
 				font-weight: @bold;
 			}
 
-			&.doi .label,
-			&.keywords .label {
+			&.doi .label {
 				display: inline;
 				font-size: @font-base;
 			}


### PR DESCRIPTION
Issue: pkp/pkp-lib#9373

- Show multilingual metadata on the article landing page
- In Website Settings > Theme, select title, keywords, and abstract metadata to show on the article landing page in other languages