### PR TITLE
Fix low contrast ratio on no/error/off/stop color  and the background color

### DIFF
--- a/plugins/themes/default/styles/variables.less
+++ b/plugins/themes/default/styles/variables.less
@@ -24,7 +24,7 @@
 
 // Yes/no, success/error, on/off, go/stop, etc. Typically green and red.
 @yes:                    #00b24e;
-@no:                     #ff4040;
+@no:                     #A80000;
 
 // Text
 @text:                   rgba(0,0,0,0.87);


### PR DESCRIPTION
This PR fixes this issue: https://github.com/pkp/pkp-lib/issues/9504 (OJS3.3 branch)

It increases the contrast ratio for elements, including asterisk (*) on required fields to 

OJS3.4 and main branch don't use this color, for this reason, not porting will be made or required.

This changes will cover WCAG 2.1 AA and AAA:
![image](https://github.com/pkp/ojs/assets/4992902/0b9b7d28-bc37-45d9-9d61-b4adc1601e7b)
