### PR TITLE
Crossref OJS 3.3: Include article prefix in title tag

### DIFF
--- a/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
+++ b/plugins/importexport/crossref/filter/ArticleCrossrefXmlFilter.inc.php
@@ -107,7 +107,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter {
 		$languageCounter = 1;
 		foreach ($titleLanguages as $lang) {
 			$titlesNode = $doc->createElementNS($deployment->getNamespace(), 'titles');
-			$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars($publication->getData('title', $lang), ENT_COMPAT, 'UTF-8')));
+			$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', htmlspecialchars($publication->getLocalizedTitle($lang), ENT_COMPAT, 'UTF-8')));
 			if ($subtitle = $publication->getData('subtitle', $lang)) {
 				$titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'subtitle', htmlspecialchars($subtitle, ENT_COMPAT, 'UTF-8')));
 			}


### PR DESCRIPTION
Adaptation of pkp/crossref-ojs#6 for OJS 3.3.

Utilizes getLocalizedTitle() to incorporate the article prefix into the title tag.