### PR TITLE
pkp/pkp-lib#11788 [stable-3_5_0] [TinyMCE] | Source Code text area - Journal Settings > Setup > Masthead > About the Journal, Selecting the source code option for tinyMCE displays shrunken text area

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -35,7 +35,7 @@ export default defineConfig(({mode}) => {
 			copy({
 				targets: [
 					{
-						src: 'lib/ui-library/public/styles/tinymce/*',
+						src: 'node_modules/tinymce/skins/ui/tinymce-5/**/*.css',
 						dest: 'lib/pkp/styles/tinymce',
 					},
 					{


### PR DESCRIPTION
- Setup correct folder source of TinyMCE's css files when copying to `lib/pkp/styles/tinymce` folder.