### PR TITLE
Update scheduledTasks.xml

### DIFF
--- a/registry/scheduledTasks.xml
+++ b/registry/scheduledTasks.xml
@@ -57,7 +57,7 @@
 	</task>
 	<task class="APP\tasks\UsageStatsLoader">
 		<descr>Process the usage stats logs and load the numbers into the DB tables.</descr>
-		<frequency day="0"/>
+		<frequency day="*"/>
 	</task>
 	<task class="PKP\task\ProcessQueueJobs">
 		<descr>Process pending queue jobs in the default queue driver and queue</descr>

--- a/registry/scheduledTasks.xml
+++ b/registry/scheduledTasks.xml
@@ -57,7 +57,7 @@
 	</task>
 	<task class="APP\tasks\UsageStatsLoader">
 		<descr>Process the usage stats logs and load the numbers into the DB tables.</descr>
-		<frequency day="*"/>
+		<frequency hour="0"/>
 	</task>
 	<task class="PKP\task\ProcessQueueJobs">
 		<descr>Process pending queue jobs in the default queue driver and queue</descr>


### PR DESCRIPTION
day="0" here causes the usageStats to be only collected once per month (when executed via cron job, don't think it affects acron). I believe this is by mistake as it would leave the default statistics page (= last month) completely empty. 

See https://github.com/pkp/pkp-lib/blob/a60e4930128362be6e961b6014374d8eacc83b62/classes/scheduledTask/ScheduledTaskHelper.php#L116 - it compares with `(int)date('j')` - which always fails as the result is a number in range 1-31 (see https://www.php.net/manual/en/datetime.format.php), never 0 - so the job only triggers when `$passTimestamp` exceeds 1 month.