### PR TITLE
 Update marcxml record.tpl (change 786 marc field by 773 and subfields)

### DIFF
--- a/plugins/oaiMetadataFormats/marcxml/templates/record.tpl
+++ b/plugins/oaiMetadataFormats/marcxml/templates/record.tpl
@@ -87,8 +87,9 @@
 		<subfield code="u">{url router=PKP\core\PKPApplication::ROUTE_PAGE journal=$journal->getPath() page="article" op="view" path=$article->getBestId()|escape urlLocaleForPage=""}</subfield>
 	</datafield>
 
-	<datafield tag="786" ind1="0" ind2=" ">
-		<subfield code="n">{$journal->getName($journal->getPrimaryLocale())|escape}; {$issue->getIssueIdentification()|escape}</subfield>
+	<datafield id="773" i1="0" i2=" ">
+		<subfield label="t">{$journal->getName($journal->getPrimaryLocale())|escape};</subfield>
+	        <subfield label="g">{$issue->getIssueIdentification()|escape}</subfield>
 	</datafield>
 
 	<datafield tag="546" ind1=" " ind2=" ">


### PR DESCRIPTION
according to official documentation of the marc bibliographic manual by loc.gov The journal title and volume must to be in 773 fields with subfield "t" and "g". the 786 field is use for other purposes .

is the same as pull request #4350 for marc schema (since april 2024).