### PR TITLE
pkp/pkp-lib#9813 cast int to string

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I9813_QuickSubmitSubmissionProgressType.php
+++ b/classes/migration/upgrade/v3_4_0/I9813_QuickSubmitSubmissionProgressType.php
@@ -36,7 +36,7 @@ class I9813_QuickSubmitSubmissionProgressType extends \PKP\migration\Migration
 
         foreach ($this->getStepMap() as $oldValue => $newValue) {
             DB::table('submissions')
-                ->where('submission_progress', $oldValue)
+                ->where('submission_progress', (string) $oldValue)
                 ->update([
                     'submission_progress' => $newValue,
                 ]);


### PR DESCRIPTION
s. https://forum.pkp.sfu.ca/t/error-during-upgrade-ojs-3-4-0-5-to-3-4-0-6-invalid-datetime-format-1292-truncated-incorrect-double-value-files/89623