### PR TITLE
#9449 Attach the issue properly when calling issueform::execute

### DIFF
--- a/controllers/grid/issues/form/IssueForm.php
+++ b/controllers/grid/issues/form/IssueForm.php
@@ -221,7 +221,7 @@ class IssueForm extends Form
             $issue = $this->issue;
         } else {
             $issue = Repo::issue()->newDataObject();
-            $this->issue =& $issue;
+            $this->issue = $issue;
             switch ($journal->getData('publishingMode')) {
                 case \APP\journal\Journal::PUBLISHING_MODE_SUBSCRIPTION:
                 case \APP\journal\Journal::PUBLISHING_MODE_NONE:

--- a/controllers/grid/issues/form/IssueForm.php
+++ b/controllers/grid/issues/form/IssueForm.php
@@ -213,8 +213,6 @@ class IssueForm extends Form
      */
     public function execute(...$functionArgs)
     {
-        parent::execute(...$functionArgs);
-
         $request = Application::get()->getRequest();
         $journal = $request->getJournal();
 
@@ -223,6 +221,7 @@ class IssueForm extends Form
             $issue = $this->issue;
         } else {
             $issue = Repo::issue()->newDataObject();
+            $this->issue =& $issue;
             switch ($journal->getData('publishingMode')) {
                 case \APP\journal\Journal::PUBLISHING_MODE_SUBSCRIPTION:
                 case \APP\journal\Journal::PUBLISHING_MODE_NONE:
@@ -278,7 +277,7 @@ class IssueForm extends Form
 
         $issue->setCoverImageAltText($this->getData('coverImageAltText'), $locale);
 
-        Hook::call('issueform::execute', [$this, $issue]);
+        parent::execute(...$functionArgs);
 
         Repo::issue()->edit($issue, []);
     }


### PR DESCRIPTION
I decided to call the Hook in the end with the `parent` call instead of previous `Hook::call('issueform::execute', [$this, $issue]);`.

This may broke some plugins that rely on that `$issue` as an argument. However, I didn´t find any plugin using that Hook on my installation. Besides, nobody noticed it before... But we may change it if you prefer.