### PR TITLE
Fix sequence casting error

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlIssueFilter.php
+++ b/plugins/importexport/native/filter/NativeXmlIssueFilter.php
@@ -337,7 +337,7 @@ class NativeXmlIssueFilter extends \PKP\plugins\importexport\native\filter\Nativ
         $section->setContextId($context->getId());
         $reviewFormId = $node->getAttribute('review_form_id');
         $section->setReviewFormId($reviewFormId ? (int) $reviewFormId : null);
-        $section->setSequence($node->getAttribute('seq'));
+        $section->setSequence((int) $node->getAttribute('seq'));
         $section->setEditorRestricted((bool) $node->getAttribute('editor_restricted'));
         $section->setMetaIndexed((bool) $node->getAttribute('meta_indexed'));
         $section->setMetaReviewed((bool) $node->getAttribute('meta_reviewed'));


### PR DESCRIPTION
This fixes an error when importing native XML using PHP 8 whereby it expects a strict integer and fails with this error otherwise:

```
1.Generic Items
- PKP\section\PKPSection::setSequence(): Argument #1 ($sequence) must be of type float, string given, called in /home/oiccpres/public_html/plugins/importexport/native/filter/NativeXmlIssueFilter.php on line 340
```