### PR TITLE
Set lensGalley submodule to track updated stable-3_3_0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 [submodule "plugins/generic/lensGalley"]
 	path = plugins/generic/lensGalley
 	url = https://github.com/asmecher/lensGalley
-	branch = i1472-fix
+	branch = stable-3_3_0
 [submodule "plugins/generic/googleAnalytics"]
 	path = plugins/generic/googleAnalytics
 	url = https://github.com/pkp/googleAnalytics.git


### PR DESCRIPTION
Tested this on a fresh install and it allows previously broken viewing of figures and tables in the XML article viewer. 