### PR TITLE
create no-embbed option for exporting issues

### DIFF
--- a/plugins/importexport/native/NativeImportExportPlugin.inc.php
+++ b/plugins/importexport/native/NativeImportExportPlugin.inc.php
@@ -196,7 +196,8 @@ class NativeImportExportPlugin extends ImportExportPlugin {
 				$exportXml = $this->exportSubmissions(
 					(array) $request->getUserVar('selectedSubmissions'),
 					$request->getContext(),
-					$request->getUser()
+					$request->getUser(),
+					$this->getExportOptionsFromRequest($request)
 				);
 				import('lib.pkp.classes.file.FileManager');
 				$fileManager = new FileManager();
@@ -209,7 +210,8 @@ class NativeImportExportPlugin extends ImportExportPlugin {
 				$exportXml = $this->exportIssues(
 					(array) $request->getUserVar('selectedIssues'),
 					$request->getContext(),
-					$request->getUser()
+					$request->getUser(),
+					$this->getExportOptionsFromRequest($request)
 				);
 				import('lib.pkp.classes.file.FileManager');
 				$fileManager = new FileManager();
@@ -222,6 +224,17 @@ class NativeImportExportPlugin extends ImportExportPlugin {
 				$dispatcher = $request->getDispatcher();
 				$dispatcher->handle404();
 		}
+	}
+
+	/**
+	 * Get export options from the request object
+	 * @param $request PKPRequest
+	 * @return array
+	 */
+	function getExportOptionsFromRequest($request) {
+		$opts = array();
+		if ($request->getUserVar('no-embed')) $opts['no-embed'] = true;
+		return $opts;
 	}
 
 	/**

--- a/plugins/importexport/native/filter/IssueGalleyNativeXmlFilter.inc.php
+++ b/plugins/importexport/native/filter/IssueGalleyNativeXmlFilter.inc.php
@@ -123,10 +123,11 @@ class IssueGalleyNativeXmlFilter extends NativeExportFilter {
 			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'date_uploaded', strftime('%Y-%m-%d', strtotime($issueFile->getDateUploaded()))));
 			$issueFileNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'date_modified', strftime('%Y-%m-%d', strtotime($issueFile->getDateModified()))));
 
-
-			$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($filePath)));
-			$embedNode->setAttribute('encoding', 'base64');
-			$issueFileNode->appendChild($embedNode);
+			if (empty($this->opts['no-embed'])) {
+				$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($filePath)));
+				$embedNode->setAttribute('encoding', 'base64');
+				$issueFileNode->appendChild($embedNode);
+			}
 
 			$issueGalleyNode->appendChild($issueFileNode);
 			return true;

--- a/plugins/importexport/native/filter/NativeFilterHelper.inc.php
+++ b/plugins/importexport/native/filter/NativeFilterHelper.inc.php
@@ -81,9 +81,12 @@ class NativeFilterHelper {
 				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image', htmlspecialchars($coverImageName, ENT_COMPAT, 'UTF-8')));
 				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image_alt_text', htmlspecialchars($coverImage['altText'], ENT_COMPAT, 'UTF-8')));
 
-				$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($filePath)));
-				$embedNode->setAttribute('encoding', 'base64');
-				$coverNode->appendChild($embedNode);
+				// Only embed if the no-embed option was not specified
+				if (empty($filter->opts['no-embed'])) {
+					$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($filePath)));
+					$embedNode->setAttribute('encoding', 'base64');
+					$coverNode->appendChild($embedNode);
+				}
 				$coversNode->appendChild($coverNode);
 			}
 		}
@@ -116,9 +119,19 @@ class NativeFilterHelper {
 				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image', htmlspecialchars($coverImage, ENT_COMPAT, 'UTF-8')));
 				$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'cover_image_alt_text', htmlspecialchars($object->getCoverImageAltText($locale), ENT_COMPAT, 'UTF-8')));
 
-				$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($filePath)));
-				$embedNode->setAttribute('encoding', 'base64');
-				$coverNode->appendChild($embedNode);
+				// Only embed if the no-embed option was not specified
+				if (empty($filter->opts['no-embed'])) {
+					$embedNode = $doc->createElementNS($deployment->getNamespace(), 'embed', base64_encode(file_get_contents($filePath)));
+					$embedNode->setAttribute('encoding', 'base64');
+					$coverNode->appendChild($embedNode);
+				} else if (!empty($filter->opts['use-file-urls'])) {
+					// Use the file URL in the XML
+					$request = Application::get()->getRequest();
+					$baseUrl = $request->getBaseUrl();
+					$context = $deployment->getContext();
+					$fileUrl = $baseUrl . '/' . $context->getPath() . '/public/' . $coverImage;
+					$coverNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'file_url', htmlspecialchars($fileUrl, ENT_COMPAT, 'UTF-8')));
+				}
 				$coversNode->appendChild($coverNode);
 			}
 		}

--- a/plugins/importexport/native/locale/en_US/locale.po
+++ b/plugins/importexport/native/locale/en_US/locale.po
@@ -125,3 +125,15 @@ msgid "plugins.importexport.native.import.error.publishedDateMissing"
 msgstr ""
 "The article \"{$articleTitle}\" is contained within an issue, but has no "
 "published date."
+
+msgid "plugins.importexport.common.export"
+msgstr "Export"
+
+msgid "plugins.importexport.native.exportOptions"
+msgstr "Export Options"
+
+msgid "plugins.importexport.native.noEmbedOption"
+msgstr "Do not embed binary files (reduces memory usage)"
+
+msgid "plugins.importexport.native.export.articles"
+msgstr "Export Articles"

--- a/plugins/importexport/native/native.xsd
+++ b/plugins/importexport/native/native.xsd
@@ -135,7 +135,7 @@
 			<element name="original_file_name" type="string" minOccurs="1" maxOccurs="1" />
 			<element name="date_uploaded" type="date" minOccurs="1" maxOccurs="1" />
 			<element name="date_modified" type="date" minOccurs="1" maxOccurs="1" />
-			<element name="embed" type="pkp:embed" />
+			<element name="embed" type="pkp:embed" minOccurs="0" maxOccurs="1" />
 		</sequence>
 	</complexType>
 
@@ -152,7 +152,7 @@
 			<sequence>
 				<element name="cover_image" type="string" minOccurs="1" maxOccurs="1" />
 				<element name="cover_image_alt_text" type="string" minOccurs="1" maxOccurs="1" />
-				<element name="embed" type="pkp:embed" />
+				<element name="embed" type="pkp:embed" minOccurs="0" maxOccurs="1" />
 			</sequence>
 			<attribute name="locale" type="string" />
 		</complexType>

--- a/plugins/importexport/native/templates/index.tpl
+++ b/plugins/importexport/native/templates/index.tpl
@@ -15,7 +15,6 @@
 	</h1>
 
 <script type="text/javascript">
-	// Attach the JS file tab handler.
 	$(function() {ldelim}
 		$('#importExportTabs').pkpHandler('$.pkp.controllers.TabHandler');
 		$('#importExportTabs').tabs('option', 'cache', true);
@@ -30,7 +29,6 @@
 	<div id="import-tab">
 		<script type="text/javascript">
 			$(function() {ldelim}
-				// Attach the form handler.
 				$('#importXmlForm').pkpHandler('$.pkp.controllers.form.FileUploadFormHandler',
 					{ldelim}
 						$uploader: $('#plupload'),
@@ -45,7 +43,6 @@
 		<form id="importXmlForm" class="pkp_form" action="{plugin_url path="importBounce"}" method="post">
 			{csrf}
 			{fbvFormArea id="importForm"}
-				{* Container for uploaded file *}
 				<input type="hidden" name="temporaryFileId" id="temporaryFileId" value="" />
 
 				{fbvFormArea id="file"}
@@ -61,8 +58,14 @@
 	<div id="exportSubmissions-tab">
 		<script type="text/javascript">
 			$(function() {ldelim}
-				// Attach the form handler.
 				$('#exportXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
+
+				$('#exportXmlForm').on('submit', function() {ldelim}
+					setTimeout(function() {ldelim}
+						$('#exportXmlForm .is_visible').removeClass('is_visible');
+						$('#exportXmlForm .pkp_spinner').hide();
+					{rdelim}, 2000);
+				{rdelim});
 			{rdelim});
 		</script>
 		<form id="exportXmlForm" class="pkp_form" action="{plugin_url path="exportSubmissions"}" method="post">
@@ -111,8 +114,14 @@
 	<div id="exportIssues-tab">
 		<script type="text/javascript">
 			$(function() {ldelim}
-				// Attach the form handler.
 				$('#exportIssuesXmlForm').pkpHandler('$.pkp.controllers.form.FormHandler');
+
+				$('#exportIssuesXmlForm').on('submit', function() {ldelim}
+					setTimeout(function() {ldelim}
+						$('#exportIssuesXmlForm .is_visible').removeClass('is_visible');
+						$('#exportIssuesXmlForm .pkp_spinner').hide();
+					{rdelim}, 2000);
+				{rdelim});
 			{rdelim});
 		</script>
 		<form id="exportIssuesXmlForm" class="pkp_form" action="{plugin_url path="exportIssues"}" method="post">
@@ -120,7 +129,15 @@
 			{fbvFormArea id="issuesXmlForm"}
 				{capture assign="issuesListGridUrl"}{url router=$smarty.const.ROUTE_COMPONENT component="grid.issues.ExportableIssuesListGridHandler" op="fetchGrid" escape=false}{/capture}
 				{load_url_in_div id="issuesListGridContainer" url=$issuesListGridUrl}
-				{fbvFormButtons submitText="plugins.importexport.native.exportIssues" hideCancel="true"}
+				{fbvFormSection list="true"}
+					{fbvElement type="checkbox" id="validation" label="plugins.importexport.common.validation" checked=$validation|default:true}
+				{/fbvFormSection}
+
+				{fbvFormSection list="true" title="plugins.importexport.native.exportOptions"}
+					{fbvElement type="checkbox" id="no-embed" name="no-embed" label="plugins.importexport.native.noEmbedOption" checked=$noEmbed|default:false}
+				{/fbvFormSection}
+
+				{fbvFormButtons submitText="plugins.importexport.common.export" hideCancel="true"}
 			{/fbvFormArea}
 		</form>
 	</div>


### PR DESCRIPTION
*Description*: I added a `--no-embbed` option for the CLI and the system interface. It reduces the memory usage, as for faster responses and lighter XML files. It solves the issue [#9769](https://github.com/pkp/pkp-lib/issues/9769).