### PR TITLE
pkp/pkp-lib#10080 fix editorial masthead locale keys and submodule update

### DIFF
--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -645,9 +645,6 @@ msgstr "A small logo or representation of the journal that can be used in lists 
 msgid "manager.setup.contextTitle"
 msgstr "Journal title"
 
-msgid "manager.setup.editorialMasthead.description"
-msgstr "Please provide the editorial history of your journal, including the full name, affiliation, and start and end dates of each editor."
-
 msgid "manager.setup.labelName"
 msgstr "Label name"
 


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/10080