### PR TITLE
Update marc record.tpl (change 786 marc field by 773 and subfields)  

### DIFF
--- a/plugins/oaiMetadataFormats/marc/templates/record.tpl
+++ b/plugins/oaiMetadataFormats/marc/templates/record.tpl
@@ -72,8 +72,9 @@
 		<subfield label="u">{url router=PKP\core\PKPApplication::ROUTE_PAGE journal=$journal->getPath() page="article" op="view" path=$article->getBestId()|escape urlLocaleForPage=""}</subfield>
 	</varfield>
 
-	<varfield id="786" i1="0" i2=" ">
-		<subfield label="n">{$journal->getName($journal->getPrimaryLocale())|escape}; {$issue->getIssueIdentification()|escape}</subfield>
+	<varfield id="773" i1="0" i2=" ">
+		<subfield label="t">{$journal->getName($journal->getPrimaryLocale())|escape};</subfield>
+	        <subfield label="g">{$issue->getIssueIdentification()|escape}</subfield>
 	</varfield>
 
 	<varfield id="546" i1=" " i2=" ">


### PR DESCRIPTION


according to official documentation of the marc bibliographic manual by loc.gov  The journal title and volume  must to be in 773 fields with subfield "t" and "g".  the 786 field is use for other purposes . 
This is important for journals imports by tools like Vufind.