### PR TITLE
pkp/pkp-lib#13171 Fix waived publication fee still requesting payment

### DIFF
--- a/classes/decision/types/Accept.php
+++ b/classes/decision/types/Accept.php
@@ -53,7 +53,7 @@ class Accept extends TypesAccept
         foreach ($actions as $action) {
             switch ($action['id']) {
                 case self::ACTION_PAYMENT:
-                    $this->requestPayment($submission, $editor, $context);
+                    $this->runPaymentAction($action, $submission, $editor, $context);
                     break;
             }
         }

--- a/classes/decision/types/SkipExternalReview.php
+++ b/classes/decision/types/SkipExternalReview.php
@@ -53,7 +53,7 @@ class SkipExternalReview extends PKPSkipExternalReview
         foreach ($actions as $action) {
             switch ($action['id']) {
                 case self::ACTION_PAYMENT:
-                    $this->requestPayment($submission, $editor, $context);
+                    $this->runPaymentAction($action, $submission, $editor, $context);
                     break;
             }
         }

--- a/classes/decision/types/traits/RequestPayment.php
+++ b/classes/decision/types/traits/RequestPayment.php
@@ -58,6 +58,19 @@ trait RequestPayment
     }
 
     /**
+     * Request or waive the publication fee based on the payment decision action
+     */
+    protected function runPaymentAction(array $action, Submission $submission, User $editor, Context $context): void
+    {
+        // Decision form may submit requestPayment as a string
+        if (filter_var($action['requestPayment'], FILTER_VALIDATE_BOOLEAN)) {
+            $this->requestPayment($submission, $editor, $context);
+        } else {
+            $this->waivePayment($submission, $editor, $context);
+        }
+    }
+
+    /**
      * Request payment from authors
      */
     protected function requestPayment(Submission $submission, User $editor, Context $context)
@@ -95,5 +108,27 @@ trait RequestPayment
 
             Mail::send($mailable);
         }
+    }
+
+    /**
+     * Waive the publication fee for this submission
+     *
+     * Records a completed payment with a zero amount so the submission can be
+     * scheduled for publication without requesting payment from authors.
+     */
+    protected function waivePayment(Submission $submission, User $editor, Context $context): void
+    {
+        $request = Application::get()->getRequest();
+        $paymentManager = Application::get()->getPaymentManager($context);
+        $queuedPayment = $paymentManager->createQueuedPayment(
+            $request,
+            OJSPaymentManager::PAYMENT_TYPE_PUBLICATION,
+            $editor->getId(),
+            $submission->getId(),
+            0,
+            '' // Zero amount, no currency
+        );
+        $paymentManager->queuePayment($queuedPayment);
+        $paymentManager->fulfillQueuedPayment($request, $queuedPayment, 'ManualPayment');
     }
 }


### PR DESCRIPTION
## Summary

When accepting a submission (or accepting and skipping review) with publication fees enabled, choosing **Waive** still requested payment and emailed authors. `runAdditionalActions()` ignored `requestPayment` and always called `requestPayment()`.

This change honors the flag:
- `requestPayment` true → request payment (unchanged)
- `requestPayment` false → record a waived publication fee (zero-amount completed payment), matching the Payments tab

`requestPayment` may arrive as a string (`"true"` / `"false"`) from the decision form, so the check uses `filter_var(..., FILTER_VALIDATE_BOOLEAN)`.

Closes pkp/pkp-lib#13171

## Out of scope

If the publication fee was already set via the Payments tab before the decision, this PR does not add extra reconciliation (e.g. skip when already waived). That edge case partly existed before for the request-payment path and can be handled separately if needed.

## Test plan

- [x] Accept + Request payment → payment email, queued payment, payment task
- [x] Accept + Waive → no payment email/task; Payments shows Waived; submission can be scheduled
- [x] Same checks for Accept and skip review