### PR TITLE
pkp/pkp-lib#12232 Fix null issueId and null suffix pattern TypeErrors in mintPublicationDoi

### DIFF
--- a/classes/doi/Repository.php
+++ b/classes/doi/Repository.php
@@ -63,8 +63,11 @@ class Repository extends \PKP\doi\Repository
         }
 
         // If not using default suffix, additional checks are required
-        $patternNeedsIssue = PubIdPlugin::suffixHasIssuePattern($this->getPubIdSuffixPattern($publication, $context));
-        $issue = Repo::issue()->get($publication->getData('issueId'));
+        $pubIdSuffixPattern = $this->getPubIdSuffixPattern($publication, $context);
+        if (empty($pubIdSuffixPattern)) { throw new DoiException(DoiException::PUBLICATION_MISSING_ISSUE, $submission->getCurrentPublication()->getLocalizedFullTitle(), $publication->getLocalizedFullTitle()); }
+        $patternNeedsIssue = PubIdPlugin::suffixHasIssuePattern($pubIdSuffixPattern);
+        $issueId = $publication->getData('issueId');
+        $issue = $issueId ? Repo::issue()->get($issueId) : null;
 
         if ($patternNeedsIssue) {
             if ($issue === null) {


### PR DESCRIPTION
## Summary

Fixes two `TypeError` regressions in `classes/doi/Repository.php` introduced by #5170 (shipped in 3.4.0-10), which addressed pkp/pkp-lib#12005.

Both errors surface as HTTP 500 responses and affect journals using **Custom Pattern** DOI suffix type with **Automatic DOI Assignment** set to **Upon reaching the copyediting stage**.

### Bug 1 — null `issueId` causes `TypeError` in `mintPublicationDoi` (pkp/pkp-lib#12232)

When a submission reaches copyediting without being assigned to an issue, `$publication->getData('issueId')` returns `null`. After #5170 restructured the issue guard, `Repo::issue()->get()` is now called unconditionally, but its signature requires `int $id` — passing `null` throws:

```
TypeError: APP\issue\Repository::get(): Argument #1 ($id) must be of type int, null given
  at classes/doi/Repository.php line 70
```

**Fix:** Extract `$issueId` first and only call `Repo::issue()->get()` when non-null.

### Bug 2 — null suffix pattern causes `TypeError` in `suffixHasIssuePattern()`

When the **Custom Pattern** DOI format is selected but the **Submissions** pattern field is left blank, `getPubIdSuffixPattern()` returns `null`. `PubIdPlugin::suffixHasIssuePattern()` declares `string $pubIdSuffix`, so passing `null` throws:

```
TypeError: APP\plugins\PubIdPlugin::suffixHasIssuePattern(): Argument #1 ($pubIdSuffix) must be of type string, null given
  at classes/doi/Repository.php line 66
```

**Fix:** Extract the suffix pattern before calling `suffixHasIssuePattern()` and throw a `DoiException` when empty, so the editorial workflow continues cleanly rather than producing an unhandled 500.

## Related

- Fixes regressions from #5170 (pkp/pkp-lib#12005)
- Addresses pkp/pkp-lib#12232

## Test plan

- [ ] Set DOI Format to **Custom Pattern**, leave the Submissions field blank → Bulk assign DOI for an unscheduled submission → confirm graceful `DoiException` instead of 500
- [ ] Set DOI Format to **Custom Pattern**, Submissions pattern = `%j-%a` (no issue tokens), submission at copyediting with no issue assigned → confirm DOI mints without error
- [ ] Set DOI Format to **Custom Pattern**, Submissions pattern includes `%v`/`%i`/`%Y`, submission with no issue → confirm existing `PUBLICATION_MISSING_ISSUE` DoiException still raised
- [ ] Set DOI Format to **Custom Pattern**, submission assigned to an issue → confirm DOI mints correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)