### PR TITLE
[OJS][stable-3_5_0] pkp/pkp-lib#12811 Use search landmark for the frontend search form

### DIFF
--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -35,7 +35,7 @@
 	{capture name="searchFormUrl"}{url escape=false}{/capture}
 	{assign var=formUrlParameters value=[]}{* Prevent Smarty warning *}
 	{$smarty.capture.searchFormUrl|parse_url:$smarty.const.PHP_URL_QUERY|default:""|parse_str:$formUrlParameters}
-	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}" role="form">
+	<form class="cmp_form" method="get" action="{$smarty.capture.searchFormUrl|strtok:"?"|escape}" role="search">
 		{foreach from=$formUrlParameters key=paramKey item=paramValue}
 			<input type="hidden" name="{$paramKey|escape}" value="{$paramValue|escape}"/>
 		{/foreach}


### PR DESCRIPTION
Addresses pkp/pkp-lib#12811 on the 3.5 LTS branch.

Companion to #5689 (the same fix on `main`). Opening both at the maintainer's request: https://github.com/pkp/pkp-lib/issues/12811#issuecomment-5024014482 — israelcefrin asked to fix LTS and the current working branch, since the defect is live in both.

## What changed

`templates/frontend/pages/search.tpl` carried `role="form"` on the search form. This changes it to `role="search"` so assistive technology exposes it as a search landmark. A `<form>` with no accessible name (this one has none) exposes no form landmark at all, so this goes from no landmark to a search landmark, not a lateral swap.

One attribute, one line. Identical to #5689.

## Scope

- The only `<form>` on the page; the two `role="status"` occurrences elsewhere are the results/no-results live regions, untouched.
- The header search is an `<a>` link, not a form, and isn't rendered on the search page, so this page exposes exactly one search landmark.

## Testing

Verified by reading the template source. I do not have an OJS instance running, so I have not repeated the screen-reader landmark check described in the issue.

Refs pkp/pkp-lib#12811

---

Prepared with AI assistance (Claude). I reviewed the template, confirmed the single call site, and checked the change against the issue's requirements.
