### PR TITLE
pkp/pkp-lib#11396 Make OJS more resilient to missing theme plugins

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -189,8 +189,8 @@
 
 			{call_hook name="Templates::Article::Main"}
 
-			{* Usage statistics chart*}
-			{if $activeTheme->getOption('displayStats') != 'none'}
+			{* Usage statistics chart *}
+			{if $activeTheme && $activeTheme->getOption('displayStats') != 'none'}
 				{$activeTheme->displayUsageStatsGraph($article->getId())}
 				<section class="item downloads_chart">
 					<h2 class="label">

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -28,14 +28,14 @@
 		{include file="frontend/components/highlights.tpl" highlights=$highlights}
 	{/if}
 
-	{if !$activeTheme->getOption('useHomepageImageAsHeader') && $homepageImage}
+	{if $activeTheme && !$activeTheme->getOption('useHomepageImageAsHeader') && $homepageImage}
 		<div class="homepage_image">
 			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:"url"}"{if $homepageImage.altText} alt="{$homepageImage.altText|escape}"{/if}>
 		</div>
 	{/if}
 
 	{* Journal Description *}
-	{if $activeTheme->getOption('showDescriptionInJournalIndex')}
+	{if $activeTheme && $activeTheme->getOption('showDescriptionInJournalIndex')}
 		<section class="homepage_about">
 			<a id="homepageAbout"></a>
 			<h2>{translate key="about.aboutContext"}</h2>


### PR DESCRIPTION
The PR is against `main`, but it applies equally well to `stable-3_4_0` and `stable-3_5_0`.