### PR TITLE
Fix EOL dates in SECURITY.md. Extend with release datte and explanations.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,23 @@
 
 ## Supported Versions
 
-| Version | Supported                                             | End Of Life   |
-| ------- | ----------------------------------------------------- | ------------- |
-| 3.5.x   | :x: Pre-release                                       | 2026 (est)    |
-| 3.4.x   | :heavy_check_mark: Active development                 | 2025 (est)    |
-| 3.3.x   | :heavy_check_mark: Active maintenance                 | 2026 (est)    |
-| 3.2.x   | :x: Not supported                                     | 2023          |
-| 3.1.x   | :x: Not supported                                     | 2022          |
-| 3.0.x   | :x: Not supported                                     | 2022          |
-| 2.x     | :x: Not supported                                     | 2021          |
-| 1.x     | :x: Not supported                                     | 2005 (approx) |
+| Version | Supported                                             | Released      | End Of Life   | Support |
+| ------- | ----------------------------------------------------- | ------------- | ------------- | :-----: |
+| 3.5.x   | :hourglass:        Pre-release                        | 2025 (est)    | 2028 (est)    | LTS     |
+| 3.4.x   | :heavy_check_mark: Active development                 | 2023          | 2025 (est)    |         |
+| 3.3.x   | :heavy_check_mark: Active maintenance                 | 2020          | 2026 (est)    | LTS     |
+| 3.2.x   | :x: Not supported                                     | 2020          | 2023          |         |
+| 3.1.x   | :x: Not supported                                     | 2017          | 2022          |         |
+| 3.0.x   | :x: Not supported                                     | 2016          | 2022          |         |
+| 2.x     | :x: Not supported                                     | 2005          | 2021          |         |
+| 1.x     | :x: Not supported                                     | 2002          | 2005 (approx) |         |
+
+PKP usually supports current major release and the last major release.
+Other releases receive bug fixes for about two years. However, that is not guaranteed.
+
+[LTS versions](https://pkp.sfu.ca/2022/02/15/pkp-announces-long-term-support-lts-software-releases/) are an exception to this general rule, that don't include new features but receive security patches and bug fixes for 3-5 years.
+At least 12 months before a LTS version reaches EOL, a new LTS version is designated, so that you have one year to perform an upgrade.
+
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
- Adding EOL for 3.5.
- Adding Released column (based on Archive page).
- Adding Support explanations.