### PR TITLE
pkp/pkp-lib#6296 Article breadcrumbs use aria-current but do not point to the current page  - OJS 3.4

### DIFF
--- a/templates/frontend/components/breadcrumbs_article.tpl
+++ b/templates/frontend/components/breadcrumbs_article.tpl
@@ -14,37 +14,37 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  * @uses $issue Issue Issue this article was published in.
  *}
-
-<nav class="cmp_breadcrumbs" role="navigation" aria-label="{translate key="navigation.breadcrumbLabel"}">
+{assign var=articlePath value=$publication->getData('urlPath')|default:$article->getId()}
+<nav class="cmp_breadcrumbs" aria-label="{translate key="navigation.breadcrumbLabel"}">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
 				{translate key="common.homepageNavigationLabel"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li>
 			<a href="{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="issue" op="archive"}">
 				{translate key="navigation.archives"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		{if $issue}
 			<li>
 				<a href="{url page="issue" op="view" path=$issue->getBestIssueId()}">
 					{$issue->getIssueIdentification()}
 				</a>
-				<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+				<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 			</li>
 		{/if}
-		<li class="current" aria-current="page">
-			<span aria-current="page">
+		<li class="current">
+			<a href="{url page="article" op="view" path=$articlePath}" current="page">
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
-					{$currentTitle|escape}
+					{$publication->getLocalizedTitle(null, 'html')|strip_unsafe_html}
 				{/if}
-			</span>
+			</a>
 		</li>
 	</ol>
 </nav>

--- a/templates/frontend/components/breadcrumbs_issue.tpl
+++ b/templates/frontend/components/breadcrumbs_issue.tpl
@@ -14,28 +14,28 @@
  * @uses $currentTitleKey string Translation key for title of current page.
  *}
 
-<nav class="cmp_breadcrumbs" role="navigation" aria-label="{translate key="navigation.breadcrumbLabel"}">
+<nav class="cmp_breadcrumbs" aria-label="{translate key="navigation.breadcrumbLabel"}">
 	<ol>
 		<li>
 			<a href="{url page="index" router=\PKP\core\PKPApplication::ROUTE_PAGE}">
 				{translate key="common.homepageNavigationLabel"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
 		<li>
 			<a href="{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="issue" op="archive"}">
 				{translate key="navigation.archives"}
 			</a>
-			<span class="separator">{translate key="navigation.breadcrumbSeparator"}</span>
+			<span class="separator" aria-hidden="true">{translate key="navigation.breadcrumbSeparator"}</span>
 		</li>
-		<li class="current" aria-current="page">
-			<span aria-current="page">
+		<li class="current">
+			<a href="{url op="view" path=$issue->getBestIssueId()}" aria-current="page">
 				{if $currentTitleKey}
 					{translate key=$currentTitleKey}
 				{else}
 					{$currentTitle|escape}
 				{/if}
-			</span>
+			</a>
 		</li>
 	</ol>
 </nav>


### PR DESCRIPTION
This PR fixes the issue https://github.com/pkp/pkp-lib/issues/6296 and also implements:

- [x] `aria-current="page"` attribute was not being use on a link to the current page
- [x] Removed `aria-current="page"` attribute from li element, it should to be used on link elements only
- [x] Include a link, using the page title as the label, to the last item on the breadcrumb (article and archive pages)
- [x] Added `aria-hidden="true"` to the breadcrumb separators (they were announced as "slash" by screen readers which is annoying for screen reader users and don't add any information to the context)

Even though showing the full article title might look overwhelming for sighted people, it is helpfull to people that rely on assistive technology like screen readers or screen magnifiers. They can double-check whether they are on the expected page through the breadcrumb interface element.
