### PR TITLE
Fix 3.3 upgrade error "undefined const SCHEMA_GALLEY" 

### DIFF
--- a/tools/upgrade.php
+++ b/tools/upgrade.php
@@ -17,6 +17,7 @@
  */
 
 require(dirname(__FILE__) . '/bootstrap.php');
+import('lib.pkp.classes.services.PKPSchemaService');
 
 $tool = new \PKP\cliTool\UpgradeTool($argv ?? []);
 $tool->execute();


### PR DESCRIPTION
Adding "import PKPSchemaService" solves fatal error updating v3.3 with PHP 8.2.x. 

See discussion on PKP forum https://forum.pkp.sfu.ca/t/error-while-upgrading-from-3-3-0-14-to-3-3-0-19/92380

Error message thrown with both "check" and "upgrade" 
```
$ php tools/upgrade.php upgrade

PHP Fatal error:  Uncaught Error: Undefined constant "SCHEMA_GALLEY" in 
journals-dev/lib/pkp/includes/functions.inc.php:224
Stack trace:
#0 journals-dev/lib/pkp/classes/db/DAORegistry.inc.php(67): instantiate()
#1 journals-dev/classes/oai/ojs/OAIDAO.inc.php(41): DAORegistry::getDAO()
#2 journals-dev/plugins/generic/driver/DRIVERPlugin.inc.php(33): OAIDAO->__construct()
#3 journals-dev/lib/pkp/classes/plugins/PluginRegistry.inc.php(69): DRIVERPlugin->register()
```