### PR TITLE
pkp/pkp-lib#9960 Button to a simplified HTML galley version

### DIFF
--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -702,6 +702,9 @@ msgstr "Requires Subscription"
 msgid "reader.subscriptionOrFeeAccess"
 msgstr "Requires Subscription or Fee"
 
+msgid "reader.accessibleLinks.buttontext"
+msgstr "simplified"
+
 msgid "reader.purchasePrice"
 msgstr "({$currency} {$price})"
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /cache/
+Crawl-delay: 60

--- a/templates/frontend/objects/galley_link.tpl
+++ b/templates/frontend/objects/galley_link.tpl
@@ -79,3 +79,32 @@
 		</span>
 	{/if}
 </a>
+{** 
+ * Create an accessible version of the HTML ('file') link that uses 'download' instead of 'view' 
+ * as the operation so that it opens outside of the <iframe>.
+ * 
+ * Include only 'file' items that are labelled 'html' (case-insensitive).
+ *}
+ {if $type == 'file' && stripos($galley->getGalleyLabel(), 'html') !== false }
+	{* GF - 2021-10-07 - remove obj_galley_link_supplementary and use obj_galley_link instead *}
+		<a class="{if $isSupplementary}obj_galley_link{else}obj_galley_link{/if} {$type}{if $restricted} restricted{/if}" href="{url page=$page op="download" path=$parentId|to_array:$galley->getBestGalleyId()}">
+		   {* Add some screen reader text to indicate if a galley is restricted *}
+		   {if $restricted}
+			  <span class="pkp_screen_reader">
+				 {if $purchaseArticleEnabled}
+					 {translate key="reader.subscriptionOrFeeAccess"}
+				 {else}
+					 {translate key="reader.subscriptionAccess"}
+				 {/if}
+			  </span>
+		   {/if}
+	
+		   {$galley->getGalleyLabel()|escape} ({translate key="reader.accessibleLinks.buttontext"})       
+	
+		   {if $restricted && $purchaseFee && $purchaseCurrency}
+			  <span class="purchase_cost">
+				  {translate key="reader.purchasePrice" price=$purchaseFee currency=$purchaseCurrency}
+			  </span>
+		   {/if}
+		</a>
+	{/if}


### PR DESCRIPTION
This PR adds a button to the HTML file directly in the ToC of the issue and the Article Landing page in OJS 3.3. 
It is a solution to the following issue:
https://github.com/pkp/pkp-lib/issues/9960