### PR TITLE
[OJS][main] pkp/pkp-lib#12811 Use search landmark for the frontend search form

### DIFF
--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -34,7 +34,7 @@
 	{capture name="searchFormUrl"}{url path=\APP\core\Application::get()->getRequest()->getRequestedArgs() escape=false}{/capture}
 	{assign var=formUrlParameters value=[]}{* Prevent Smarty warning *}
 	{$smarty.capture.searchFormUrl|parse_url:$smarty.const.PHP_URL_QUERY|default:""|parse_str:$formUrlParameters}
-	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}" role="form">
+	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}" role="search">
 		{foreach from=$formUrlParameters key=paramKey item=paramValue}
 			<input type="hidden" name="{$paramKey|escape}" value="{$paramValue|escape}"/>
 		{/foreach}


### PR DESCRIPTION
Addresses pkp/pkp-lib#12811.

## What changed

`templates/frontend/pages/search.tpl` carried `role="form"` on the search form, exposing it as a generic form landmark. This changes it to `role="search"` so assistive technology exposes it as a search landmark, which screen readers offer dedicated navigation for.

One attribute, one line.

## Why `role="search"` rather than a `<search>` element

The issue suggests either. I used the attribute because the element in question already *is* a `<form>`, so `role="search"` on it is the minimal correct change and preserves the existing label/input/submit associations. Introducing a `<search>` wrapper would add a nesting level without changing what assistive technology reports.

## Scope checks

- **Single landmark**: this is the only `<form>` on the page, so there is one primary search landmark and no disambiguating label is needed. The included templates that live in `lib/pkp` (`header.tpl`, `footer.tpl`, `breadcrumbs.tpl`) and the four default sidebar blocks were checked on GitHub rather than locally, since `lib/pkp` is not initialised in my clone. The header search is an `<a href>` link, not a form, and is suppressed on this page in any case.
- **No other call sites**: `role="form"` appears exactly once in the OJS templates. The three occurrences in `pkp-lib` (`userLogin.tpl`, `userLostPassword.tpl`, `userRegister.tpl`) are login/registration forms, not search, so I left them alone.
- **Label association preserved**: the `<label class="pkp_screen_reader" for="query">` / `<input id="query">` pairing is untouched.

## Related observation, not changed here

`pkp/ops` has the same search form in `templates/frontend/pages/search.tpl` with **no** `role` attribute at all, so it does not expose a search landmark either. I have not touched it since this issue is scoped to OJS, but happy to open a matching PR against OPS if you would like it.

## Branch target

Targeted `main` because the issue is labelled `a11y:enhancement`. Glad to backport to `stable-3_5_0` if you would rather have it there, or in addition.

## Testing

Verified by reading the template source and the surrounding label/input structure. Nothing was rendered: I do not have an OJS instance running locally, so I have **not** confirmed the landmark with a screen reader against a live install. Given the change is a single ARIA role attribute on an element that is already a form, the risk is low, but I want to be straight that the manual screen-reader verification described in the issue was not repeated by me.

---

Prepared with AI assistance (Claude). I reviewed the template, confirmed the call sites, and checked the change against the issue's stated requirements.
