### PR TITLE
 pkp/pkp-lib#9557 Section::getAbbrev() and PKPSection::getTitle() can return null 

### DIFF
--- a/classes/section/Section.php
+++ b/classes/section/Section.php
@@ -31,7 +31,7 @@ class Section extends \PKP\section\PKPSection
         return $this->getLocalizedData('abbrev');
     }
 
-    public function getAbbrev(?string $locale): string|array
+    public function getAbbrev(?string $locale): string|array|null
     {
         return $this->getData('abbrev', $locale);
     }


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9557