### PR TITLE
pkp/pkp-lib#5887 Register the author_settings index migration

### DIFF
--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -219,6 +219,7 @@
 		<migration class="PKP\migration\upgrade\v3_6_0\I11583_ClassNamespaceFromDotNotationClassPath"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I10962_UpdateEmailTemplateVariables"/>
 		<migration class="PKP\migration\upgrade\v3_6_0\I12074_EncryptCredentials"/>
+		<migration class="PKP\migration\upgrade\v3_6_0\I5887_AddAuthorSettingsNameValueIndex"/>
 		<migration class="PKP\migration\upgrade\v3_6_0\I12204_ReviewAssignmentPublicVisibility"/>
         <migration class="PKP\migration\upgrade\v3_6_0\I12048_ReviewRoundAuthorResponse"/>
 		<migration class="PKP\migration\upgrade\v3_6_0\I11993_MakeNotesUserIdNullable" />


### PR DESCRIPTION
Refs #5887. Companion to pkp/pkp-lib#13174, which adds the migration; this registers it.

Without the index, `Author\Collector::filterByName()` scans `author_settings` (401,286 rows on the journal it was measured on, `type=ALL`). With it, the same lookup is `type=ref` over 443 rows, and an article page with 32 authors goes from 12.6 s to 0.57 s with the Recommend Articles by Author plugin enabled.

The migration is a no-op when the index already exists, so it is safe on installations that added it by hand.
