### PR TITLE
pkp/pkp-lib#13114 DataciteXmlFilter: consider null as parameter for g…

### DIFF
--- a/plugins/generic/datacite/filter/DataciteXmlFilter.php
+++ b/plugins/generic/datacite/filter/DataciteXmlFilter.php
@@ -978,7 +978,7 @@ class DataciteXmlFilter extends \PKP\plugins\importexport\native\filter\NativeEx
      * @return mixed The value of the primary locale
      *  or null if no primary translation could be found.
      */
-    public function getPrimaryTranslation(array $localizedData, array $localePrecedence): mixed
+    public function getPrimaryTranslation(?array $localizedData, array $localePrecedence): mixed
     {
         // Check whether we have localized data at all.
         if (!is_array($localizedData) || empty($localizedData)) {


### PR DESCRIPTION
…etPrimaryTranslation()

see https://github.com/pkp/pkp-lib/issues/13114