### PR TITLE
pkp/pkp-lib#5199 Set the current page on the top menu  - OJS 3.4

### DIFF
--- a/plugins/themes/default/styles/head.less
+++ b/plugins/themes/default/styles/head.less
@@ -117,7 +117,7 @@
 
 	a {
 		display: inline-block;
-		padding: 0.125rem 0;
+		padding: 0.86rem 0;
 		color: @text-bg-base;
 		text-decoration: none;
 
@@ -127,6 +127,18 @@
 			text-decoration: underline;
 		}
 	}
+	@media (max-width: @screen-desktop) {
+
+		.active {
+			background-color: @bg-base-border-color;
+			
+		}
+		.active a {
+			font-weight: bold;
+			
+		}
+	}
+
 
 	#siteNav {
 		position: absolute;
@@ -358,6 +370,19 @@
 			}
 		}
 
+		// Visualy highlighting the current menu item
+		> li.active {
+			> a {
+				//background: @primary-lift;
+				border-color: @text-bg-base;
+				outline: 0;
+			}
+				&:hover {
+					color: @bg-base;
+					border-color: red;
+				}			
+		}
+
 		// Reproduce positioning of dropdown menu from Popper.js
 		> li:hover ul {
 			position: absolute;
@@ -377,7 +402,8 @@
 		}
 
 		.dropdown-menu a:focus,
-		.dropdown-menu a:hover {
+		.dropdown-menu a:hover,
+		.dropdown-menu li.active a, {
 			border-color: @primary;
 		}
 


### PR DESCRIPTION
This PR fixes this issue https://github.com/pkp/pkp-lib/issues/5199:

- [x]  Add class `"active"` to visually highlight the current menu item
- [x] Add `aria-current="page"` to screen readers announce the current page from the na menu
- [X] Increase menu items padding-top and padding-bottom when using mobile screen (24px height minimum recommended buy WCAG 2.2)

I've ported the check page function from Pragma theme adjusting the function to add the class and the aria attribute while checking for submenus.