### PR TITLE
pkp/pkp-lib#13237 Declare empty value for the archiving PN boolean toggle field

### DIFF
--- a/classes/components/forms/FieldArchivingPn.php
+++ b/classes/components/forms/FieldArchivingPn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file classes/components/form/FieldArchivingPn.php
  *
@@ -56,5 +57,15 @@ class FieldArchivingPn extends FieldOptions
         $config['settingsUrl'] = $this->settingsUrl;
 
         return $config;
+    }
+
+    /**
+     * @copydoc Field::getEmptyValue()
+     *
+     * This field is a single-checkbox boolean toggle.
+     */
+    public function getEmptyValue()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
Part of https://github.com/pkp/pkp-lib/issues/13237 — companion to https://github.com/pkp/pkp-lib/pull/13238

`FieldArchivingPn` renders through its own component with strictly boolean value semantics, so it declares its empty value (`false`) explicitly rather than relying on the `FieldOptions` mode detection.